### PR TITLE
feat: marketplace fee (non-custodial split) + hardened verifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
 # --- Payments (x402) ---
 # Facilitator that verifies/settles x402 payment proofs.
 X402_FACILITATOR_URL=
+# Marketplace fee (apps/api gateway). When TAEL_FEE_ADDRESS is set, the gateway
+# routes TAEL_FEE_BPS of each call's price to it in the same transaction
+# (non-custodial). Leave the address blank to disable the fee. 100 bps = 1%.
+TAEL_FEE_ADDRESS=
+TAEL_FEE_BPS=100
 
 # --- Web (apps/web) ---
 # NEXT_PUBLIC_* values are exposed to the browser — never put secrets here.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
+    "pay:testnet": "tsx src/scripts/testnet-pay.ts",
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -4,7 +4,13 @@ import {
   type PaymentVerifier,
   type SettlementReceipt,
 } from "@tael/payments";
-import { createStellarSettlement, type StellarNetwork } from "@tael/stellar";
+import { PaymentVerificationError } from "@tael/types";
+import {
+  createStellarSettlement,
+  verifyTransactionPayments,
+  type ExpectedPayment,
+  type StellarNetwork,
+} from "@tael/stellar";
 import { getDatabase } from "@tael/database";
 import { type Env } from "./env";
 import { InMemoryWalletRepository } from "./modules/wallets/wallet.repository";
