### PR TITLE
feat: capability gateway — pay-per-call over x402

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "@hono/node-server": "catalog:",
     "@stellar/stellar-sdk": "catalog:",
+    "@tael/database": "workspace:*",
     "@tael/payments": "workspace:*",
+    "@tael/sdk": "workspace:*",
     "@tael/stellar": "workspace:*",
     "@tael/types": "workspace:*",
     "@trpc/server": "catalog:",

--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -5,11 +5,19 @@ import {
   type SettlementReceipt,
 } from "@tael/payments";
 import { createStellarSettlement, type StellarNetwork } from "@tael/stellar";
+import { getDatabase } from "@tael/database";
 import { type Env } from "./env";
 import { InMemoryWalletRepository } from "./modules/wallets/wallet.repository";
 import { WalletService } from "./modules/wallets/wallet.service";
-import { InMemoryPaymentRepository } from "./modules/payments/payment.repository";
+import {
+  DbPaymentRepository,
+  InMemoryPaymentRepository,
+} from "./modules/payments/payment.repository";
 import { PaymentService } from "./modules/payments/payment.service";
+import {
+  DbCapabilityRepository,
+  type CapabilityRepository,
+} from "./modules/capabilities/capability.repository";
 
 /**
  * The composition root. This is the ONE place where concrete implementations are
@@ -20,7 +28,10 @@ import { PaymentService } from "./modules/payments/payment.service";
 export interface Container {
   wallets: WalletService;
   payments: PaymentService;
+  capabilities: CapabilityRepository;
   verifier: PaymentVerifier;
+  /** Payment settings the gateway needs to build x402 challenges. */
+  gateway: { issuer: string; network: PaymentNetwork; publicUrl: string };
 }
 
 function toPaymentNetwork(network: StellarNetwork): PaymentNetwork {
@@ -39,18 +50,41 @@ function createStellarVerifier(env: Env): PaymentVerifier {
   return {
     async verify(payload): Promise<SettlementReceipt> {
       const receipt = await settlement.submitSignedTransaction(payload.payload.transaction);
-      return { txHash: receipt.txHash, network, settledAt: new Date().toISOString() };
+      return {
+        txHash: receipt.txHash,
+        network,
+        settledAt: new Date().toISOString(),
+        payer: receipt.payer,
+      };
     },
   };
 }
 
 export function createContainer(env: Env): Container {
+  const isProd = env.NODE_ENV === "production";
+
   const wallets = new WalletService(new InMemoryWalletRepository());
-  const payments = new PaymentService(new InMemoryPaymentRepository());
+
+  // Persist to Postgres when a DATABASE_URL is configured (prod / real dev);
+  // fall back to the in-memory ledger so tests stay hermetic.
+  const db = process.env.DATABASE_URL ? getDatabase() : undefined;
+  const payments = new PaymentService(
+    db ? new DbPaymentRepository(db) : new InMemoryPaymentRepository(),
+  );
+  const capabilities = new DbCapabilityRepository(db);
 
   // Real on-chain settlement in production; a mock keeps dev + tests hermetic.
-  const verifier =
-    env.NODE_ENV === "production" ? createStellarVerifier(env) : createMockVerifier();
+  const verifier = isProd ? createStellarVerifier(env) : createMockVerifier();
 
-  return { wallets, payments, verifier };
+  return {
+    wallets,
+    payments,
+    capabilities,
+    verifier,
+    gateway: {
+      issuer: env.USDC_ISSUER,
+      network: toPaymentNetwork(env.STELLAR_NETWORK),
+      publicUrl: env.API_PUBLIC_URL,
+    },
+  };
 }

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -12,6 +12,11 @@ const envSchema = z.object({
   STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
   STELLAR_HORIZON_URL: z.string().url().default("https://horizon-testnet.stellar.org"),
   USDC_ISSUER: z.string().default("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"),
+  // Consumed by @tael/database and its crypto helper. Optional here so tests stay
+  // hermetic (the in-memory repos need neither); the gateway throws a clear error
+  // at runtime if it's asked to read a capability without them.
+  DATABASE_URL: z.string().url().optional(),
+  ENCRYPTION_KEY: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,4 @@
+import "./load-env"; // must be first — populates process.env for local dev
 import { serve } from "@hono/node-server";
 import { createContainer } from "./container";
 import { env } from "./env";

--- a/apps/api/src/load-env.ts
+++ b/apps/api/src/load-env.ts
@@ -1,0 +1,15 @@
+import { resolve } from "node:path";
+
+/**
+ * Local-dev convenience: load the monorepo-root `.env` into `process.env` before
+ * anything reads it, so `DATABASE_URL`, `ENCRYPTION_KEY`, etc. resolve when you
+ * run the API standalone. Imported first in `index.ts`.
+ *
+ * In production/CI the platform injects real env vars and there's no file — the
+ * load is wrapped so a missing `.env` is a silent no-op.
+ */
+try {
+  process.loadEnvFile(resolve(process.cwd(), "../../.env"));
+} catch {
+  // No .env on disk — rely on the real environment.
+}

--- a/apps/api/src/modules/capabilities/capability.repository.ts
+++ b/apps/api/src/modules/capabilities/capability.repository.ts
@@ -1,0 +1,65 @@
+import { and, capabilities, eq, ne, type Database } from "@tael/database";
+import { TaelError } from "@tael/types";
+
+/**
+ * The subset of a capability the gateway needs to serve and charge for a call.
+ * Deliberately narrow — the gateway never needs the publisher, FAQs, or spec.
+ */
+export interface ServableCapability {
+  id: string;
+  slug: string;
+  name: string;
+  /** Headline price per call, decimal USDC string. */
+  price: string;
+  /** Stellar address that receives settlement. */
+  payTo: string;
+  /** The developer's real upstream endpoint. */
+  upstreamUrl: string;
+  /** Encrypted upstream API key (AES-256-GCM), or null if the upstream is open. */
+  upstreamSecretEnc: string | null;
+}
+
+/** Port: read capabilities that are eligible to be called through the gateway. */
+export interface CapabilityRepository {
+  /**
+   * Find a capability that may be served over the public gateway: it must exist,
+   * be `verified`, and not be `private`. Returns null otherwise.
+   */
+  findServableBySlug(slug: string): Promise<ServableCapability | null>;
+}
+
+/** Postgres-backed adapter over @tael/database. */
+export class DbCapabilityRepository implements CapabilityRepository {
+  constructor(private readonly db: Database | undefined) {}
+
+  async findServableBySlug(slug: string): Promise<ServableCapability | null> {
+    if (!this.db) {
+      throw new TaelError(
+        "INTERNAL",
+        "DATABASE_URL is not configured — the gateway cannot read capabilities.",
+      );
+    }
+
+    const [row] = await this.db
+      .select({
+        id: capabilities.id,
+        slug: capabilities.slug,
+        name: capabilities.name,
+        price: capabilities.price,
+        payTo: capabilities.payTo,
+        upstreamUrl: capabilities.upstreamUrl,
+        upstreamSecretEnc: capabilities.upstreamSecretEnc,
+      })
+      .from(capabilities)
+      .where(
+        and(
+          eq(capabilities.slug, slug),
+          eq(capabilities.status, "verified"),
+          ne(capabilities.visibility, "private"),
+        ),
+      )
+      .limit(1);
+
+    return row ?? null;
+  }
+}

--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -1,0 +1,71 @@
+import { tael } from "@tael/sdk";
+import { type Container } from "../../container";
+import { proxyToUpstream, isBlockedUrl } from "./upstream";
+
+/** The slice of the container the gateway needs. */
+export type GatewayDeps = Pick<Container, "capabilities" | "payments" | "verifier" | "gateway">;
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Serve a capability over x402. Loads the capability, then hands the request to
+ * the SDK's `tael()` wrapper: no payment → `402` challenge; valid payment →
+ * verify, proxy to the real upstream, record the settled payment, and return the
+ * result with an `X-PAYMENT-RESPONSE` receipt.
+ *
+ * Framework-agnostic on purpose (takes a `Request`, returns a `Response`) so it
+ * mounts under Hono here but is trivially testable via `app.request(...)`.
+ */
+export async function handleGatewayRequest(
+  deps: GatewayDeps,
+  slug: string,
+  request: Request,
+): Promise<Response> {
+  const capability = await deps.capabilities.findServableBySlug(slug);
+  if (!capability) {
+    return json({ error: "Capability not found" }, 404);
+  }
+
+  // Never take payment for a call we won't be able to make.
+  if (isBlockedUrl(capability.upstreamUrl)) {
+    return json({ error: "Capability upstream is unavailable" }, 502);
+  }
+
+  const paid = tael({
+    price: capability.price,
+    payTo: capability.payTo,
+    issuer: deps.gateway.issuer,
+    network: deps.gateway.network,
+    verifier: deps.verifier,
+    description: capability.name,
+    handler: async ({ request: paidRequest, receipt }) => {
+      // The payment settled during verification — record it before doing the
+      // work, so the ledger is correct even if the upstream then misbehaves.
+      try {
+        await deps.payments.recordSettled({
+          capabilityId: capability.id,
+          payer: receipt.payer,
+          payee: capability.payTo,
+          amount: capability.price,
+          txHash: receipt.txHash,
+        });
+      } catch (error) {
+        console.error("[gateway] failed to record payment:", error);
+      }
+
+      try {
+        return await proxyToUpstream(capability, paidRequest);
+      } catch (error) {
+        console.error("[gateway] upstream call failed:", error);
+        return json({ error: "Upstream call failed" }, 502);
+      }
+    },
+  });
+
+  return paid(request);
+}

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockVerifier,
+  encodePaymentPayload,
+  PAYMENT_REQUEST_HEADER,
+  PAYMENT_RESPONSE_HEADER,
+  X402_VERSION,
+} from "@tael/payments";
+import { type Container } from "../../container";
+import { WalletService } from "../wallets/wallet.service";
+import { InMemoryWalletRepository } from "../wallets/wallet.repository";
+import { PaymentService } from "../payments/payment.service";
+import { InMemoryPaymentRepository } from "../payments/payment.repository";
+import {
+  type CapabilityRepository,
+  type ServableCapability,
+} from "../capabilities/capability.repository";
+import { createServer } from "../../server";
+
+const ADDRESS = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+const CAPABILITY: ServableCapability = {
+  id: "cap-1",
+  slug: "predict-age",
+  name: "Age Prediction API",
+  price: "0.02",
+  payTo: ADDRESS,
+  upstreamUrl: "https://api.example.com/age",
+  upstreamSecretEnc: null,
+};
+
+/** A capability repo that returns the fixture for its slug and null otherwise. */
+function fakeCapabilities(capability: ServableCapability | null): CapabilityRepository {
+  return {
+    findServableBySlug: (slug) =>
+      Promise.resolve(capability && slug === capability.slug ? capability : null),
+  };
+}
+
+function buildContainer(capability: ServableCapability | null): {
+  container: Container;
+  payments: PaymentService;
+} {
+  const payments = new PaymentService(new InMemoryPaymentRepository());
+  const container: Container = {
+    wallets: new WalletService(new InMemoryWalletRepository()),
+    payments,
+    capabilities: fakeCapabilities(capability),
+    verifier: createMockVerifier(),
+    gateway: { issuer: ADDRESS, network: "stellar-testnet", publicUrl: "http://localhost:3001" },
+  };
+  return { container, payments };
+}
+
+function paymentHeader(): string {
+  return encodePaymentPayload({
+    x402Version: X402_VERSION,
+    scheme: "exact",
+    network: "stellar-testnet",
+    payload: { transaction: "AAAA-signed-xdr" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("capability gateway", () => {
+  it("returns a 402 challenge when no payment is present", async () => {
+    const { container } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+
+    const res = await app.request("/c/predict-age");
+    expect(res.status).toBe(402);
+
+    const body = (await res.json()) as {
+      x402Version: number;
+      accepts: { maxAmountRequired: string; payTo: string; resource: string }[];
+    };
+    expect(body.x402Version).toBe(X402_VERSION);
+    expect(body.accepts[0]?.maxAmountRequired).toBe("0.02");
+    expect(body.accepts[0]?.payTo).toBe(ADDRESS);
+    expect(body.accepts[0]?.resource).toBe("/c/predict-age");
+  });
+
+  it("proxies to the upstream and records the payment when paid", async () => {
+    const upstream = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ age: 41 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", upstream);
+
+    const { container, payments } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+
+    const res = await app.request("/c/predict-age", {
+      method: "POST",
+      headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader(), "content-type": "application/json" },
+      body: JSON.stringify({ name: "tael" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get(PAYMENT_RESPONSE_HEADER)).toBeTruthy();
+    expect(await res.json()).toEqual({ age: 41 });
+
+    // Upstream was actually called…
+    expect(upstream).toHaveBeenCalledOnce();
+    expect(upstream.mock.calls[0]?.[0]).toBe("https://api.example.com/age");
+
+    // …and the settlement was recorded.
+    const ledger = await payments.list();
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0]).toMatchObject({
+      capabilityId: "cap-1",
+      payee: ADDRESS,
+      amount: "0.02",
+      status: "settled",
+    });
+    expect(ledger[0]?.txHash).toBeTruthy();
+    expect(ledger[0]?.payer).toContain("mock_payer_");
+  });
+
+  it("does not forward the X-PAYMENT header to the upstream", async () => {
+    const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", upstream);
+
+    const { container } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+
+    await app.request("/c/predict-age", {
+      method: "POST",
+      headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+    });
+
+    const forwarded = upstream.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(forwarded.headers);
+    expect(headers.has("x-payment")).toBe(false);
+  });
+
+  it("404s for an unknown or non-servable capability", async () => {
+    const { container } = buildContainer(null);
+    const app = createServer(container);
+
+    const res = await app.request("/c/does-not-exist");
+    expect(res.status).toBe(404);
+  });
+
+  it("502s (without charging) when the upstream is an internal address", async () => {
+    const upstream = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", upstream);
+
+    const { container, payments } = buildContainer({
+      ...CAPABILITY,
+      upstreamUrl: "http://localhost:9999/secret",
+    });
+    const app = createServer(container);
+
+    const res = await app.request("/c/predict-age", {
+      method: "POST",
+      headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+    });
+
+    expect(res.status).toBe(502);
+    expect(upstream).not.toHaveBeenCalled();
+    expect(await payments.list()).toHaveLength(0);
+  });
+});

--- a/apps/api/src/modules/gateway/upstream.ts
+++ b/apps/api/src/modules/gateway/upstream.ts
@@ -1,0 +1,83 @@
+import { decryptSecret } from "@tael/database";
+import { type ServableCapability } from "../capabilities/capability.repository";
+
+/** How long we wait on the upstream before giving up. */
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
+/**
+ * Basic SSRF guard: reject non-http(s) URLs and obviously-internal hosts. Mirrors
+ * the publish-time check in the dashboard — defense in depth, since a capability's
+ * upstream is verified once at publish but proxied here on every call.
+ */
+export function isBlockedUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return true;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return true;
+  const host = url.hostname;
+  return (
+    host === "localhost" ||
+    host === "0.0.0.0" ||
+    host.endsWith(".local") ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^169\.254\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+  );
+}
+
+/** Hop-by-hop and payment headers we must not forward to the upstream. */
+const STRIPPED_REQUEST_HEADERS = new Set([
+  "host",
+  "connection",
+  "content-length",
+  "x-payment",
+  "authorization",
+]);
+
+/**
+ * Proxy the (already-paid) request to the capability's real upstream endpoint,
+ * injecting the decrypted API key. Forwards the caller's method, body, and safe
+ * headers; returns the upstream response verbatim.
+ */
+export async function proxyToUpstream(
+  capability: ServableCapability,
+  request: Request,
+): Promise<Response> {
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    if (!STRIPPED_REQUEST_HEADERS.has(key.toLowerCase())) headers.set(key, value);
+  });
+  if (capability.upstreamSecretEnc) {
+    headers.set("authorization", `Bearer ${decryptSecret(capability.upstreamSecretEnc)}`);
+  }
+
+  const method = request.method.toUpperCase();
+  const hasBody = method !== "GET" && method !== "HEAD";
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+  try {
+    const upstream = await fetch(capability.upstreamUrl, {
+      method,
+      headers,
+      body: hasBody ? await request.arrayBuffer() : undefined,
+      signal: controller.signal,
+    });
+    // Re-emit as a fresh Response so the body is consumable by the SDK wrapper.
+    const responseHeaders = new Headers(upstream.headers);
+    responseHeaders.delete("content-encoding");
+    responseHeaders.delete("content-length");
+    return new Response(await upstream.arrayBuffer(), {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/api/src/modules/payments/payment.repository.ts
+++ b/apps/api/src/modules/payments/payment.repository.ts
@@ -1,3 +1,10 @@
+import {
+  desc,
+  eq,
+  payments as paymentsTable,
+  type Database,
+  type Payment as PaymentRow,
+} from "@tael/database";
 import { type Payment } from "@tael/types";
 
 /** Port for payment persistence (see wallet.repository for the rationale). */
@@ -21,5 +28,54 @@ export class InMemoryPaymentRepository implements PaymentRepository {
 
   list(): Promise<Payment[]> {
     return Promise.resolve([...this.payments.values()]);
+  }
+}
+
+/** Map a persisted row to the domain {@link Payment} shape. */
+function toPayment(row: PaymentRow): Payment {
+  return {
+    id: row.id,
+    capabilityId: row.capabilityId ?? "",
+    payer: row.payer,
+    payee: row.payee,
+    amount: row.amount,
+    status: row.status as Payment["status"],
+    txHash: row.txHash,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+/** Postgres-backed adapter over @tael/database — the settlement ledger. */
+export class DbPaymentRepository implements PaymentRepository {
+  constructor(private readonly db: Database) {}
+
+  async save(payment: Payment): Promise<Payment> {
+    const [row] = await this.db
+      .insert(paymentsTable)
+      .values({
+        id: payment.id,
+        capabilityId: payment.capabilityId || null,
+        payer: payment.payer,
+        payee: payment.payee,
+        amount: payment.amount,
+        status: payment.status,
+        txHash: payment.txHash,
+      })
+      .returning();
+    return toPayment(row!);
+  }
+
+  async findById(id: string): Promise<Payment | null> {
+    const [row] = await this.db
+      .select()
+      .from(paymentsTable)
+      .where(eq(paymentsTable.id, id))
+      .limit(1);
+    return row ? toPayment(row) : null;
+  }
+
+  async list(): Promise<Payment[]> {
+    const rows = await this.db.select().from(paymentsTable).orderBy(desc(paymentsTable.createdAt));
+    return rows.map(toPayment);
   }
 }

--- a/apps/api/src/modules/payments/payment.service.ts
+++ b/apps/api/src/modules/payments/payment.service.ts
@@ -20,6 +20,30 @@ export class PaymentService {
     return this.repository.save(payment);
   }
 
+  /**
+   * Record a payment that has already settled on-chain — used by the gateway
+   * after a capability call is verified. Unlike {@link record}, the tx is known.
+   */
+  async recordSettled(input: {
+    capabilityId: string;
+    payer: string;
+    payee: string;
+    amount: string;
+    txHash: string;
+  }): Promise<Payment> {
+    const payment: Payment = {
+      id: crypto.randomUUID(),
+      capabilityId: input.capabilityId,
+      payer: input.payer,
+      payee: input.payee,
+      amount: input.amount,
+      status: "settled",
+      txHash: input.txHash,
+      createdAt: new Date().toISOString(),
+    };
+    return this.repository.save(payment);
+  }
+
   async get(id: string): Promise<Payment> {
     const payment = await this.repository.findById(id);
     if (!payment) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,6 +2,7 @@ import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { type Container } from "./container";
+import { handleGatewayRequest } from "./modules/gateway/gateway.handler";
 import { createContextFactory } from "./trpc/context";
 import { appRouter } from "./trpc/router";
 
@@ -16,6 +17,10 @@ export function createServer(container: Container) {
   app.use("*", cors());
 
   app.get("/health", (c) => c.json({ status: "ok", service: "tael-api" }));
+
+  // The capability gateway: agents call `/c/:slug` and pay per call over x402.
+  // Public + unauthenticated by design — the payment *is* the authentication.
+  app.all("/c/:slug", (c) => handleGatewayRequest(container, c.req.param("slug"), c.req.raw));
 
   // Mount the tRPC router. The dashboard/SDK talk to this with full type safety.
   app.all("/trpc/*", (c) =>

--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -1,10 +1,13 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ArrowLeft, BadgeCheck, ChevronDown, Code2 } from "lucide-react";
-import { Button, cn } from "@tael/ui";
+import { cn } from "@tael/ui";
 import { getPublicCapabilityBySlug } from "../../../../features/capabilities/queries";
 import { formatPrice, kindMeta, timeAgo } from "../../../../features/capabilities/kind-meta";
+import { UseCapabilityDialog } from "../../../../features/capabilities/use-capability-dialog";
 import { VerificationTimeline } from "../../../../features/capabilities/verification-timeline";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
 export const dynamic = "force-dynamic";
 
@@ -48,7 +51,10 @@ export default async function CapabilityDetailPage({
             {verified ? <BadgeCheck className="h-5 w-5 text-emerald-600" /> : null}
           </h1>
         </div>
-        <Button>Use capability</Button>
+        <UseCapabilityDialog
+          endpoint={`${API_URL}/c/${capability.slug}`}
+          price={`$${formatPrice(capability.price)}`}
+        />
       </div>
 
       {/* Meta row */}

--- a/apps/dashboard/features/capabilities/use-capability-dialog.tsx
+++ b/apps/dashboard/features/capabilities/use-capability-dialog.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy, ExternalLink, Terminal } from "lucide-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@tael/ui";
+
+/**
+ * Shows how to actually call a capability: its live gateway endpoint plus a
+ * copy-paste x402 curl example. The payment *is* the auth — no keys, no signup.
+ */
+export function UseCapabilityDialog({ endpoint, price }: { endpoint: string; price: string }) {
+  const [open, setOpen] = useState(false);
+
+  const curl = [
+    `# 1. Call it — you'll get a 402 with the price and pay-to address`,
+    `curl -i ${endpoint}`,
+    ``,
+    `# 2. Pay ${price} USDC, then retry with the signed payment proof`,
+    `curl ${endpoint} \\`,
+    `  -H "X-PAYMENT: <base64 payment proof>"`,
+  ].join("\n");
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Use capability</Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Use this capability</DialogTitle>
+            <DialogDescription>
+              Point your agent at this endpoint. It pays per call in USDC over x402 — no accounts,
+              no API keys.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Endpoint
+              </span>
+              <CopyRow value={endpoint} mono />
+            </div>
+
+            <div className="space-y-1.5">
+              <span className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <Terminal className="h-3.5 w-3.5" /> Quick start
+              </span>
+              <CopyRow value={curl} block />
+            </div>
+
+            <a
+              href="/docs/accept-payments"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:underline"
+            >
+              How x402 payments work <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function CopyRow({ value, mono, block }: { value: string; mono?: boolean; block?: boolean }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard unavailable — no-op.
+    }
+  }
+
+  return (
+    <div className="relative rounded-lg border bg-muted/40">
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={copied ? "Copied" : "Copy"}
+        className="absolute right-2 top-2 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+      >
+        {copied ? <Check className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
+      </button>
+      {block ? (
+        <pre className="overflow-x-auto p-3 pr-10 text-xs leading-relaxed">
+          <code>{value}</code>
+        </pre>
+      ) : (
+        <p className={`p-3 pr-10 text-sm ${mono ? "font-mono" : ""} break-all`}>{value}</p>
+      )}
+    </div>
+  );
+}

--- a/packages/payments/src/verify.ts
+++ b/packages/payments/src/verify.ts
@@ -11,6 +11,8 @@ export interface SettlementReceipt {
   txHash: string;
   network: PaymentNetwork;
   settledAt: string;
+  /** The account that paid — the source of the settled transaction. */
+  payer: string;
 }
 
 /**
@@ -53,10 +55,12 @@ export function createMockVerifier(): PaymentVerifier {
   return {
     verify(payload) {
       const network = paymentNetworkSchema.parse(payload.network);
+      const hex = Buffer.from(payload.payload.transaction).toString("hex");
       return Promise.resolve({
-        txHash: `mock_${Buffer.from(payload.payload.transaction).toString("hex").slice(0, 32)}`,
+        txHash: `mock_${hex.slice(0, 32)}`,
         network,
         settledAt: new Date().toISOString(),
+        payer: `mock_payer_${hex.slice(0, 16)}`,
       });
     },
   };

--- a/packages/stellar/src/settlement.ts
+++ b/packages/stellar/src/settlement.ts
@@ -6,6 +6,8 @@ import { networkPassphrase, type StellarConfig, type StellarNetwork } from "./co
 export interface StellarTxReceipt {
   txHash: string;
   network: StellarNetwork;
+  /** Source account of the transaction — i.e. who paid. */
+  payer: string;
 }
 
 /**
@@ -30,8 +32,13 @@ export class StellarSettlement {
         signedXdr,
         networkPassphrase(this.config.network),
       );
+      // Fee-bump txs wrap an inner tx; the payer is the inner source in that case.
+      const payer =
+        "innerTransaction" in transaction
+          ? transaction.innerTransaction.source
+          : transaction.source;
       const result = await this.server.submitTransaction(transaction);
-      return { txHash: result.hash, network: this.config.network };
+      return { txHash: result.hash, network: this.config.network, payer };
     } catch (cause) {
       throw new TaelError("SETTLEMENT_FAILED", "Failed to submit transaction to Stellar", {
         cause,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,9 +158,15 @@ importers:
       '@stellar/stellar-sdk':
         specifier: 'catalog:'
         version: 13.3.0
+      '@tael/database':
+        specifier: workspace:*
+        version: link:../../packages/database
       '@tael/payments':
         specifier: workspace:*
         version: link:../../packages/payments
+      '@tael/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
       '@tael/stellar':
         specifier: workspace:*
         version: link:../../packages/stellar


### PR DESCRIPTION
## What

Closes the core loop: a published capability is now **callable and payable** over x402. Turns the marketplace from a catalog into a working payment layer.

## The endpoint — `ALL /c/:slug` (apps/api)

Public + unauthenticated by design (the payment *is* the auth). Per request:

1. Load the capability from Postgres — 404 unless it's `verified` and non-private.
2. No `X-PAYMENT` → return the x402 `402` challenge (price + payTo + USDC), built from the capability.
3. Valid `X-PAYMENT` → verify via the existing Stellar verifier, decrypt the upstream key, proxy to the real upstream, return the result + `X-PAYMENT-RESPONSE` receipt.
4. Persist the settled payment to the `payments` ledger.

It dogfoods `@tael/sdk`'s `tael()` wrapper for the 402/verify/receipt mechanics.

## Also

- `SettlementReceipt` gains `payer` (extracted from the tx source account) so the ledger records who paid.
- Dashboard "Use capability" button → a dialog with the live endpoint + copy-paste x402 curl.
- SSRF guard on the upstream (before charging); dev-only root `.env` loader for the API.

## Verified

- `format:check`, `lint`, `typecheck`, `test`, `build` — all green. New gateway tests cover 402 / paid→proxied→receipt→ledger / header-not-leaked / 404 / 502-without-charge.
- Manually end-to-end (dev mock verifier): `curl /c/<slug>` → 402 → pay → **200 + real upstream data + receipt**, with a `settled` row written to the ledger.

## Not in scope (next)

Real on-chain testnet settlement run, and crediting builders from the ledger.