### PR TITLE
feat(web): real docs content + Vercel-style code blocks

### DIFF
--- a/apps/web/app/docs/_components/copy-button.tsx
+++ b/apps/web/app/docs/_components/copy-button.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+
+/** Copies the raw source of a code block to the clipboard. */
+export function CopyButton({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — no-op.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={copied ? "Copied" : "Copy code"}
+      className="shrink-0 rounded-md p-1.5 text-ink-muted transition-colors hover:bg-surface hover:text-ink dark:text-white/45 dark:hover:bg-white/10 dark:hover:text-white"
+    >
+      {copied ? (
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden>
+          <path
+            d="M20 6L9 17l-5-5"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : (
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden>
+          <rect x="9" y="9" width="12" height="12" rx="2" stroke="currentColor" strokeWidth="2" />
+          <path
+            d="M5 15V5a2 2 0 012-2h10"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/apps/web/app/docs/_components/doc-page.tsx
+++ b/apps/web/app/docs/_components/doc-page.tsx
@@ -1,0 +1,198 @@
+import type { ReactNode } from "react";
+import { highlight } from "sugar-high";
+import { CopyButton } from "./copy-button";
+
+/** Shared shell for a written docs page: eyebrow + title + lead, article body,
+ *  and the sticky "On this page" table of contents — matching the intro page. */
+export function DocPage({
+  eyebrow,
+  title,
+  lead,
+  toc,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  toc?: { label: string; href: string }[];
+  children: ReactNode;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-[1180px] gap-10 px-8 py-12">
+      <article className="min-w-0 flex-1">
+        <p className="text-[13px] font-medium tracking-[-0.01em] text-ink-muted dark:text-white/45">
+          {eyebrow}
+        </p>
+        <h1 className="mt-2 text-[38px] font-semibold leading-tight tracking-[-0.02em] text-ink dark:text-white">
+          {title}
+        </h1>
+        <p className="mt-3 text-[18px] leading-7 tracking-[-0.01em] text-ink-soft dark:text-white/70">
+          {lead}
+        </p>
+        <div className="mt-8">{children}</div>
+      </article>
+
+      {toc && toc.length > 0 ? (
+        <aside className="sticky top-20 hidden h-max w-52 shrink-0 xl:block">
+          <p className="mb-3 text-[13px] font-medium tracking-[-0.01em] text-ink-muted dark:text-white/45">
+            On this page
+          </p>
+          <ul className="flex flex-col gap-1 border-l border-line dark:border-white/10">
+            {toc.map((item) => (
+              <li key={item.href}>
+                <a
+                  href={item.href}
+                  className="-ml-px block border-l-2 border-transparent py-1 pl-3 text-[13px] tracking-[-0.01em] text-ink-muted transition-colors hover:border-accent hover:text-black dark:text-white/45 dark:hover:text-white"
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      ) : null}
+    </div>
+  );
+}
+
+/** Section heading with an anchor id (targets from the TOC). */
+export function H2({ id, children }: { id: string; children: ReactNode }) {
+  return (
+    <h2
+      id={id}
+      className="mt-14 scroll-mt-20 text-[24px] font-semibold tracking-[-0.02em] text-ink first:mt-0 dark:text-white"
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function H3({ id, children }: { id?: string; children: ReactNode }) {
+  return (
+    <h3
+      id={id}
+      className="mt-8 scroll-mt-20 text-[17px] font-semibold tracking-[-0.01em] text-ink dark:text-white"
+    >
+      {children}
+    </h3>
+  );
+}
+
+export function P({ children }: { children: ReactNode }) {
+  return (
+    <p className="mt-4 text-[15px] leading-7 tracking-[-0.01em] text-ink-soft dark:text-white/70">
+      {children}
+    </p>
+  );
+}
+
+export function Ul({ children }: { children: ReactNode }) {
+  return (
+    <ul className="mt-4 flex list-disc flex-col gap-2 pl-5 text-[15px] leading-7 tracking-[-0.01em] text-ink-soft marker:text-ink-muted dark:text-white/70 dark:marker:text-white/30">
+      {children}
+    </ul>
+  );
+}
+
+/** Inline monospace token. */
+export function Code({ children }: { children: ReactNode }) {
+  return (
+    <code className="rounded-md border border-line bg-surface/60 px-1.5 py-0.5 font-mono text-[13px] text-ink dark:border-white/10 dark:bg-white/[0.06] dark:text-white/80">
+      {children}
+    </code>
+  );
+}
+
+/** Text link inside prose. */
+export function A({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <a href={href} className="font-medium text-accent underline-offset-2 hover:underline">
+      {children}
+    </a>
+  );
+}
+
+/** Informational callout, matching the intro-page style. */
+export function Callout({ children }: { children: ReactNode }) {
+  return (
+    <div className="mt-6 flex gap-3 rounded-xl border border-line bg-surface/50 px-5 py-4 dark:border-white/10 dark:bg-white/[0.04]">
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        className="mt-0.5 shrink-0 text-ink-muted dark:text-white/45"
+        aria-hidden
+      >
+        <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
+        <path d="M12 11v5M12 8h.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+      <div className="text-[14px] leading-6 tracking-[-0.01em] text-ink-soft dark:text-white/65">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+type Lang = "ts" | "tsx" | "js" | "json" | "bash";
+
+const LANG_BADGE: Record<Lang, { label: string; className: string }> = {
+  ts: { label: "TS", className: "bg-[#3178c6] text-white" },
+  tsx: { label: "TSX", className: "bg-[#3178c6] text-white" },
+  js: { label: "JS", className: "bg-[#f7df1e] text-black" },
+  json: { label: "{ }", className: "bg-ink text-white dark:bg-white/15" },
+  bash: { label: "›_", className: "bg-ink text-white dark:bg-white/15" },
+};
+
+const LANG_NAME: Record<Lang, string> = {
+  ts: "TypeScript",
+  tsx: "TypeScript",
+  js: "JavaScript",
+  json: "JSON",
+  bash: "Terminal",
+};
+
+/** Best-effort language detection from the title, then the code content. */
+function inferLang(code: string, title?: string): Lang {
+  const t = (title ?? "").toLowerCase();
+  if (t.endsWith(".tsx")) return "tsx";
+  if (t.endsWith(".ts")) return "ts";
+  if (t.endsWith(".js")) return "js";
+  if (t.endsWith(".json")) return "json";
+  if (t === "terminal" || t === "bash" || t === "shell") return "bash";
+  const trimmed = code.trimStart();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return "json";
+  if (/^(curl|pnpm|npm|yarn|npx|printf|export |[A-Z_]+=)/.test(trimmed)) return "bash";
+  return "ts";
+}
+
+/** Fenced code block with a language badge, filename header, and copy button.
+ *  Syntax is highlighted with sugar-high; token colors come from the --sh-* CSS
+ *  variables in globals.css (light + dark palettes). */
+export function CodeBlock({ title, code, lang }: { title?: string; code: string; lang?: Lang }) {
+  const resolved = lang ?? inferLang(code, title);
+  const badge = LANG_BADGE[resolved];
+  const html = highlight(code);
+
+  return (
+    <div className="mt-6 overflow-hidden rounded-xl border border-line dark:border-white/10">
+      <div className="flex items-center gap-2 border-b border-line bg-surface/50 pl-3 pr-2 dark:border-white/10 dark:bg-white/[0.03]">
+        <span
+          className={`flex h-5 min-w-[20px] items-center justify-center rounded px-1 text-[10px] font-bold leading-none ${badge.className}`}
+        >
+          {badge.label}
+        </span>
+        <span className="flex-1 truncate py-2 font-mono text-[12px] text-ink-muted dark:text-white/45">
+          {title ?? LANG_NAME[resolved]}
+        </span>
+        <CopyButton code={code} />
+      </div>
+      <pre className="overflow-x-auto bg-white p-4 text-[13px] leading-6 dark:bg-[#0c0c0c]">
+        <code
+          className="font-mono [&_.sh__line]:block"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/app/docs/_components/docs-sidebar.tsx
+++ b/apps/web/app/docs/_components/docs-sidebar.tsx
@@ -16,15 +16,12 @@ export const SECTIONS = [
     items: [
       { label: "Accept payments", href: "/docs/accept-payments" },
       { label: "Wrap an API", href: "/docs/wrap-an-api" },
-      { label: "Agent wallets", href: "/docs/agent-wallets" },
-      { label: "Webhooks", href: "/docs/webhooks" },
     ],
   },
   {
     title: "SDKs",
     items: [
       { label: "Node.js", href: "/docs/sdk/node" },
-      { label: "Python", href: "/docs/sdk/python" },
       { label: "cURL", href: "/docs/sdk/curl" },
     ],
   },

--- a/apps/web/app/docs/_components/github-star.tsx
+++ b/apps/web/app/docs/_components/github-star.tsx
@@ -1,0 +1,49 @@
+const REPO = "rahulsainlll/tael-protocol";
+const REPO_URL = `https://github.com/${REPO}`;
+
+/** Fetch the repo's star count, revalidated hourly. Returns null on failure. */
+async function getStars(): Promise<number | null> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+      headers: { accept: "application/vnd.github+json" },
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === "number" ? data.stargazers_count : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatCount(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k` : String(n);
+}
+
+/** "Star on GitHub" pill for the docs nav — logo + live star count. */
+export async function GithubStar() {
+  const stars = await getStars();
+
+  return (
+    <a
+      href={REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      title="Star Tael on GitHub"
+      className="flex items-center gap-2 rounded-full border border-line px-3 py-1.5 text-[13px] font-medium text-ink transition-colors hover:bg-surface/60 dark:border-white/10 dark:text-white dark:hover:bg-white/[0.06]"
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+        <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.46-1.18-1.11-1.49-1.11-1.49-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.56-1.14-4.56-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.28 2.75 1.05a9.34 9.34 0 015 0c1.91-1.33 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.79-4.57 5.05.36.32.68.94.68 1.9 0 1.37-.01 2.48-.01 2.82 0 .27.18.6.69.49A10.02 10.02 0 0022 12.25C22 6.58 17.52 2 12 2z" />
+      </svg>
+      <span>Star</span>
+      {stars !== null ? (
+        <span className="flex items-center gap-1 text-ink-muted dark:text-white/45">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+            <path d="M12 2l2.9 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77 5.82 21l1.18-6.87-5-4.87 7.1-1.01L12 2z" />
+          </svg>
+          {formatCount(stars)}
+        </span>
+      ) : null}
+    </a>
+  );
+}

--- a/apps/web/app/docs/accept-payments/page.tsx
+++ b/apps/web/app/docs/accept-payments/page.tsx
@@ -1,0 +1,107 @@
+import { A, Callout, Code, CodeBlock, DocPage, H2, P, Ul } from "../_components/doc-page";
+
+const TOC = [
+  { label: "The flow", href: "#flow" },
+  { label: "1. The challenge", href: "#challenge" },
+  { label: "2. The payment", href: "#payment" },
+  { label: "3. Verification", href: "#verification" },
+  { label: "Verifiers", href: "#verifiers" },
+];
+
+export default function AcceptPaymentsPage() {
+  return (
+    <DocPage
+      eyebrow="Guides"
+      title="Accept payments"
+      lead="The full x402 flow behind every paid call: challenge, pay, verify, receipt."
+      toc={TOC}
+    >
+      <H2 id="flow">The flow</H2>
+      <Ul>
+        <li>A client requests a paid resource with no payment.</li>
+        <li>
+          The server responds <Code>402 Payment Required</Code> with one or more acceptable payment
+          options.
+        </li>
+        <li>
+          The client pays and retries with an <Code>X-PAYMENT</Code> proof.
+        </li>
+        <li>The server verifies + settles the payment, runs the handler, and returns a receipt.</li>
+      </Ul>
+      <Callout>
+        The protocol envelope lives in <Code>@tael/payments</Code>; on-chain settlement is injected
+        as a <Code>PaymentVerifier</Code> (implemented by <Code>@tael/stellar</Code>). The SDK wires
+        them together for you.
+      </Callout>
+
+      <H2 id="challenge">1. The challenge</H2>
+      <P>
+        A <Code>402</Code> body carries an <Code>accepts</Code> array. Each entry is a
+        fully-specified payment requirement — amount, asset, recipient, and the resource being
+        bought:
+      </P>
+      <CodeBlock
+        title="402 Payment Required"
+        code={`{
+  "x402Version": 1,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "stellar-testnet",
+      "maxAmountRequired": "0.02",
+      "payTo": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      "asset": { "code": "USDC", "issuer": "G..." },
+      "resource": "/v1/ocr",
+      "description": "Extract text from a document",
+      "maxTimeoutSeconds": 60
+    }
+  ]
+}`}
+      />
+
+      <H2 id="payment">2. The payment</H2>
+      <P>
+        The client builds a signed Stellar payment for <Code>maxAmountRequired</Code> USDC to{" "}
+        <Code>payTo</Code>, wraps it in the payment envelope, and base64-encodes it into the{" "}
+        <Code>X-PAYMENT</Code> header. The <Code>exact</Code> scheme means it must pay exactly the
+        amount required — no more, no less.
+      </P>
+      <CodeBlock
+        title="X-PAYMENT (decoded)"
+        code={`{
+  "x402Version": 1,
+  "scheme": "exact",
+  "network": "stellar-testnet",
+  "payload": { "transaction": "<signed XDR>" }
+}`}
+      />
+
+      <H2 id="verification">3. Verification &amp; receipt</H2>
+      <P>
+        Tael checks that the proof&apos;s scheme and network match the challenge, then delegates to
+        the verifier to settle on-chain. On success it runs your handler and attaches an{" "}
+        <Code>X-PAYMENT-RESPONSE</Code> receipt to the response. A malformed or underpaid proof gets
+        another <Code>402</Code> with an <Code>error</Code> message rather than reaching your code.
+      </P>
+
+      <H2 id="verifiers">Verifiers</H2>
+      <P>
+        The verifier is the only chain-specific piece, and it&apos;s injected so your handler code
+        stays portable:
+      </P>
+      <Ul>
+        <li>
+          <Code>createMockVerifier()</Code> — accepts any well-formed proof. Use it in dev and
+          tests.
+        </li>
+        <li>
+          The Stellar verifier from <Code>@tael/stellar</Code> — submits and confirms the
+          transaction on the network. Use it in production.
+        </li>
+      </Ul>
+      <P>
+        Ready to add this to an endpoint? See <A href="/docs/wrap-an-api">Wrap an API</A>.
+      </P>
+    </DocPage>
+  );
+}

--- a/apps/web/app/docs/authentication/page.tsx
+++ b/apps/web/app/docs/authentication/page.tsx
@@ -1,0 +1,84 @@
+import { A, Callout, Code, CodeBlock, DocPage, H2, P, Ul } from "../_components/doc-page";
+
+const TOC = [
+  { label: "No keys, no accounts", href: "#no-keys" },
+  { label: "The X-PAYMENT header", href: "#x-payment" },
+  { label: "The receipt", href: "#receipt" },
+  { label: "Networks", href: "#networks" },
+];
+
+export default function AuthenticationPage() {
+  return (
+    <DocPage
+      eyebrow="Get started"
+      title="Authentication"
+      lead="In Tael, the payment is the authentication — there are no API keys."
+      toc={TOC}
+    >
+      <H2 id="no-keys">No keys, no accounts</H2>
+      <P>
+        Traditional APIs authenticate a caller with a shared secret (an API key or OAuth token) and
+        bill them later. That assumes a human signed up first. Tael removes that step: an agent
+        proves it is allowed to call your endpoint by <strong>paying for the call</strong>, in the
+        same request. There is nothing to register and no credential to leak.
+      </P>
+      <Callout>
+        This is the <A href="/docs/accept-payments">x402 / HTTP-402</A> model: a resource answers{" "}
+        <Code>402 Payment Required</Code> with its price, the caller attaches a payment proof, and
+        the server verifies it before doing any work.
+      </Callout>
+
+      <H2 id="x-payment">The X-PAYMENT header</H2>
+      <P>
+        A paying client retries the request with an <Code>X-PAYMENT</Code> header: a base64-encoded
+        JSON envelope containing a signed Stellar transaction (XDR) that transfers the required USDC
+        to your <Code>payTo</Code> address.
+      </P>
+      <CodeBlock
+        title="X-PAYMENT (decoded)"
+        code={`{
+  "x402Version": 1,
+  "scheme": "exact",
+  "network": "stellar-testnet",
+  "payload": {
+    "transaction": "<base64 signed Stellar XDR>"
+  }
+}`}
+      />
+      <P>
+        Tael validates the protocol invariants (scheme and network must match the challenge) and
+        then hands the signed transaction to your <Code>PaymentVerifier</Code>, which settles it on
+        Stellar. Only if settlement succeeds does your handler run.
+      </P>
+
+      <H2 id="receipt">The receipt</H2>
+      <P>
+        On success the response carries an <Code>X-PAYMENT-RESPONSE</Code> header — a base64 receipt
+        proving settlement. Your handler also receives the settlement details as{" "}
+        <Code>receipt</Code> so you can attribute the call to the paying wallet.
+      </P>
+      <CodeBlock
+        title="handler context"
+        code={`handler: async ({ request, receipt }) => {
+  // receipt describes the settled payment (payer, amount, tx)
+  return Response.json({ ok: true, paidBy: receipt.payer });
+}`}
+      />
+
+      <H2 id="networks">Networks</H2>
+      <P>Tael settles in USDC on Stellar. Pick the network per environment:</P>
+      <Ul>
+        <li>
+          <Code>stellar-testnet</Code> — for development, with the mock verifier or test USDC.
+        </li>
+        <li>
+          <Code>stellar-mainnet</Code> — for production, with the real Stellar verifier.
+        </li>
+      </Ul>
+      <P>
+        See <A href="/docs/sdk/node">the Node.js SDK reference</A> for how to plug in the Stellar
+        verifier.
+      </P>
+    </DocPage>
+  );
+}

--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { DocsSidebar } from "./_components/docs-sidebar";
+import { GithubStar } from "./_components/github-star";
 import { ThemeToggle } from "./_components/theme-toggle";
 
 export const metadata: Metadata = {
@@ -44,6 +45,7 @@ export default function DocsLayout({ children }: { children: ReactNode }) {
           </nav>
 
           <div className="ml-auto flex items-center gap-3">
+            <GithubStar />
             <ThemeToggle />
             <a
               href="/"

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -4,18 +4,54 @@ const TOC = [
 ];
 
 const QUICKSTART = [
-  { title: "Node.js", desc: "Wrap an API and get paid in USDC." },
-  { title: "Next.js", desc: "Add pay-per-call routes to your app." },
-  { title: "Python", desc: "Meter and monetize your endpoints." },
-  { title: "MCP", desc: "Charge agents for MCP tool calls." },
-  { title: "cURL", desc: "Call the HTTP API directly." },
-  { title: "x402", desc: "Accept x402 payment proofs." },
+  {
+    title: "Quickstart",
+    desc: "Install the SDK and gate a handler in minutes.",
+    href: "/docs/quickstart",
+  },
+  {
+    title: "Wrap an API",
+    desc: "Put any HTTP handler behind a per-call price.",
+    href: "/docs/wrap-an-api",
+  },
+  {
+    title: "Authentication",
+    desc: "How agents authenticate by paying — no keys.",
+    href: "/docs/authentication",
+  },
+  {
+    title: "Accept payments",
+    desc: "The 402 → pay → receipt flow, end to end.",
+    href: "/docs/accept-payments",
+  },
+  {
+    title: "Node.js SDK",
+    desc: "createTael, tael, and the option reference.",
+    href: "/docs/sdk/node",
+  },
+  {
+    title: "cURL",
+    desc: "Drive the x402 flow with raw HTTP.",
+    href: "/docs/sdk/curl",
+  },
 ];
 
 const EXPLORE = [
-  { title: "Accept payments", desc: "Take USDC on Stellar from any agent, non-custodially." },
-  { title: "Agent wallets", desc: "Provision and manage wallets your agents pay from." },
-  { title: "Webhooks", desc: "React to payments and settlement events in real time." },
+  {
+    title: "Accept payments",
+    desc: "Take USDC on Stellar from any agent, non-custodially.",
+    href: "/docs/accept-payments",
+  },
+  {
+    title: "Wrap an API",
+    desc: "Monetize an existing endpoint with a single SDK call.",
+    href: "/docs/wrap-an-api",
+  },
+  {
+    title: "Authentication",
+    desc: "Payments are the auth — no accounts or API keys.",
+    href: "/docs/authentication",
+  },
 ];
 
 export default function DocsIntroPage() {
@@ -53,7 +89,8 @@ export default function DocsIntroPage() {
           </svg>
           <p className="text-[14px] leading-6 tracking-[-0.01em] text-ink-soft dark:text-white/65">
             Wrap any API, MCP tool, or data service with one SDK call and get paid in USDC on
-            Stellar every time an agent uses it. Non-custodial, no accounts required.
+            Stellar every time an agent uses it. Payments ride on the open x402 / HTTP-402 protocol
+            — non-custodial, no accounts or API keys required.
           </p>
         </div>
 
@@ -71,14 +108,14 @@ export default function DocsIntroPage() {
           {QUICKSTART.map((card) => (
             <a
               key={card.title}
-              href="#"
+              href={card.href}
               className="group rounded-xl border border-line bg-white p-5 shadow-[0_1px_2px_0_rgba(0,0,0,0.03)] transition-colors hover:border-ink-muted/40 dark:border-white/10 dark:bg-white/[0.02] dark:shadow-none dark:hover:border-white/25"
             >
               <div className="mb-8 flex h-8 w-8 items-center justify-center rounded-lg bg-surface text-[13px] font-semibold text-ink dark:bg-white/[0.08] dark:text-white">
                 {card.title.slice(0, 2)}
               </div>
               <p className="text-[15px] font-semibold tracking-[-0.01em] text-ink dark:text-white">
-                {card.title} Quickstart
+                {card.title}
               </p>
               <p className="mt-1 text-[13px] leading-5 tracking-[-0.01em] text-ink-muted dark:text-white/45">
                 {card.desc}
@@ -101,7 +138,7 @@ export default function DocsIntroPage() {
           {EXPLORE.map((row) => (
             <a
               key={row.title}
-              href="#"
+              href={row.href}
               className="flex items-center justify-between px-5 py-4 transition-colors hover:bg-surface/50 dark:hover:bg-white/[0.04]"
             >
               <div>

--- a/apps/web/app/docs/quickstart/page.tsx
+++ b/apps/web/app/docs/quickstart/page.tsx
@@ -1,0 +1,110 @@
+import { A, Callout, Code, CodeBlock, DocPage, H2, P, Ul } from "../_components/doc-page";
+
+const TOC = [
+  { label: "Install", href: "#install" },
+  { label: "Wrap a handler", href: "#wrap" },
+  { label: "Run it", href: "#run" },
+  { label: "What happens", href: "#flow" },
+  { label: "Next steps", href: "#next" },
+];
+
+export default function QuickstartPage() {
+  return (
+    <DocPage
+      eyebrow="Get started"
+      title="Quickstart"
+      lead="Gate any HTTP handler behind a USDC payment in a few minutes."
+      toc={TOC}
+    >
+      <H2 id="install">Install</H2>
+      <P>Add the SDK to your project. It ships as ESM + types and has no framework dependency.</P>
+      <CodeBlock title="terminal" code={`pnpm add @tael/sdk\n# or: npm i @tael/sdk`} />
+
+      <H2 id="wrap">Wrap a handler</H2>
+      <P>
+        <Code>createTael</Code> binds your service-wide settlement details once, then returns a{" "}
+        <Code>paid()</Code> wrapper you put around any Fetch-style handler. Here it is as a Next.js
+        route handler:
+      </P>
+      <CodeBlock
+        title="app/api/ocr/route.ts"
+        code={`import { createTael, createMockVerifier } from "@tael/sdk";
+
+const paid = createTael({
+  payTo: process.env.TAEL_PAY_TO!,   // your Stellar address (G...)
+  issuer: process.env.USDC_ISSUER!,  // USDC issuer on your network
+  network: "stellar-testnet",
+  verifier: createMockVerifier(),    // swap for the Stellar verifier in prod
+});
+
+export const POST = paid({
+  price: "0.02",                     // 0.02 USDC per call
+  description: "Extract text from a document",
+  handler: async ({ request, receipt }) => {
+    const body = await request.json();
+    // ...your real work; runs only after payment settles...
+    return Response.json({ text: "INVOICE #1042 ...", paidBy: receipt.payer });
+  },
+});`}
+      />
+      <Callout>
+        The wrapper returns a standard <Code>(Request) =&gt; Promise&lt;Response&gt;</Code>, so the
+        same code drops into Hono, Bun, Deno, and Cloudflare Workers unchanged — not just Next.js.
+      </Callout>
+
+      <H2 id="run">Run it</H2>
+      <P>
+        Start your app and call the route with no payment. Tael answers with a{" "}
+        <Code>402 Payment Required</Code> challenge instead of running your handler:
+      </P>
+      <CodeBlock
+        title="terminal"
+        code={`curl -i -X POST http://localhost:3000/api/ocr
+
+HTTP/1.1 402 Payment Required
+content-type: application/json
+
+{
+  "x402Version": 1,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "stellar-testnet",
+      "maxAmountRequired": "0.02",
+      "payTo": "G...",
+      "asset": { "code": "USDC", "issuer": "G..." },
+      "resource": "/api/ocr"
+    }
+  ]
+}`}
+      />
+
+      <H2 id="flow">What happens on each call</H2>
+      <Ul>
+        <li>
+          No <Code>X-PAYMENT</Code> header → Tael replies <Code>402</Code> with the challenge above.
+        </li>
+        <li>
+          The agent signs a Stellar USDC payment and retries with the <Code>X-PAYMENT</Code> proof.
+        </li>
+        <li>
+          Tael verifies the payment through your <Code>verifier</Code>, runs your handler, and
+          echoes an <Code>X-PAYMENT-RESPONSE</Code> receipt.
+        </li>
+      </Ul>
+
+      <H2 id="next">Next steps</H2>
+      <Ul>
+        <li>
+          <A href="/docs/authentication">Authentication</A> — why there are no API keys.
+        </li>
+        <li>
+          <A href="/docs/accept-payments">Accept payments</A> — the full challenge → receipt flow.
+        </li>
+        <li>
+          <A href="/docs/sdk/node">Node.js SDK</A> — the complete option reference.
+        </li>
+      </Ul>
+    </DocPage>
+  );
+}

--- a/apps/web/app/docs/sdk/curl/page.tsx
+++ b/apps/web/app/docs/sdk/curl/page.tsx
@@ -1,0 +1,99 @@
+import { A, Callout, Code, CodeBlock, DocPage, H2, P } from "../../_components/doc-page";
+
+const TOC = [
+  { label: "1. Get the challenge", href: "#challenge" },
+  { label: "2. Build the proof", href: "#proof" },
+  { label: "3. Send the payment", href: "#send" },
+  { label: "4. Read the receipt", href: "#receipt" },
+];
+
+export default function CurlSdkPage() {
+  return (
+    <DocPage
+      eyebrow="SDKs"
+      title="cURL"
+      lead="Drive the x402 flow with raw HTTP — no SDK required."
+      toc={TOC}
+    >
+      <P>
+        Tael is just HTTP. Any client that can set a header can pay for a call, which makes it easy
+        to test endpoints from the terminal.
+      </P>
+
+      <H2 id="challenge">1. Get the challenge</H2>
+      <P>
+        Call the resource with no payment. You get a <Code>402</Code> whose <Code>accepts[0]</Code>{" "}
+        tells you exactly what to pay and to whom.
+      </P>
+      <CodeBlock
+        title="terminal"
+        code={`curl -i -X POST https://api.example.com/v1/ocr
+
+HTTP/1.1 402 Payment Required
+content-type: application/json
+
+{
+  "x402Version": 1,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "stellar-testnet",
+      "maxAmountRequired": "0.02",
+      "payTo": "G...",
+      "asset": { "code": "USDC", "issuer": "G..." },
+      "resource": "/v1/ocr"
+    }
+  ]
+}`}
+      />
+
+      <H2 id="proof">2. Build the proof</H2>
+      <P>
+        Sign a Stellar payment of <Code>maxAmountRequired</Code> USDC to <Code>payTo</Code>, put its
+        XDR into the payment envelope, and base64-encode the JSON:
+      </P>
+      <CodeBlock
+        title="X-PAYMENT (before encoding)"
+        code={`{
+  "x402Version": 1,
+  "scheme": "exact",
+  "network": "stellar-testnet",
+  "payload": { "transaction": "<signed XDR>" }
+}`}
+      />
+      <CodeBlock title="terminal" code={`PAYMENT=$(printf '%s' "$ENVELOPE_JSON" | base64)`} />
+      <Callout>
+        The signed transaction is produced with a Stellar wallet or the Stellar SDK. Tael verifies
+        and settles it — it never holds your keys.
+      </Callout>
+
+      <H2 id="send">3. Send the payment</H2>
+      <P>
+        Retry the request with the <Code>X-PAYMENT</Code> header. Tael verifies it, runs the
+        handler, and returns your result.
+      </P>
+      <CodeBlock
+        title="terminal"
+        code={`curl -i -X POST https://api.example.com/v1/ocr \\
+  -H "X-PAYMENT: $PAYMENT" \\
+  -H "content-type: application/json" \\
+  -d '{ "document_url": "https://example.com/invoice.pdf" }'
+
+HTTP/1.1 200 OK
+x-payment-response: <base64 receipt>
+
+{ "text": "INVOICE #1042 ..." }`}
+      />
+
+      <H2 id="receipt">4. Read the receipt</H2>
+      <P>
+        The <Code>X-PAYMENT-RESPONSE</Code> header is a base64 receipt proving the payment settled —
+        decode it to confirm the amount, payer, and transaction.
+      </P>
+      <P>
+        Building a real integration in code instead? The <A href="/docs/sdk/node">Node.js SDK</A>{" "}
+        handles the encoding and verification for you.
+      </P>
+    </DocPage>
+  );
+}

--- a/apps/web/app/docs/sdk/node/page.tsx
+++ b/apps/web/app/docs/sdk/node/page.tsx
@@ -1,0 +1,126 @@
+import { A, Code, CodeBlock, DocPage, H2, P, Ul } from "../../_components/doc-page";
+
+const TOC = [
+  { label: "Install", href: "#install" },
+  { label: "createTael", href: "#create-tael" },
+  { label: "tael", href: "#tael" },
+  { label: "TaelOptions", href: "#options" },
+  { label: "Verifiers", href: "#verifiers" },
+  { label: "Exports", href: "#exports" },
+];
+
+export default function NodeSdkPage() {
+  return (
+    <DocPage
+      eyebrow="SDKs"
+      title="Node.js"
+      lead="Reference for @tael/sdk — wrap any Fetch handler with x402 payments."
+      toc={TOC}
+    >
+      <H2 id="install">Install</H2>
+      <CodeBlock title="terminal" code={`pnpm add @tael/sdk`} />
+
+      <H2 id="create-tael">createTael(defaults)</H2>
+      <P>
+        Binds service-wide settlement details once and returns a <Code>paid()</Code> function for
+        defining individual routes. This is the recommended entry point.
+      </P>
+      <CodeBlock
+        title="createTael"
+        code={`const paid = createTael({
+  payTo,     // StellarAddress that receives settlement
+  issuer,    // StellarAddress of the USDC issuer
+  network,   // "stellar-testnet" | "stellar-mainnet"
+  verifier,  // PaymentVerifier
+});
+
+// paid(route) -> (Request) => Promise<Response>
+export const POST = paid({ price: "0.02", handler });`}
+      />
+
+      <H2 id="tael">tael(options)</H2>
+      <P>
+        The one-shot form. Takes the full option set and returns a payment-gated Fetch handler{" "}
+        <Code>(Request) =&gt; Promise&lt;Response&gt;</Code>. Use it when a route doesn&apos;t share
+        defaults with others.
+      </P>
+      <CodeBlock
+        title="tael"
+        code={`const handler = tael({
+  price: "0.02",
+  payTo,
+  issuer,
+  network: "stellar-testnet",
+  verifier: createMockVerifier(),
+  handler: ({ request, receipt }) => Response.json({ ok: true }),
+});`}
+      />
+
+      <H2 id="options">TaelOptions</H2>
+      <Ul>
+        <li>
+          <Code>price: string</Code> — price per call, a decimal USDC string (e.g.{" "}
+          <Code>&quot;0.02&quot;</Code>).
+        </li>
+        <li>
+          <Code>payTo: string</Code> — Stellar address that receives settlement.
+        </li>
+        <li>
+          <Code>issuer: string</Code> — the USDC issuer on the target network.
+        </li>
+        <li>
+          <Code>network: &quot;stellar-testnet&quot; | &quot;stellar-mainnet&quot;</Code>
+        </li>
+        <li>
+          <Code>verifier: PaymentVerifier</Code> — verifies + settles the payment.
+        </li>
+        <li>
+          <Code>description?: string</Code> — human text shown in the <Code>402</Code> challenge.
+        </li>
+        <li>
+          <Code>handler: (ctx) =&gt; Response | Promise&lt;Response&gt;</Code> — runs after payment.
+          Receives <Code>&#123; request, receipt &#125;</Code>.
+        </li>
+      </Ul>
+      <P>
+        With <Code>createTael</Code>, <Code>payTo</Code>/<Code>issuer</Code>/<Code>network</Code>/
+        <Code>verifier</Code> come from the defaults and each route supplies only <Code>price</Code>
+        , <Code>handler</Code>, and an optional <Code>description</Code>.
+      </P>
+
+      <H2 id="verifiers">Verifiers</H2>
+      <P>
+        The <Code>PaymentVerifier</Code> is the chain-specific port. It&apos;s injected so the SDK
+        stays chain-agnostic and your handlers stay portable.
+      </P>
+      <Ul>
+        <li>
+          <Code>createMockVerifier()</Code> — re-exported from the SDK; accepts any well-formed
+          proof for dev and tests.
+        </li>
+        <li>
+          The Stellar verifier from <Code>@tael/stellar</Code> — real on-chain settlement for
+          production.
+        </li>
+      </Ul>
+
+      <H2 id="exports">Exports</H2>
+      <Ul>
+        <li>
+          <Code>createTael</Code>, <Code>tael</Code>
+        </li>
+        <li>
+          Types: <Code>TaelOptions</Code>, <Code>TaelDefaults</Code>, <Code>TaelRoute</Code>,{" "}
+          <Code>TaelContext</Code>, <Code>TaelHandler</Code>, <Code>FetchHandler</Code>
+        </li>
+        <li>
+          Re-exported from <Code>@tael/payments</Code>: <Code>createMockVerifier</Code>,{" "}
+          <Code>PaymentVerifier</Code>, <Code>PaymentNetwork</Code>, <Code>SettlementReceipt</Code>
+        </li>
+      </Ul>
+      <P>
+        Prefer raw HTTP? See the <A href="/docs/sdk/curl">cURL guide</A>.
+      </P>
+    </DocPage>
+  );
+}

--- a/apps/web/app/docs/wrap-an-api/page.tsx
+++ b/apps/web/app/docs/wrap-an-api/page.tsx
@@ -1,0 +1,114 @@
+import { A, Callout, Code, CodeBlock, DocPage, H2, P, Ul } from "../_components/doc-page";
+
+const TOC = [
+  { label: "One handler", href: "#one-handler" },
+  { label: "Shared defaults", href: "#defaults" },
+  { label: "Multiple routes", href: "#multiple" },
+  { label: "Reading the receipt", href: "#receipt" },
+  { label: "Frameworks", href: "#frameworks" },
+];
+
+export default function WrapAnApiPage() {
+  return (
+    <DocPage
+      eyebrow="Guides"
+      title="Wrap an API"
+      lead="Put a per-call price on any existing HTTP endpoint with one SDK call."
+      toc={TOC}
+    >
+      <H2 id="one-handler">One handler</H2>
+      <P>
+        The lowest-level primitive is <Code>tael()</Code>. Give it a price, your settlement details,
+        and a handler; it returns a payment-gated Fetch handler.
+      </P>
+      <CodeBlock
+        title="tael()"
+        code={`import { tael, createMockVerifier } from "@tael/sdk";
+
+export const handler = tael({
+  price: "0.02",
+  payTo: "G...",
+  issuer: "G...",
+  network: "stellar-testnet",
+  verifier: createMockVerifier(),
+  handler: () => Response.json({ ok: true }),
+});`}
+      />
+
+      <H2 id="defaults">Shared defaults</H2>
+      <P>
+        Most services expose several priced routes that share the same <Code>payTo</Code>,{" "}
+        <Code>issuer</Code>, <Code>network</Code>, and <Code>verifier</Code>. Bind those once with{" "}
+        <Code>createTael()</Code> so each route only declares what&apos;s different — its price and
+        handler.
+      </P>
+      <CodeBlock
+        title="createTael()"
+        code={`import { createTael, createMockVerifier } from "@tael/sdk";
+
+export const paid = createTael({
+  payTo: process.env.TAEL_PAY_TO!,
+  issuer: process.env.USDC_ISSUER!,
+  network: "stellar-testnet",
+  verifier: createMockVerifier(),
+});`}
+      />
+
+      <H2 id="multiple">Multiple routes</H2>
+      <P>Reuse the wrapper across endpoints, each with its own price:</P>
+      <CodeBlock
+        title="routes"
+        code={`export const ocr = paid({
+  price: "0.02",
+  description: "Extract text from a document",
+  handler: runOcr,
+});
+
+export const translate = paid({
+  price: "0.05",
+  description: "Translate a document",
+  handler: runTranslate,
+});`}
+      />
+      <Callout>
+        Prices are decimal strings of USDC (e.g. <Code>&quot;0.02&quot;</Code>). The value becomes{" "}
+        <Code>maxAmountRequired</Code> in the <Code>402</Code> challenge for that route.
+      </Callout>
+
+      <H2 id="receipt">Reading the receipt</H2>
+      <P>
+        Your handler runs only after payment settles and receives a <Code>receipt</Code> alongside
+        the request, so you can attribute usage or log settlement:
+      </P>
+      <CodeBlock
+        title="handler context"
+        code={`handler: async ({ request, receipt }) => {
+  const input = await request.json();
+  const result = await doWork(input);
+  return Response.json({ result, paidBy: receipt.payer });
+}`}
+      />
+
+      <H2 id="frameworks">Frameworks</H2>
+      <P>
+        Because the wrapper is a plain <Code>(Request) =&gt; Promise&lt;Response&gt;</Code>, it
+        works anywhere the Web Fetch standard does:
+      </P>
+      <Ul>
+        <li>
+          <strong>Next.js</strong> — <Code>export const POST = paid(&#123;...&#125;)</Code> in a
+          route handler.
+        </li>
+        <li>
+          <strong>Hono</strong> — mount it as a handler on a route.
+        </li>
+        <li>
+          <strong>Bun, Deno, Cloudflare Workers</strong> — use it as the fetch entrypoint.
+        </li>
+      </Ul>
+      <P>
+        For the exact option shapes, see the <A href="/docs/sdk/node">Node.js SDK reference</A>.
+      </P>
+    </DocPage>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -6,3 +6,29 @@ body {
   color: #27272a;
   background-color: #ffffff;
 }
+
+/* Syntax highlighting (sugar-high) — light palette, Vercel-style colors. */
+:root {
+  --sh-class: #1f6feb;
+  --sh-identifier: #354150;
+  --sh-sign: #8996a3;
+  --sh-property: #0550ae;
+  --sh-entity: #6f42c1;
+  --sh-jsxliterals: #6266d1;
+  --sh-string: #007f7a;
+  --sh-keyword: #d1349b;
+  --sh-comment: #a2a9b4;
+}
+
+/* Dark palette — vivid tokens on a near-black block. */
+.dark {
+  --sh-class: #e5c07b;
+  --sh-identifier: #d6deeb;
+  --sh-sign: #7d8799;
+  --sh-property: #79c0ff;
+  --sh-entity: #61afef;
+  --sh-jsxliterals: #79c0ff;
+  --sh-string: #7ee787;
+  --sh-keyword: #ff7b9c;
+  --sh-comment: #7d8590;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -39,7 +39,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
       className={`${inter.variable} ${delicious.variable} ${dot.variable}`}
     >
-      <body className="font-sans antialiased">
+      <body className="font-sans antialiased" suppressHydrationWarning>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,8 @@
     "next-themes": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "resend": "^6.17.2"
+    "resend": "^6.17.2",
+    "sugar-high": "^1.2.1"
   },
   "devDependencies": {
     "@tael/config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       resend:
         specifier: ^6.17.2
         version: 6.17.2
+      sugar-high:
+        specifier: ^1.2.1
+        version: 1.2.1
     devDependencies:
       '@tael/config':
         specifier: workspace:*
@@ -5307,6 +5310,9 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  sugar-high@1.2.1:
+    resolution: {integrity: sha512-C2E0iSC0Gwv+7t32ATFxgiH6fxskoSfd/nF5z11pQSrgJHYjY8/U11K+X0izV9ZyPNPwaomtn6uF7y11MxVNQA==}
 
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
@@ -11511,6 +11517,8 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
+
+  sugar-high@1.2.1: {}
 
   superstruct@2.0.2: {}
 


### PR DESCRIPTION
## What

Fills in the docs site with **real content** (grounded in `@tael/sdk` and `@tael/payments` source, not placeholders) and upgrades the code blocks.

### Docs content
- New pages: Quickstart, Authentication, Accept payments, Wrap an API, and the Node.js + cURL SDK references — all via a shared `doc-page` component that matches the existing intro design.
- Home cards + Explore rows now link to those real pages.
- Sidebar trimmed to shipped features (dropped Python SDK, Webhooks, Agent wallets).

### Code blocks (Vercel-style)
- Syntax highlighting via `sugar-high` with light + dark palettes.
- Every block has a language badge (TS/JS/JSON/Terminal) + filename header + a copy button.

### Other
- GitHub 'Star' button with a live star count in the docs nav.
- Fix a hydration warning caused by browser extensions (e.g. Grammarly) injecting `data-*` attributes into `<body>` — `suppressHydrationWarning`.

## Verify
`pnpm format:check`, `pnpm lint`, `pnpm --filter web typecheck`, and `pnpm --filter web build` all pass locally.