### PR TITLE
New web: landing redesign, waitlist + polish

### DIFF
--- a/apps/web/app/_components/provider-cards.tsx
+++ b/apps/web/app/_components/provider-cards.tsx
@@ -45,20 +45,38 @@ const CARDS = [
   },
 ];
 
+const pill =
+  "rounded-[10px] bg-[#ECECED] px-4 py-2.5 text-[14px] font-medium tracking-[-0.02em] text-black";
+
 export function ProviderCards() {
   return (
-    <div className="grid w-full grid-cols-1 gap-7 sm:grid-cols-2 lg:w-[728px]">
-      {CARDS.map((card) => (
-        <div
-          key={card.alt}
-          className="flex h-[124px] flex-col gap-5 rounded-[11px] border border-[#E9E9E9] bg-white p-5 shadow-[0_1px_2px_0_rgba(0,0,0,0.03)]"
+    <div className="flex w-full flex-col gap-7 lg:w-[728px]">
+      <div className="grid grid-cols-1 gap-7 sm:grid-cols-2">
+        {CARDS.map((card) => (
+          <div
+            key={card.alt}
+            className="flex h-[124px] flex-col gap-5 rounded-[11px] border border-[#E9E9E9] bg-white p-5 shadow-[0_1px_2px_0_rgba(0,0,0,0.03)]"
+          >
+            <img src={card.logo} alt={card.alt} style={{ width: card.w, height: card.h }} />
+            <p className="text-[13px] font-normal leading-5 tracking-[-0.03em] text-ink-muted">
+              {card.desc}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* CTA pills */}
+      <div className="flex flex-wrap items-center gap-3">
+        <span className={pill}>10+ agents available</span>
+        <a
+          href="https://discord.gg/tcb6b7ZYha"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${pill} transition-colors hover:bg-[#e2e2e4]`}
         >
-          <img src={card.logo} alt={card.alt} style={{ width: card.w, height: card.h }} />
-          <p className="text-[13px] font-normal leading-5 tracking-[-0.03em] text-ink-muted">
-            {card.desc}
-          </p>
-        </div>
-      ))}
+          Join community to try now
+        </a>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/_components/site-header.tsx
+++ b/apps/web/app/_components/site-header.tsx
@@ -3,12 +3,10 @@
 import { useEffect, useState } from "react";
 import { WaitlistTrigger } from "./waitlist-trigger";
 
-const NAV_LINKS = ["Products", "Developer", "Community"];
+const NAV_LINKS = ["Products", "Community"];
 
 // Real destinations for nav links that have one; others fall back to "#".
-const NAV_HREFS: Record<string, string> = {
-  Developer: "https://discord.gg/tcb6b7ZYha",
-};
+const NAV_HREFS: Record<string, string> = {};
 
 // Flip to the light theme once the hero gradient behind the nav goes light
 // (roughly when the headline/input have scrolled up toward the nav).

--- a/apps/web/app/_components/waitlist-trigger.tsx
+++ b/apps/web/app/_components/waitlist-trigger.tsx
@@ -21,7 +21,17 @@ export function WaitlistTrigger({
       onClick={() => {
         const input = document.getElementById("waitlist-email") as HTMLInputElement | null;
         if (!input) return;
-        input.scrollIntoView({ behavior: "smooth", block: "center" });
+        // Only scroll if the input isn't already visible (e.g. clicked from the
+        // footer). When it's on-screen (hero), just focus — no jump.
+        const rect = input.getBoundingClientRect();
+        const visible = rect.top >= 48 && rect.bottom <= window.innerHeight;
+        if (!visible) {
+          // Scroll the WINDOW to the very top so the whole hero is in view (not
+          // scrollIntoView, which also scrolls the hero's overflow-hidden
+          // container and leaves it stuck with no scrollbar to undo it).
+          window.scrollTo({ top: 0, behavior: "smooth" });
+        }
+        // preventScroll stops focus from scrolling the overflow-hidden hero.
         input.focus({ preventScroll: true });
       }}
     >

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -68,8 +68,8 @@ export default function HomePage() {
               <br />
               For AI agents.
             </h1>
-            <p className="text-[18px] font-normal leading-[26px] tracking-[-0.035em] text-white">
-              Connect every app you use - 100 apps and 3000 actions, all in one platform.
+            <p className="max-w-[430px] text-[18px] font-normal leading-[26px] tracking-[-0.035em] text-white">
+              Pay for every API you use. 100 apps and 3000 actions, all in one platform.
             </p>
           </div>
 


### PR DESCRIPTION
## What & why
Full redesign of the marketing site (`apps/web`) with a working email waitlist, plus follow-up UX polish. Supersedes #6 (this branch includes everything there plus the fixes below).

### Landing page
- Dark orbit hero (gradient, concentric rings, AI-provider icons on an arc) with headline, subtext, email capture.
- Sticky navbar that hides on scroll-down / reveals on scroll-up and flips to a light theme over the white section.
- 2×3 provider cards (Claude, OpenAI, groq, Anthropic, Grok, ElevenLabs) + "agents available" / "Join community to try now" CTA pills.
- Footer link columns (Product / Connect) + X icon; Discord/X wired to real URLs. `/coming-soon` linked from Guide & FAQs.

### Waitlist (`/api/waitlist`)
- Sends a team notification + a welcome email to the signer via **Resend** (verified `taelprotocol.xyz`).
- Client form with loading/success/error states; nav "Join waitlist" and footer "Try now" focus the field (window-scroll, no stuck overflow-hidden hero).

### Polish
- Removed Developer + duplicate Community nav tabs.
- Right-sized Anthropic/ElevenLabs logos; tuned hero subheading copy and wrapping.

## Type of change
- [x] Feature

## Checklist
- [x] `pnpm typecheck` passes locally
- [ ] Tests / changeset (no published `@tael/*` package changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)