### PR TITLE
chore: make the API deployable on Railway

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,10 @@ import { createServer } from "./server";
 const container = createContainer(env);
 const app = createServer(container);
 
-serve({ fetch: app.fetch, port: env.API_PORT }, (info) => {
-  console.log(`▲ Tael API listening on http://localhost:${info.port}`);
+// Cloud hosts (Railway/Render/Fly) inject the port to bind via `PORT`; fall back
+// to API_PORT for local dev. Bind 0.0.0.0 so the platform proxy can reach it.
+const port = Number(process.env.PORT) || env.API_PORT;
+
+serve({ fetch: app.fetch, port, hostname: "0.0.0.0" }, (info) => {
+  console.log(`▲ Tael API listening on port ${info.port}`);
 });

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "pnpm install --frozen-lockfile --prod=false && pnpm --filter @tael/api build"
+  },
+  "deploy": {
+    "startCommand": "NODE_ENV=production node apps/api/dist/index.js",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## What

Makes `apps/api` (the capability gateway) deployable to Railway — it's currently local-only.

- **Port binding:** listen on `process.env.PORT` (Railway/Render/Fly inject it) with `API_PORT` as the local fallback, bound to `0.0.0.0` so the platform proxy can reach it.
- **`railway.json`:** builder = Nixpacks; build installs with devDeps (`--prod=false`, so `tsup` survives Nixpacks' default `NODE_ENV=production`) then `pnpm --filter @tael/api build`; start runs the bundled `dist` with `NODE_ENV=production` (switches on the real Stellar verifier); health check on `/health`.

## Verified

- Typecheck + the exact Railway build command pass locally.
- Ran the built `dist` as Railway would (`PORT=3005 node apps/api/dist/index.js`) → bound the injected port and served `/health` 200, with the bundled `@tael/database` deps (`postgres`, `drizzle-orm`) resolving correctly.

## After merge — deploy steps (Railway UI)

1. New Project → GitHub Repo → `tael-protocol`.
2. Variables: `DATABASE_URL`, `DIRECT_URL`, `ENCRYPTION_KEY`, `STELLAR_NETWORK`, `STELLAR_HORIZON_URL`, `USDC_ISSUER`, `TAEL_FEE_ADDRESS`, `TAEL_FEE_BPS`, and `NIXPACKS_NODE_VERSION=22`. (Do **not** set `NODE_ENV` — the start command sets it, so the build keeps devDeps.)
3. Networking → Generate Domain (or custom `api.taelprotocol.xyz`).
4. Point the dashboard's `NEXT_PUBLIC_API_URL` at the Railway URL in Vercel.