### PR TITLE
style(web): prettier-format new marketing site files

### DIFF
--- a/apps/web/app/_components/footer-links.tsx
+++ b/apps/web/app/_components/footer-links.tsx
@@ -48,7 +48,10 @@ export function FooterLinks() {
             <span className={`${item} text-[#989898]`}>{col.title}</span>
             {col.links.map((label) =>
               label === "Try now" ? (
-                <WaitlistTrigger key={label} className={`${item} text-left text-black hover:bg-[#ECECED]`}>
+                <WaitlistTrigger
+                  key={label}
+                  className={`${item} text-left text-black hover:bg-[#ECECED]`}
+                >
                   {label}
                 </WaitlistTrigger>
               ) : (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -12,11 +12,27 @@ const HERO_GRADIENT =
 
 // Orbiting provider icons, positioned on the arc (coords relative to the 1440px stage).
 const ORBIT = [
-  { src: "/logos/orbit-anthropic.svg", w: 35, h: 24, size: 60, left: 242, top: 382, alt: "Anthropic" },
+  {
+    src: "/logos/orbit-anthropic.svg",
+    w: 35,
+    h: 24,
+    size: 60,
+    left: 242,
+    top: 382,
+    alt: "Anthropic",
+  },
   { src: "/logos/orbit-openai.svg", w: 33, h: 32, size: 62, left: 365, top: 240, alt: "OpenAI" },
   { src: "/logos/orbit-claude.svg", w: 36, h: 36, size: 64, left: 686, top: 124, alt: "Claude" },
   { src: "/logos/orbit-grok.svg", w: 36, h: 36, size: 64, left: 863, top: 156, alt: "Grok" },
-  { src: "/logos/orbit-perplexity.png", w: 50, h: 50, size: 62, left: 1017, top: 240, alt: "Perplexity" },
+  {
+    src: "/logos/orbit-perplexity.png",
+    w: 50,
+    h: 50,
+    size: 62,
+    left: 1017,
+    top: 240,
+    alt: "Perplexity",
+  },
   { src: "/logos/orbit-lovable.svg", w: 27, h: 28, size: 60, left: 1138, top: 382, alt: "Lovable" },
 ];
 
@@ -44,12 +60,22 @@ export default function HomePage() {
           />
 
           {/* vertical guide rails (start below the nav) */}
-          <div className="pointer-events-none absolute h-full w-px bg-white/[0.09]" style={{ left: 80, top: 48 }} />
-          <div className="pointer-events-none absolute h-full w-px bg-white/[0.09]" style={{ left: 1360, top: 48 }} />
+          <div
+            className="pointer-events-none absolute h-full w-px bg-white/[0.09]"
+            style={{ left: 80, top: 48 }}
+          />
+          <div
+            className="pointer-events-none absolute h-full w-px bg-white/[0.09]"
+            style={{ left: 1360, top: 48 }}
+          />
 
           {/* orbit icons */}
           {ORBIT.map((o) => (
-            <div key={o.alt} className={iconCircle} style={{ left: o.left, top: o.top, width: o.size, height: o.size }}>
+            <div
+              key={o.alt}
+              className={iconCircle}
+              style={{ left: o.left, top: o.top, width: o.size, height: o.size }}
+            >
               <img src={o.src} alt={o.alt} style={{ width: o.w, height: o.h }} />
             </div>
           ))}


### PR DESCRIPTION
Fixes the failing **Format check** on `main` — two files from the new marketing site (`apps/web/app/_components/footer-links.tsx`, `apps/web/app/page.tsx`) weren't Prettier-formatted.

Prettier-only, no logic changes. Full gauntlet green locally: **format · lint · typecheck · test · build** all pass (on top of latest main incl. the #7 ESLint fix).

Merging this makes `main` fully green → `taelprotocol.xyz` deploys the new site.