### PR TITLE
ci: make release workflow manual (workflow_dispatch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,11 @@
 name: Release
 
+# Manual-only for now. The @tael/* packages aren't published to npm yet (the
+# @tael scope isn't claimed), so auto-publishing on every push to main fails with
+# E404. Run this from the Actions tab once the npm scope + trusted publishing are
+# set up — or switch back to `push: { branches: [main] }` to re-enable auto-release.
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The Release workflow ran on every push to `main` and tried to publish the `@tael/*` packages to npm, failing with E404 because the `@tael` scope isn't claimed yet.

This switches its trigger to `workflow_dispatch` (manual). Run it from the **Actions** tab when you're actually ready to publish (npm scope + trusted publishing set up), or switch back to `push: { branches: [main] }` to re-enable auto-release.

No code changes — CI (lint/typecheck/test/build) is unaffected.