### PR TITLE
fix(auth): testnet dev login + visible wallet errors

### DIFF
--- a/apps/dashboard/app/(auth)/login/page.tsx
+++ b/apps/dashboard/app/(auth)/login/page.tsx
@@ -1,5 +1,8 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@tael/ui";
 import { ConnectWalletButton } from "../../../features/auth/connect-wallet-button";
+import { DevLogin } from "../../../features/auth/dev-login";
+
+const isTestnet = process.env.NEXT_PUBLIC_STELLAR_NETWORK !== "mainnet";
 
 export default function LoginPage() {
   return (
@@ -11,8 +14,21 @@ export default function LoginPage() {
           account if you&apos;re new.
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
         <ConnectWalletButton />
+        {isTestnet ? (
+          <>
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-card px-2 text-muted-foreground">or, on testnet</span>
+              </div>
+            </div>
+            <DevLogin />
+          </>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/apps/dashboard/app/api/auth/dev/route.ts
+++ b/apps/dashboard/app/api/auth/dev/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { createSessionToken } from "@tael/auth";
+import { stellarAddressSchema } from "@tael/types";
+import { AUTH_SECRET, SESSION_COOKIE } from "../../../../lib/config";
+
+/**
+ * Testnet-only convenience login: create a session for a Stellar address WITHOUT
+ * a signature. Disabled on mainnet. This unblocks dev/demo while the full
+ * wallet-signature flow is being sorted out — it is NOT secure (no proof of
+ * ownership) and must never be enabled on mainnet.
+ */
+export async function POST(request: Request) {
+  if (process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet") {
+    return NextResponse.json({ error: "Dev login is disabled on mainnet" }, { status: 403 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as { address?: string };
+  const parsed = stellarAddressSchema.safeParse(body.address?.trim());
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Enter a valid Stellar address (G…)" }, { status: 400 });
+  }
+
+  const token = await createSessionToken(parsed.data, AUTH_SECRET);
+  const response = NextResponse.json({ ok: true, address: parsed.data });
+  response.cookies.set(SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7,
+  });
+  return response;
+}

--- a/apps/dashboard/features/auth/connect-wallet-button.tsx
+++ b/apps/dashboard/features/auth/connect-wallet-button.tsx
@@ -13,23 +13,26 @@ export function ConnectWalletButton() {
   async function connect() {
     setError(null);
     setLoading(true);
+    // Track which step fails so the on-screen error is actionable.
+    let step = "opening wallet";
     try {
       const kit = await getWalletKit();
-
-      // Opens the wallet picker, sets the chosen wallet active, returns its address.
       const { address } = await kit.authModal();
 
+      step = "requesting challenge";
       const challengeRes = await fetch(
         `/api/auth/challenge?address=${encodeURIComponent(address)}`,
       );
-      if (!challengeRes.ok) throw new Error("Could not start sign-in");
+      if (!challengeRes.ok) throw new Error(`challenge request failed (${challengeRes.status})`);
       const { message, challengeToken } = (await challengeRes.json()) as {
         message: string;
         challengeToken: string;
       };
 
+      step = "signing message";
       const { signedMessage } = await kit.signMessage(message, { address });
 
+      step = "verifying signature";
       const verifyRes = await fetch("/api/auth/verify", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -37,15 +40,16 @@ export function ConnectWalletButton() {
       });
       if (!verifyRes.ok) {
         const data = (await verifyRes.json().catch(() => ({}))) as { error?: string };
-        throw new Error(data.error ?? "Sign-in failed");
+        throw new Error(data.error ?? `verify failed (${verifyRes.status})`);
       }
 
       router.push("/");
       router.refresh();
     } catch (err) {
-      // authModal rejects when the user simply closes the picker — don't shout about that.
-      const message = err instanceof Error ? err.message : "Sign-in failed";
-      setError(/clos|cancel|reject|dismiss/i.test(message) ? null : message);
+      const detail = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line no-console
+      console.error(`[tael auth] failed while ${step}:`, err);
+      setError(`Failed while ${step}: ${detail}`);
       setLoading(false);
     }
   }

--- a/apps/dashboard/features/auth/dev-login.tsx
+++ b/apps/dashboard/features/auth/dev-login.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Input } from "@tael/ui";
+
+/**
+ * Testnet-only fallback: sign in with just a Stellar address (no signature).
+ * Lets you into the dashboard while the wallet-signature flow is debugged.
+ */
+export function DevLogin() {
+  const router = useRouter();
+  const [address, setAddress] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function submit() {
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/dev", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ address: address.trim() }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error ?? "Login failed");
+      }
+      router.push("/");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Login failed");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Input
+        placeholder="G… (testnet address)"
+        value={address}
+        onChange={(event) => setAddress(event.target.value)}
+      />
+      <Button
+        variant="outline"
+        className="w-full"
+        onClick={() => void submit()}
+        disabled={loading || address.trim().length === 0}
+      >
+        {loading ? "Signing in…" : "Continue with address (testnet)"}
+      </Button>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
The wallet flow was failing silently on the deployed site (Freighter not detected, other wallets not completing). Two changes:

## 1. Unblock — testnet dev login
Adds a testnet-only `Continue with address` option (`/api/auth/dev` + `DevLogin`): paste a `G…` address → get a session → into the dashboard. **Disabled on mainnet**, no signature (dev/demo only). Lets you use + keep building the product regardless of the wallet extension issue.

## 2. Make wallet failures diagnosable
The connect button now shows **which step failed** (opening wallet / requesting challenge / signing / verifying) on screen and `console.error`s the full error — so we can fix the real wallet flow with facts instead of guessing.

Green: format · lint · typecheck · build.