@@ -31,7 +37,15 @@ export interface Container {
   capabilities: CapabilityRepository;
   verifier: PaymentVerifier;
   /** Payment settings the gateway needs to build x402 challenges. */
-  gateway: { issuer: string; network: PaymentNetwork; publicUrl: string };
+  gateway: {
+    issuer: string;
+    network: PaymentNetwork;
+    publicUrl: string;
+    /** Marketplace fee recipient (Stellar address); undefined = no fee. */
+    feeAddress?: string;
+    /** Fee in basis points (100 = 1%). */
+    feeBps: number;
+  };
 }
 
 function toPaymentNetwork(network: StellarNetwork): PaymentNetwork {
@@ -48,13 +62,32 @@ function createStellarVerifier(env: Env): PaymentVerifier {
   const network = toPaymentNetwork(env.STELLAR_NETWORK);
 
   return {
-    async verify(payload): Promise<SettlementReceipt> {
+    async verify(payload, requirements): Promise<SettlementReceipt> {
+      // Validate — offline — that the signed tx actually pays the required legs
+      // (builder + any fee) in USDC, BEFORE submitting. Without this the gateway
+      // would settle and serve any well-formed transaction (submit-and-trust).
+      const expected: ExpectedPayment[] = [
+        { to: requirements.payTo, minAmount: requirements.maxAmountRequired },
+      ];
+      if (requirements.fee) {
+        expected.push({ to: requirements.fee.payTo, minAmount: requirements.fee.amount });
+      }
+      const check = verifyTransactionPayments(
+        payload.payload.transaction,
+        env.STELLAR_NETWORK,
+        env.USDC_ISSUER,
+        expected,
+      );
+      if (!check.ok) {
+        throw new PaymentVerificationError(check.reason ?? "Payment does not satisfy requirements");
+      }
+
       const receipt = await settlement.submitSignedTransaction(payload.payload.transaction);
       return {
         txHash: receipt.txHash,
         network,
         settledAt: new Date().toISOString(),
-        payer: receipt.payer,
+        payer: check.payer ?? receipt.payer,
       };
     },
   };
@@ -85,6 +118,8 @@ export function createContainer(env: Env): Container {
       issuer: env.USDC_ISSUER,
       network: toPaymentNetwork(env.STELLAR_NETWORK),
       publicUrl: env.API_PUBLIC_URL,
+      feeAddress: env.TAEL_FEE_ADDRESS,
+      feeBps: env.TAEL_FEE_BPS,
     },
   };
 }

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -17,6 +17,11 @@ const envSchema = z.object({
   // at runtime if it's asked to read a capability without them.
   DATABASE_URL: z.string().url().optional(),
   ENCRYPTION_KEY: z.string().optional(),
+  // Marketplace fee. When TAEL_FEE_ADDRESS is set, the gateway takes TAEL_FEE_BPS
+  // of each call's price and routes it to that Stellar address in the same tx
+  // (non-custodial). Unset → no fee (builder keeps 100%). 100 bps = 1%.
+  TAEL_FEE_ADDRESS: z.string().optional(),
+  TAEL_FEE_BPS: z.coerce.number().int().min(0).max(10000).default(100),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -1,4 +1,5 @@
 import { tael } from "@tael/sdk";
+import { splitFee } from "@tael/payments";
 import { type Container } from "../../container";
 import { proxyToUpstream, isBlockedUrl } from "./upstream";
 
@@ -36,6 +37,14 @@ export async function handleGatewayRequest(
     return json({ error: "Capability upstream is unavailable" }, 502);
   }
 
+  // Take the marketplace fee out of the price (non-custodial: it's paid directly
+  // to Tael in the same tx). No fee address configured → builder keeps 100%.
+  const fee =
+    deps.gateway.feeAddress && deps.gateway.feeBps > 0
+      ? { payTo: deps.gateway.feeAddress, bps: deps.gateway.feeBps }
+      : undefined;
+  const split = splitFee(capability.price, fee ? deps.gateway.feeBps : 0);
+
   const paid = tael({
     price: capability.price,
     payTo: capability.payTo,
@@ -43,6 +52,7 @@ export async function handleGatewayRequest(
     network: deps.gateway.network,
     verifier: deps.verifier,
     description: capability.name,
+    fee,
     handler: async ({ request: paidRequest, receipt }) => {
       // The payment settled during verification — record it before doing the
       // work, so the ledger is correct even if the upstream then misbehaves.
@@ -51,7 +61,8 @@ export async function handleGatewayRequest(
           capabilityId: capability.id,
           payer: receipt.payer,
           payee: capability.payTo,
-          amount: capability.price,
+          amount: split.net,
+          fee: split.fee,
           txHash: receipt.txHash,
         });
       } catch (error) {

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -37,7 +37,10 @@ function fakeCapabilities(capability: ServableCapability | null): CapabilityRepo
   };
 }
 
-function buildContainer(capability: ServableCapability | null): {
+function buildContainer(
+  capability: ServableCapability | null,
+  fee?: { feeAddress: string; feeBps: number },
+): {
   container: Container;
   payments: PaymentService;
 } {
@@ -47,7 +50,13 @@ function buildContainer(capability: ServableCapability | null): {
     payments,
     capabilities: fakeCapabilities(capability),
     verifier: createMockVerifier(),
-    gateway: { issuer: ADDRESS, network: "stellar-testnet", publicUrl: "http://localhost:3001" },
+    gateway: {
+      issuer: ADDRESS,
+      network: "stellar-testnet",
+      publicUrl: "http://localhost:3001",
+      feeAddress: fee?.feeAddress,
+      feeBps: fee?.feeBps ?? 0,
+    },
   };
   return { container, payments };
 }
@@ -110,17 +119,44 @@ describe("capability gateway", () => {
     expect(upstream).toHaveBeenCalledOnce();
     expect(upstream.mock.calls[0]?.[0]).toBe("https://api.example.com/age");
 
-    // …and the settlement was recorded.
+    // …and the settlement was recorded (no fee configured → builder keeps 100%).
     const ledger = await payments.list();
     expect(ledger).toHaveLength(1);
     expect(ledger[0]).toMatchObject({
       capabilityId: "cap-1",
       payee: ADDRESS,
       amount: "0.02",
+      fee: "0",
       status: "settled",
     });
     expect(ledger[0]?.txHash).toBeTruthy();
     expect(ledger[0]?.payer).toContain("mock_payer_");
+  });
+
+  it("splits out the marketplace fee when one is configured", async () => {
+    const feeAddress = "GC62IXD4GCRMGDR34NIWG3TVCECGBJHVW3UW7URX4F6CF54WIOMSLBRK";
+    const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", upstream);
+
+    // 1% fee on a 0.02 price → builder nets 0.0198, Tael takes 0.0002.
+    const { container, payments } = buildContainer(CAPABILITY, { feeAddress, feeBps: 100 });
+    const app = createServer(container);
+
+    // The 402 challenge advertises the split.
+    const challenge = await app.request("/c/predict-age");
+    const body = (await challenge.json()) as {
+      accepts: { maxAmountRequired: string; fee?: { payTo: string; amount: string } }[];
+    };
+    expect(body.accepts[0]?.maxAmountRequired).toBe("0.0198");
+    expect(body.accepts[0]?.fee).toEqual({ payTo: feeAddress, amount: "0.0002" });
+
+    // And a paid call records the builder's net + Tael's fee.
+    await app.request("/c/predict-age", {
+      method: "POST",
+      headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+    });
+    const ledger = await payments.list();
+    expect(ledger[0]).toMatchObject({ amount: "0.0198", fee: "0.0002", status: "settled" });
   });
 
   it("does not forward the X-PAYMENT header to the upstream", async () => {

--- a/apps/api/src/modules/payments/payment.repository.ts
+++ b/apps/api/src/modules/payments/payment.repository.ts
@@ -39,6 +39,7 @@ function toPayment(row: PaymentRow): Payment {
     payer: row.payer,
     payee: row.payee,
     amount: row.amount,
+    fee: row.fee,
     status: row.status as Payment["status"],
     txHash: row.txHash,
     createdAt: row.createdAt.toISOString(),
@@ -58,6 +59,7 @@ export class DbPaymentRepository implements PaymentRepository {
         payer: payment.payer,
         payee: payment.payee,
         amount: payment.amount,
+        fee: payment.fee,
         status: payment.status,
         txHash: payment.txHash,
       })

--- a/apps/api/src/modules/payments/payment.service.ts
+++ b/apps/api/src/modules/payments/payment.service.ts
@@ -13,6 +13,7 @@ export class PaymentService {
       payer: input.payer,
       payee: input.payee,
       amount: input.amount,
+      fee: "0",
       status: "pending",
       txHash: null,
       createdAt: new Date().toISOString(),
@@ -23,12 +24,14 @@ export class PaymentService {
   /**
    * Record a payment that has already settled on-chain — used by the gateway
    * after a capability call is verified. Unlike {@link record}, the tx is known.
+   * `amount` is the builder's net share; `fee` is Tael's cut from the same tx.
    */
   async recordSettled(input: {
     capabilityId: string;
     payer: string;
     payee: string;
     amount: string;
+    fee: string;
     txHash: string;
   }): Promise<Payment> {
     const payment: Payment = {
@@ -37,6 +40,7 @@ export class PaymentService {
       payer: input.payer,
       payee: input.payee,
       amount: input.amount,
+      fee: input.fee,
       status: "settled",
       txHash: input.txHash,
       createdAt: new Date().toISOString(),

--- a/apps/api/src/scripts/testnet-pay.ts
+++ b/apps/api/src/scripts/testnet-pay.ts
@@ -1,0 +1,100 @@
+/**
+ * Manual operator script — pay for a capability on TESTNET, end to end, against a
+ * running gateway. Proves the REAL settlement path (a real signed Stellar tx
+ * submitted to Horizon), not the dev mock verifier.
+ *
+ * Prereqs (testnet):
+ *   - PAYER_SECRET: a funded testnet account (XLM for fees) with a USDC trustline
+ *     and USDC balance.
+ *   - The capability's payTo AND the Tael fee address must have USDC trustlines
+ *     (Stellar can't pay an account that hasn't opted into the asset).
+ *   - The gateway must run with NODE_ENV=production so it uses the real verifier.
+ *
+ * Usage:
+ *   GATEWAY_URL=http://localhost:3001 SLUG=<slug> PAYER_SECRET=S... \
+ *     pnpm --filter @tael/api pay:testnet
+ */
+import {
+  Asset,
+  BASE_FEE,
+  Horizon,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { networkPassphrase, type StellarNetwork } from "@tael/stellar";
+
+interface Requirement {
+  network: string;
+  maxAmountRequired: string;
+  payTo: string;
+  asset: { code: string; issuer: string };
+  fee?: { payTo: string; amount: string };
+}
+
+const GATEWAY_URL = process.env.GATEWAY_URL ?? "http://localhost:3001";
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+const NETWORK = (process.env.STELLAR_NETWORK ?? "testnet") as StellarNetwork;
+
+async function main(): Promise<void> {
+  const slug = process.env.SLUG;
+  const secret = process.env.PAYER_SECRET;
+  if (!slug || !secret) throw new Error("Set SLUG and PAYER_SECRET env vars.");
+
+  const payer = Keypair.fromSecret(secret);
+
+  // 1. Fetch the 402 challenge.
+  const challengeRes = await fetch(`${GATEWAY_URL}/c/${slug}`);
+  if (challengeRes.status !== 402) {
+    throw new Error(`Expected 402, got ${challengeRes.status}: ${await challengeRes.text()}`);
+  }
+  const challenge = (await challengeRes.json()) as { accepts: Requirement[] };
+  const req = challenge.accepts[0];
+  if (!req) throw new Error("Challenge had no payment requirements.");
+  console.log("Challenge:", JSON.stringify(req, null, 2));
+
+  const usdc = new Asset(req.asset.code, req.asset.issuer);
+
+  // 2. Build + sign the payment: builder leg (+ fee leg, if any).
+  const server = new Horizon.Server(HORIZON_URL);
+  const account = await server.loadAccount(payer.publicKey());
+  const builder = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: networkPassphrase(NETWORK),
+  }).addOperation(
+    Operation.payment({ destination: req.payTo, asset: usdc, amount: req.maxAmountRequired }),
+  );
+  if (req.fee) {
+    builder.addOperation(
+      Operation.payment({ destination: req.fee.payTo, asset: usdc, amount: req.fee.amount }),
+    );
+  }
+  const tx = builder.setTimeout(120).build();
+  tx.sign(payer);
+
+  // 3. Encode the X-PAYMENT proof and retry the call.
+  const header = Buffer.from(
+    JSON.stringify({
+      x402Version: 1,
+      scheme: "exact",
+      network: req.network,
+      payload: { transaction: tx.toXDR() },
+    }),
+    "utf8",
+  ).toString("base64");
+
+  const paidRes = await fetch(`${GATEWAY_URL}/c/${slug}`, {
+    method: "POST",
+    headers: { "X-PAYMENT": header, "content-type": "application/json" },
+    body: "{}",
+  });
+
+  console.log("\nStatus:", paidRes.status);
+  console.log("Receipt:", paidRes.headers.get("x-payment-response"));
+  console.log("Body:", await paidRes.text());
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -10,6 +10,7 @@ const testEnv: Env = {
   STELLAR_NETWORK: "testnet",
   STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org",
   USDC_ISSUER: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+  TAEL_FEE_BPS: 100,
 };
 
 const app = createServer(createContainer(testEnv));

--- a/packages/database/drizzle/0003_high_living_lightning.sql
+++ b/packages/database/drizzle/0003_high_living_lightning.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "payments" ADD COLUMN "fee" numeric(20, 7) DEFAULT '0' NOT NULL;

--- a/packages/database/drizzle/meta/0003_snapshot.json
+++ b/packages/database/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,827 @@
+{
+  "id": "c335b93b-19d5-4671-a22d-7c84b41cb7b1",
+  "prevId": "4754550a-033b-4956-af0b-f7b18922bfe1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_wallet_address_idx": {
+          "name": "users_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Main'"
+        },
+        "balance_cached": {
+          "name": "balance_cached",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallets_owner_id_idx": {
+          "name": "wallets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallets_owner_id_users_id_fk": {
+          "name": "wallets_owner_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_address_unique": {
+          "name": "wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "capability_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "capability_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "capability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "faqs": {
+          "name": "faqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pay_to": {
+          "name": "pay_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_secret_enc": {
+          "name": "upstream_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capabilities_publisher_id_idx": {
+          "name": "capabilities_publisher_id_idx",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_kind_idx": {
+          "name": "capabilities_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_visibility_idx": {
+          "name": "capabilities_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capabilities_publisher_id_users_id_fk": {
+          "name": "capabilities_publisher_id_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capabilities_slug_unique": {
+          "name": "capabilities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_wallet_id_wallets_id_fk": {
+          "name": "agents_wallet_id_wallets_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer": {
+          "name": "payer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_capability_id_idx": {
+          "name": "payments_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_agent_id_idx": {
+          "name": "payments_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payer_idx": {
+          "name": "payments_payer_idx",
+          "columns": [
+            {
+              "expression": "payer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payee_idx": {
+          "name": "payments_payee_idx",
+          "columns": [
+            {
+              "expression": "payee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_status_idx": {
+          "name": "payments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_capability_id_capabilities_id_fk": {
+          "name": "payments_capability_id_capabilities_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_agent_id_agents_id_fk": {
+          "name": "payments_agent_id_agents_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_owner_id_idx": {
+          "name": "api_keys_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_owner_id_users_id_fk": {
+          "name": "api_keys_owner_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.capability_kind": {
+      "name": "capability_kind",
+      "schema": "public",
+      "values": [
+        "api",
+        "mcp",
+        "agent",
+        "model",
+        "dataset"
+      ]
+    },
+    "public.capability_status": {
+      "name": "capability_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "verified"
+      ]
+    },
+    "public.capability_visibility": {
+      "name": "capability_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "private"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "settled",
+        "failed",
+        "refunded"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783797111325,
       "tag": "0002_huge_stone_men",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1783853490304,
+      "tag": "0003_high_living_lightning",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/payments.ts
+++ b/packages/database/src/schema/payments.ts
@@ -19,8 +19,10 @@ export const payments = pgTable(
     /** Payer + payee Stellar addresses (denormalized so history is self-contained). */
     payer: text("payer").notNull(),
     payee: text("payee").notNull(),
-    /** Amount in USDC, decimal string. */
+    /** Amount the payee (builder) receives, in USDC. */
     amount: numeric("amount", { precision: 20, scale: 7 }).notNull(),
+    /** Marketplace fee taken by Tael in the same transaction, in USDC. */
+    fee: numeric("fee", { precision: 20, scale: 7 }).notNull().default("0"),
 
     status: paymentStatus("status").notNull().default("pending"),
     /** Stellar transaction hash once settled; null while pending. */

--- a/packages/payments/src/x402.test.ts
+++ b/packages/payments/src/x402.test.ts
@@ -2,14 +2,60 @@ import { describe, expect, it } from "vitest";
 import { PaymentVerificationError } from "@tael/types";
 import {
   buildPaymentRequired,
+  buildPaymentRequirements,
   decodePaymentHeader,
   encodePaymentPayload,
+  splitFee,
   X402_VERSION,
   type PaymentPayload,
 } from "./x402";
 import { createMockVerifier, verifyPayment } from "./verify";
 
 const ADDRESS = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const FEE_ADDRESS = "GC62IXD4GCRMGDR34NIWG3TVCECGBJHVW3UW7URX4F6CF54WIOMSLBRK";
+
+describe("splitFee", () => {
+  it("splits a price into net + fee using basis points", () => {
+    expect(splitFee("0.02", 100)).toEqual({ net: "0.0198", fee: "0.0002" });
+    expect(splitFee("1", 250)).toEqual({ net: "0.975", fee: "0.025" });
+  });
+
+  it("returns the full amount and zero fee when bps is 0", () => {
+    expect(splitFee("0.02", 0)).toEqual({ net: "0.02", fee: "0" });
+  });
+
+  it("net + fee always reconstitutes the total (no value lost)", () => {
+    // 0.0000001 (one stroop) at 1% rounds the fee down to 0.
+    expect(splitFee("0.0000001", 100)).toEqual({ net: "0.0000001", fee: "0" });
+  });
+});
+
+describe("buildPaymentRequirements with a fee", () => {
+  it("emits a fee leg and reduces the main amount", () => {
+    const req = buildPaymentRequirements({
+      price: "0.02",
+      payTo: ADDRESS,
+      issuer: ADDRESS,
+      network: "stellar-testnet",
+      resource: "/c/x",
+      fee: { payTo: FEE_ADDRESS, bps: 100 },
+    });
+    expect(req.maxAmountRequired).toBe("0.0198");
+    expect(req.fee).toEqual({ payTo: FEE_ADDRESS, amount: "0.0002" });
+  });
+
+  it("omits the fee leg when no fee is set", () => {
+    const req = buildPaymentRequirements({
+      price: "0.02",
+      payTo: ADDRESS,
+      issuer: ADDRESS,
+      network: "stellar-testnet",
+      resource: "/c/x",
+    });
+    expect(req.maxAmountRequired).toBe("0.02");
+    expect(req.fee).toBeUndefined();
+  });
+});
 
 describe("x402 challenge", () => {
   it("builds a 402 body from a price", () => {

--- a/packages/payments/src/x402.ts
+++ b/packages/payments/src/x402.ts
@@ -36,19 +36,48 @@ export const assetSchema = z.object({
   issuer: stellarAddressSchema,
 });
 
+/**
+ * An optional platform fee leg. When present, the payer must — atomically, in
+ * the same transaction — pay `amount` to `payTo` (the marketplace) in addition
+ * to the main payment. This keeps fee collection non-custodial: the fee lands
+ * directly in the marketplace's wallet, never held by anyone.
+ */
+export const paymentFeeSchema = z.object({
+  payTo: stellarAddressSchema,
+  amount: moneyAmountSchema,
+});
+export type PaymentFee = z.infer<typeof paymentFeeSchema>;
+
 export const paymentRequirementsSchema = z.object({
   scheme: paymentSchemeSchema,
   network: paymentNetworkSchema,
-  /** The exact amount required, as a decimal string. */
+  /** The amount required for the main payee (the builder's net share). */
   maxAmountRequired: moneyAmountSchema,
   payTo: stellarAddressSchema,
   asset: assetSchema,
+  /** Optional marketplace fee paid in the same transaction. */
+  fee: paymentFeeSchema.optional(),
   /** Identifier of the resource being paid for (usually the request path). */
   resource: z.string().min(1),
   description: z.string().default(""),
   maxTimeoutSeconds: z.number().int().positive().default(60),
 });
 export type PaymentRequirements = z.infer<typeof paymentRequirementsSchema>;
+
+/**
+ * Split a total price into the payee's net share and a marketplace fee, using
+ * integer (atomic) math so amounts are exact. `bps` is basis points — 100 = 1%.
+ * The fee rounds down, so the payee never receives less than `total - ceil(fee)`.
+ */
+export function splitFee(
+  total: MoneyAmount | Money,
+  bps: number,
+): { net: MoneyAmount; fee: MoneyAmount } {
+  const money = total instanceof Money ? total : Money.parse(total);
+  if (bps <= 0) return { net: money.toDecimalString(), fee: "0" };
+  const fee = Money.ofAtomic((money.atomic * BigInt(bps)) / 10000n);
+  return { net: money.subtract(fee).toDecimalString(), fee: fee.toDecimalString() };
+}
 
 /** The JSON body of a `402 Payment Required` response. */
 export const paymentRequiredSchema = z.object({
@@ -71,23 +100,39 @@ export const paymentPayloadSchema = z.object({
 export type PaymentPayload = z.infer<typeof paymentPayloadSchema>;
 
 export interface BuildRequirementsOptions {
+  /** Total price the payer pays (before splitting out any fee). */
   price: MoneyAmount | Money;
   payTo: StellarAddress;
   network: PaymentNetwork;
   issuer: StellarAddress;
   resource: string;
   description?: string;
+  /**
+   * Optional marketplace fee taken out of `price`. When set, the payee receives
+   * `price - fee` and `fee.payTo` receives the fee — atomically, same tx.
+   */
+  fee?: { payTo: StellarAddress; bps: number };
 }
 
 /** Build a single {@link PaymentRequirements} entry from a capability's price. */
 export function buildPaymentRequirements(options: BuildRequirementsOptions): PaymentRequirements {
-  const amount = options.price instanceof Money ? options.price.toDecimalString() : options.price;
+  const total = options.price instanceof Money ? options.price.toDecimalString() : options.price;
+
+  let maxAmountRequired = total;
+  let fee: PaymentFee | undefined;
+  if (options.fee && options.fee.bps > 0) {
+    const split = splitFee(total, options.fee.bps);
+    maxAmountRequired = split.net;
+    fee = { payTo: options.fee.payTo, amount: split.fee };
+  }
+
   return paymentRequirementsSchema.parse({
     scheme: "exact",
     network: options.network,
-    maxAmountRequired: amount,
+    maxAmountRequired,
     payTo: options.payTo,
     asset: { code: "USDC", issuer: options.issuer },
+    fee,
     resource: options.resource,
     description: options.description ?? "",
   });

--- a/packages/sdk/src/tael.ts
+++ b/packages/sdk/src/tael.ts
@@ -35,6 +35,12 @@ export interface TaelOptions {
   verifier: PaymentVerifier;
   /** Human description shown in the 402 challenge. */
   description?: string;
+  /**
+   * Optional marketplace fee taken out of `price` and paid to `fee.payTo` in the
+   * same transaction. Used by the Tael gateway; omit it for self-hosted routes
+   * (the developer keeps 100%).
+   */
+  fee?: { payTo: StellarAddress; bps: number };
   handler: TaelHandler;
 }
 
@@ -65,6 +71,7 @@ export function tael(options: TaelOptions): FetchHandler {
       network: options.network,
       resource,
       description: options.description,
+      fee: options.fee,
     });
 
     const paymentRequired = (error?: string): Response =>

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -6,3 +6,4 @@ export * from "./config";
 export * from "./usdc";
 export * from "./settlement";
 export * from "./verify";
+export * from "./payment-verify";

--- a/packages/stellar/src/payment-verify.test.ts
+++ b/packages/stellar/src/payment-verify.test.ts
@@ -1,0 +1,108 @@
+import {
+  Account,
+  Asset,
+  BASE_FEE,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import { networkPassphrase } from "./config";
+import { usdcAsset } from "./usdc";
+import { verifyTransactionPayments, type ExpectedPayment } from "./payment-verify";
+
+const ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const BUILDER = Keypair.random().publicKey();
+const TAEL = Keypair.random().publicKey();
+
+/** Build + sign a testnet tx with the given payment ops, returning the XDR + payer. */
+function buildTx(payer: Keypair, ops: { to: string; amount: string; asset?: Asset }[]): string {
+  const account = new Account(payer.publicKey(), "0");
+  const builder = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: networkPassphrase("testnet"),
+  });
+  for (const op of ops) {
+    builder.addOperation(
+      Operation.payment({
+        destination: op.to,
+        asset: op.asset ?? usdcAsset(ISSUER),
+        amount: op.amount,
+      }),
+    );
+  }
+  const tx = builder.setTimeout(60).build();
+  tx.sign(payer);
+  return tx.toXDR();
+}
+
+const builderLeg: ExpectedPayment = { to: BUILDER, minAmount: "0.0099" };
+const feeLeg: ExpectedPayment = { to: TAEL, minAmount: "0.0001" };
+
+describe("verifyTransactionPayments", () => {
+  it("accepts a tx that pays the builder + fee, and returns the payer", () => {
+    const payer = Keypair.random();
+    const xdr = buildTx(payer, [
+      { to: BUILDER, amount: "0.0099" },
+      { to: TAEL, amount: "0.0001" },
+    ]);
+
+    const result = verifyTransactionPayments(xdr, "testnet", ISSUER, [builderLeg, feeLeg]);
+    expect(result.ok).toBe(true);
+    expect(result.payer).toBe(payer.publicKey());
+  });
+
+  it("accepts amounts above the minimum", () => {
+    const xdr = buildTx(Keypair.random(), [
+      { to: BUILDER, amount: "1.0" },
+      { to: TAEL, amount: "0.5" },
+    ]);
+    expect(verifyTransactionPayments(xdr, "testnet", ISSUER, [builderLeg, feeLeg]).ok).toBe(true);
+  });
+
+  it("rejects an underpaid leg", () => {
+    const xdr = buildTx(Keypair.random(), [
+      { to: BUILDER, amount: "0.0001" }, // below 0.0099
+      { to: TAEL, amount: "0.0001" },
+    ]);
+    const result = verifyTransactionPayments(xdr, "testnet", ISSUER, [builderLeg, feeLeg]);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain(BUILDER);
+  });
+
+  it("rejects a missing fee leg", () => {
+    const xdr = buildTx(Keypair.random(), [{ to: BUILDER, amount: "0.0099" }]);
+    expect(verifyTransactionPayments(xdr, "testnet", ISSUER, [builderLeg, feeLeg]).ok).toBe(false);
+  });
+
+  it("rejects payment to the wrong destination", () => {
+    const xdr = buildTx(Keypair.random(), [
+      { to: TAEL, amount: "0.0099" }, // builder share sent to the wrong address
+      { to: TAEL, amount: "0.0001" },
+    ]);
+    expect(verifyTransactionPayments(xdr, "testnet", ISSUER, [builderLeg, feeLeg]).ok).toBe(false);
+  });
+
+  it("rejects the wrong asset (native XLM instead of USDC)", () => {
+    const xdr = buildTx(Keypair.random(), [
+      { to: BUILDER, amount: "0.0099", asset: Asset.native() },
+      { to: TAEL, amount: "0.0001", asset: Asset.native() },
+    ]);
+    expect(verifyTransactionPayments(xdr, "testnet", ISSUER, [builderLeg, feeLeg]).ok).toBe(false);
+  });
+
+  it("rejects USDC from the wrong issuer", () => {
+    const wrongIssuer = Keypair.random().publicKey();
+    const xdr = buildTx(Keypair.random(), [
+      { to: BUILDER, amount: "0.0099", asset: new Asset("USDC", wrongIssuer) },
+      { to: TAEL, amount: "0.0001", asset: new Asset("USDC", wrongIssuer) },
+    ]);
+    expect(verifyTransactionPayments(xdr, "testnet", ISSUER, [builderLeg, feeLeg]).ok).toBe(false);
+  });
+
+  it("returns not-ok for malformed XDR", () => {
+    const result = verifyTransactionPayments("not-a-real-xdr", "testnet", ISSUER, [builderLeg]);
+    expect(result.ok).toBe(false);
+    expect(result.payer).toBeNull();
+  });
+});

--- a/packages/stellar/src/payment-verify.ts
+++ b/packages/stellar/src/payment-verify.ts
@@ -1,0 +1,75 @@
+import { TransactionBuilder, type Operation, type Transaction } from "@stellar/stellar-sdk";
+import { Money } from "@tael/types";
+import { networkPassphrase, type StellarNetwork } from "./config";
+import { USDC_CODE } from "./usdc";
+
+/** One leg a transaction must satisfy: a USDC payment of at least `minAmount` to `to`. */
+export interface ExpectedPayment {
+  to: string;
+  /** Minimum amount as a decimal USDC string, e.g. "0.02". */
+  minAmount: string;
+}
+
+export interface TxPaymentCheck {
+  ok: boolean;
+  /** Source account of the transaction (the payer), when parseable. */
+  payer: string | null;
+  reason?: string;
+}
+
+/**
+ * Verify — offline, straight from the signed XDR — that a transaction contains a
+ * USDC payment satisfying **each** expected leg (destination + minimum amount).
+ * Returns the payer (the transaction's source account).
+ *
+ * This is the security check that stops "submit-and-trust": a payer can't get a
+ * paid result unless the tx actually pays the right amount, in USDC, to the
+ * right recipient(s). Settlement (submission to Horizon) is a separate step.
+ */
+export function verifyTransactionPayments(
+  signedXdr: string,
+  network: StellarNetwork,
+  usdcIssuer: string,
+  expected: ExpectedPayment[],
+): TxPaymentCheck {
+  let tx: Transaction;
+  try {
+    const parsed = TransactionBuilder.fromXDR(signedXdr, networkPassphrase(network));
+    // A fee-bump wraps an inner transaction; validate its ops + source.
+    tx = "innerTransaction" in parsed ? parsed.innerTransaction : parsed;
+  } catch {
+    return { ok: false, payer: null, reason: "Malformed transaction XDR" };
+  }
+
+  const payer = tx.source;
+
+  // Every USDC payment operation in the transaction, as { destination, amount }.
+  const usdcPayments = tx.operations
+    .filter((op): op is Operation.Payment => op.type === "payment")
+    .filter(
+      (op) =>
+        !op.asset.isNative() &&
+        op.asset.getCode() === USDC_CODE &&
+        op.asset.getIssuer() === usdcIssuer,
+    )
+    .map((op) => ({ destination: op.destination, amount: Money.parse(op.amount) }));
+
+  // Match each expected leg to a distinct payment op (so one op can't cover two).
+  const used = new Set<number>();
+  for (const leg of expected) {
+    const min = Money.parse(leg.minAmount);
+    const idx = usdcPayments.findIndex(
+      (p, i) => !used.has(i) && p.destination === leg.to && !p.amount.subtract(min).isNegative(),
+    );
+    if (idx === -1) {
+      return {
+        ok: false,
+        payer,
+        reason: `Missing USDC payment of >= ${leg.minAmount} to ${leg.to}`,
+      };
+    }
+    used.add(idx);
+  }
+
+  return { ok: true, payer };
+}

--- a/packages/types/src/payment.ts
+++ b/packages/types/src/payment.ts
@@ -10,7 +10,10 @@ export const paymentSchema = z.object({
   capabilityId: z.string(),
   payer: stellarAddressSchema,
   payee: stellarAddressSchema,
+  /** Amount the payee (builder) receives, in USDC. */
   amount: moneyAmountSchema,
+  /** Marketplace fee taken by Tael in the same transaction, in USDC. */
+  fee: moneyAmountSchema.default("0"),
   status: paymentStatusSchema,
   /** Stellar transaction hash once settled; `null` while pending. */
   txHash: z.string().nullable(),


### PR DESCRIPTION
## What

Gives Tael revenue **and** fixes a security hole in the gateway, together.

### Revenue — non-custodial 1% fee split
Stellar lets one transaction pay multiple parties, so the agent's single signed tx pays the **builder** and **Tael** atomically — the fee lands directly in Tael's wallet, never held by anyone.

- `@tael/payments`: optional `fee` leg on `PaymentRequirements` + `splitFee(price, bps)` (exact integer math).
- `@tael/sdk`: `tael()` gains an optional `fee` — the gateway passes it; self-hosted routes omit it and keep 100%.
- Gateway: fee from `TAEL_FEE_ADDRESS` + `TAEL_FEE_BPS` (default 100 = 1%); records builder-net + Tael-fee separately on the ledger (new `payments.fee` column, migration 0003).

Taken **out of** the price: the agent pays the listed price, the builder nets 99%, Tael takes 1%. Unset `TAEL_FEE_ADDRESS` → no fee.

### Security — hardened verifier
The production verifier was **submit-and-trust**: it submitted any signed tx and served the result without checking it actually paid. Now `@tael/stellar`'s `verifyTransactionPayments()` confirms the tx pays the right amount, in USDC, to the right destination(s) **before** settling — 8 offline tests cover underpaid / wrong-dest / wrong-asset / wrong-issuer / missing-leg / malformed.

## Verified

- `format:check`, `lint`, `typecheck`, `test`, `build` — all green (new splitFee, verifier, and gateway-fee tests).
- **Live (dev mock):** the x402 challenge advertises the split (`0.00099` builder + `0.00001` fee on a `0.001` price), a paid call returns 200, and the ledger row records `amount 0.0009900 / fee 0.0000100 / settled`.
- `pnpm --filter @tael/api pay:testnet` provided to prove the real on-chain path.

## Notes

- Migration 0003 (`ADD COLUMN fee … DEFAULT '0' NOT NULL`) is already applied to the dev DB; apply it wherever else the API runs.
- Builder **earnings dashboard** (reads these ledger rows) is the follow-up PR (Thread 2).