### PR TITLE
style: fix Prettier formatting from database merge

### DIFF
--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -33,7 +33,12 @@ export default async function CapabilityDetailPage({
 
       {/* Header */}
       <div className="flex items-start gap-4">
-        <div className={cn("flex h-14 w-14 shrink-0 items-center justify-center rounded-xl", meta.tile)}>
+        <div
+          className={cn(
+            "flex h-14 w-14 shrink-0 items-center justify-center rounded-xl",
+            meta.tile,
+          )}
+        >
           <Icon className="h-6 w-6" />
         </div>
         <div className="min-w-0 flex-1 space-y-1">

--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -27,11 +27,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html
-      lang="en"
-      className={`${inter.variable} ${delicious.variable}`}
-      suppressHydrationWarning
-    >
+    <html lang="en" className={`${inter.variable} ${delicious.variable}`} suppressHydrationWarning>
       <body className="min-h-screen font-sans antialiased">
         <Providers>{children}</Providers>
       </body>

--- a/apps/dashboard/features/capabilities/actions.ts
+++ b/apps/dashboard/features/capabilities/actions.ts
@@ -188,7 +188,13 @@ async function testUpstream(args: {
   secret: string;
 }): Promise<TestResult> {
   if (isBlockedUrl(args.url)) {
-    return { name: args.name, ok: false, status: null, response: "", error: "Endpoint not allowed" };
+    return {
+      name: args.name,
+      ok: false,
+      status: null,
+      response: "",
+      error: "Endpoint not allowed",
+    };
   }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 15000);

--- a/apps/dashboard/features/capabilities/publish-wizard.tsx
+++ b/apps/dashboard/features/capabilities/publish-wizard.tsx
@@ -567,8 +567,7 @@ function StepIndicator({ step }: { step: Step }) {
     { key: "verify", label: "Verify", icon: Sparkles },
     { key: "done", label: "Publish", icon: Check },
   ];
-  const activeIndex =
-    step === "describe" ? 0 : step === "test" ? 1 : step === "verify" ? 2 : 3;
+  const activeIndex = step === "describe" ? 0 : step === "test" ? 1 : step === "verify" ? 2 : 3;
 
   return (
     <div className="flex items-center gap-2">

--- a/apps/dashboard/features/capabilities/schema.ts
+++ b/apps/dashboard/features/capabilities/schema.ts
@@ -28,9 +28,7 @@ export type DescribeCapabilityInput = z.infer<typeof describeCapabilitySchema>;
 
 /** Step 2 (final): the above plus the publisher's answered FAQ. */
 export const publishCapabilitySchema = describeCapabilitySchema.extend({
-  faqs: z
-    .array(z.object({ question: z.string(), answer: z.string().default("") }))
-    .default([]),
+  faqs: z.array(z.object({ question: z.string(), answer: z.string().default("") })).default([]),
 });
 
 export type PublishCapabilityInput = z.infer<typeof publishCapabilitySchema>;

--- a/apps/dashboard/features/capabilities/verification-timeline.tsx
+++ b/apps/dashboard/features/capabilities/verification-timeline.tsx
@@ -38,7 +38,13 @@ export function VerificationTimeline({ verified }: { verified: boolean }) {
       tone: "neutral",
       done: true,
     },
-    { label: "AI reviewed", subtitle: "Response checked", icon: Sparkles, tone: "blue", done: true },
+    {
+      label: "AI reviewed",
+      subtitle: "Response checked",
+      icon: Sparkles,
+      tone: "blue",
+      done: true,
+    },
     {
       label: "Verified",
       subtitle: verified ? "Live in marketplace" : "Pending",
@@ -61,7 +67,10 @@ export function VerificationTimeline({ verified }: { verified: boolean }) {
         {steps.map((step, i) => {
           const Icon = step.icon;
           return (
-            <div key={step.label} className="relative flex flex-col items-center gap-2.5 text-center">
+            <div
+              key={step.label}
+              className="relative flex flex-col items-center gap-2.5 text-center"
+            >
               {i < steps.length - 1 ? (
                 <span
                   className={cn(
@@ -78,12 +87,7 @@ export function VerificationTimeline({ verified }: { verified: boolean }) {
               >
                 <Icon className={cn("h-5 w-5", ICON[step.tone])} />
               </span>
-              <span
-                className={cn(
-                  "rounded-md px-2.5 py-1 text-xs font-semibold",
-                  PILL[step.tone],
-                )}
-              >
+              <span className={cn("rounded-md px-2.5 py-1 text-xs font-semibold", PILL[step.tone])}>
                 {step.label}
               </span>
               <span className="text-xs text-muted-foreground">{step.subtitle}</span>

--- a/packages/claude/src/faq.ts
+++ b/packages/claude/src/faq.ts
@@ -94,7 +94,10 @@ export async function generateFaqQuestions(input: GenerateFaqInput): Promise<str
 
     const parsed = faqQuestionsSchema.safeParse(JSON.parse(extractText(response.content)));
     const questions = parsed.success
-      ? parsed.data.questions.map((q) => q.trim()).filter(Boolean).slice(0, 5)
+      ? parsed.data.questions
+          .map((q) => q.trim())
+          .filter(Boolean)
+          .slice(0, 5)
       : [];
     return questions.length >= 3 ? questions : fallbackQuestions(input.kind);
   } catch {

--- a/packages/claude/src/usage.ts
+++ b/packages/claude/src/usage.ts
@@ -22,7 +22,7 @@ export interface AiUsage {
  */
 export function recordAiUsage(usage: AiUsage): void {
   // TODO(billing): debit `usage.userAddress`'s balance for the AI cost.
-   
+
   console.info(
     `[ai usage] ${usage.action} model=${usage.model} in=${usage.inputTokens} out=${usage.outputTokens} user=${usage.userAddress}`,
   );

--- a/packages/database/src/migrate.ts
+++ b/packages/database/src/migrate.ts
@@ -16,17 +16,15 @@ async function main() {
   const client = postgres(url, { max: 1 });
   const db = drizzle(client);
 
-   
   console.log("Running migrations…");
   await migrate(db, { migrationsFolder: "./drizzle" });
-   
+
   console.log("Migrations complete.");
 
   await client.end();
 }
 
 main().catch((error) => {
-   
   console.error("Migration failed:", error);
   process.exit(1);
 });


### PR DESCRIPTION
The `feat/database` commits merged with Prettier violations (lint + typecheck passed, `format:check` was not run), turning main's CI red. This formats the 9 affected files — **no logic changes**.

Fixes the failing `Lint · Typecheck · Test · Build` → Format check step on main. Also unblocks docs PR #10, whose CI runs against main.