### PR TITLE
fix(eslint): add Next.js ESLint plugin so @next/next rules resolve

### DIFF
--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -3,6 +3,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import prettier from "eslint-config-prettier";
+import nextPlugin from "@next/eslint-plugin-next";
 import globals from "globals";
 
 export default tseslint.config(
@@ -43,6 +44,18 @@ export default tseslint.config(
         "warn",
         { prefer: "type-imports", fixStyle: "inline-type-imports" },
       ],
+    },
+  },
+  {
+    // Next.js apps: register the Next plugin so its rules — and any
+    // `eslint-disable @next/next/...` directives in app code — resolve.
+    files: ["apps/web/**/*.{ts,tsx}", "apps/dashboard/**/*.{ts,tsx}"],
+    plugins: { "@next/next": nextPlugin },
+    rules: {
+      ...nextPlugin.configs.recommended.rules,
+      ...nextPlugin.configs["core-web-vitals"].rules,
+      // App Router only — no `pages/` dir, so this rule is irrelevant + noisy.
+      "@next/next/no-html-link-for-pages": "off",
     },
   },
   // Must be last: turns off any rules that conflict with Prettier formatting.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "@eslint/js": "catalog:",
+    "@next/eslint-plugin-next": "catalog:",
     "eslint-config-prettier": "catalog:",
     "globals": "catalog:",
     "tailwindcss-animate": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@hono/node-server':
       specifier: ^1.14.0
       version: 1.19.14
+    '@next/eslint-plugin-next':
+      specifier: ^15.2.2
+      version: 15.5.20
     '@radix-ui/react-dialog':
       specifier: ^1.1.4
       version: 1.1.18
@@ -309,6 +312,9 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.39.4
+      '@next/eslint-plugin-next':
+        specifier: 'catalog:'
+        version: 15.5.20
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@1.21.7)
@@ -1233,6 +1239,9 @@ packages:
 
   '@next/env@15.5.20':
     resolution: {integrity: sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==}
+
+  '@next/eslint-plugin-next@15.5.20':
+    resolution: {integrity: sha512-MZUgFpVd9rGSZpb8bNceUWvkAZe6aQw/6h2SSqHQuYzKfaiEUEVPIO6mXqaBmiBEBSN1f1sOc1uV8GCM90oegg==}
 
   '@next/swc-darwin-arm64@15.5.20':
     resolution: {integrity: sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==}
@@ -3564,6 +3573,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -6110,6 +6123,10 @@ snapshots:
       rxjs: 7.8.1
 
   '@next/env@15.5.20': {}
+
+  '@next/eslint-plugin-next@15.5.20':
+    dependencies:
+      fast-glob: 3.3.1
 
   '@next/swc-darwin-arm64@15.5.20':
     optional: true
@@ -9421,6 +9438,14 @@ snapshots:
   eyes@0.1.8: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
 
   fast-glob@3.3.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   eslint-config-prettier: ^10.1.1
   globals: ^16.0.0
   prettier: ^3.5.3
+  "@next/eslint-plugin-next": ^15.2.2
 
   # --- Runtime: shared kernel ---
   zod: ^3.24.2


### PR DESCRIPTION
## Why
PR #6 (the new marketing site) fails to build because our shared ESLint config doesn't register the Next.js plugin, so the `// eslint-disable-next-line @next/next/no-img-element` comments in that code error with *"Definition for rule '@next/next/no-img-element' was not found."* Merging #6 as-is would break the build on `main`.

## What
- Add `@next/eslint-plugin-next` (catalog + `@tael/config`).
- Register it in the shared flat config, scoped to the Next apps (`apps/web`, `apps/dashboard`), with the recommended + core-web-vitals rules.
- Disable `no-html-link-for-pages` (we're App Router only — no `pages/` dir).

## Verified
- `pnpm lint` green on `main` as-is.
- **Test-merged `feat/new-web` locally on top of this** → `pnpm lint` and `pnpm --filter web build` both **pass**. So after this lands, #6 merges + builds cleanly.

## Merge order
Merge **this first**, then #6.