### PR TITLE
feat(web): SEO + social previews (Open Graph, sitemap, structured data)

### DIFF
--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -5,8 +5,18 @@ import { GithubStar } from "./_components/github-star";
 import { ThemeToggle } from "./_components/theme-toggle";
 
 export const metadata: Metadata = {
-  title: "Docs — Tael",
-  description: "Documentation for Tael, the payment layer for autonomous AI agents.",
+  title: "Docs",
+  description:
+    "Documentation for Tael — wrap any API behind x402 payments and let AI agents pay per call in USDC on Stellar.",
+  alternates: { canonical: "/docs" },
+  openGraph: {
+    type: "website",
+    url: "https://taelprotocol.xyz/docs",
+    siteName: "Tael",
+    title: "Tael Docs",
+    description:
+      "Wrap any API behind x402 payments and let AI agents pay per call in USDC on Stellar.",
+  },
 };
 
 const TABS = [

--- a/apps/web/app/icon.svg
+++ b/apps/web/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#000000" />
+  <text x="16" y="23" font-family="Georgia, serif" font-size="22" fill="#156DFC" text-anchor="middle">t</text>
+</svg>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -26,10 +26,89 @@ const dot = DotGothic16({
   display: "swap",
 });
 
+const SITE_URL = "https://taelprotocol.xyz";
+const TITLE = "Tael — The payment layer for autonomous AI agents";
+const DESCRIPTION =
+  "Tael lets AI agents pay for any API, MCP tool, model, or dataset per call in USDC on Stellar — no accounts, no API keys, no billing setup.";
+
 export const metadata: Metadata = {
-  title: "Tael — The payment layer for autonomous AI agents",
-  description:
-    "Let AI agents pay for APIs, MCP tools, data, and digital services using USDC on Stellar.",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: TITLE,
+    template: "%s — Tael",
+  },
+  description: DESCRIPTION,
+  applicationName: "Tael",
+  keywords: [
+    "Tael",
+    "Tael Protocol",
+    "taelprotocol",
+    "payment layer for AI agents",
+    "AI agent payments",
+    "agent payments",
+    "pay per call API",
+    "x402",
+    "HTTP 402",
+    "USDC",
+    "Stellar",
+    "MCP payments",
+    "machine payments",
+    "autonomous agents",
+  ],
+  authors: [{ name: "Tael", url: SITE_URL }],
+  creator: "Tael",
+  publisher: "Tael",
+  alternates: { canonical: "/" },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: { index: true, follow: true, "max-image-preview": "large", "max-snippet": -1 },
+  },
+  openGraph: {
+    type: "website",
+    url: SITE_URL,
+    siteName: "Tael",
+    title: TITLE,
+    description: DESCRIPTION,
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TITLE,
+    description: DESCRIPTION,
+    site: "@taelprotocol",
+    creator: "@taelprotocol",
+  },
+};
+
+/** Organization + WebSite structured data — helps Google attribute the brand
+ *  name "Tael" and can surface the docs/community as sitelinks. */
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": `${SITE_URL}/#organization`,
+      name: "Tael",
+      alternateName: "Tael Protocol",
+      url: SITE_URL,
+      logo: `${SITE_URL}/icon.svg`,
+      description: DESCRIPTION,
+      sameAs: [
+        "https://x.com/taelprotocol",
+        "https://github.com/rahulsainlll/tael-protocol",
+        "https://discord.gg/tcb6b7ZYha",
+      ],
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_URL}/#website`,
+      url: SITE_URL,
+      name: "Tael",
+      description: DESCRIPTION,
+      publisher: { "@id": `${SITE_URL}/#organization` },
+    },
+  ],
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
@@ -40,6 +119,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className={`${inter.variable} ${delicious.variable} ${dot.variable}`}
     >
       <body className="font-sans antialiased" suppressHydrationWarning>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -1,0 +1,46 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "Tael — The payment layer for autonomous AI agents";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+/** Branded social preview card — matches the marketing hero. */
+export default function OpengraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "72px 80px",
+        background: "linear-gradient(180deg, #000000 0%, #0a0a0a 55%, #26262b 100%)",
+        color: "#ffffff",
+        fontFamily: "sans-serif",
+      }}
+    >
+      {/* Wordmark */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <span style={{ fontSize: 44, color: "#156DFC", lineHeight: 1 }}>t</span>
+        <span style={{ fontSize: 40, fontWeight: 500, letterSpacing: "0.01em" }}>tael</span>
+      </div>
+
+      {/* Headline */}
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <div style={{ fontSize: 88, fontWeight: 600, lineHeight: 1.02, letterSpacing: "-0.03em" }}>
+          The payment layer.
+        </div>
+        <div style={{ fontSize: 88, fontWeight: 600, lineHeight: 1.02, letterSpacing: "-0.03em" }}>
+          For AI agents.
+        </div>
+      </div>
+
+      {/* Subtitle */}
+      <div style={{ display: "flex", fontSize: 30, color: "rgba(255,255,255,0.62)" }}>
+        Pay for any API, tool, or dataset — per call, in USDC on Stellar.
+      </div>
+    </div>,
+    { ...size },
+  );
+}

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://taelprotocol.xyz";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://taelprotocol.xyz";
+
+const paths = [
+  "",
+  "/docs",
+  "/docs/quickstart",
+  "/docs/authentication",
+  "/docs/accept-payments",
+  "/docs/wrap-an-api",
+  "/docs/sdk/node",
+  "/docs/sdk/curl",
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  return paths.map((path) => ({
+    url: `${SITE_URL}${path}`,
+    lastModified,
+    changeFrequency: "weekly",
+    priority: path === "" ? 1 : 0.7,
+  }));
+}

--- a/apps/web/app/twitter-image.tsx
+++ b/apps/web/app/twitter-image.tsx
@@ -1,0 +1,2 @@
+// Reuse the Open Graph card for Twitter/X previews.
+export { default, alt, size, contentType } from "./opengraph-image";


### PR DESCRIPTION
## Why

Sharing `taelprotocol.xyz` showed no preview, and Google couldn't place us — searching "taelprotocol stellar" autocorrects to "stateprotocol". The site had **no** `metadataBase`, Open Graph, favicon, sitemap, robots, or structured data. This adds all of it.

## What

- **Rich metadata** on the root (and docs) layout: `metadataBase`, canonical, keywords (Tael / Tael Protocol / x402 / USDC / Stellar…), robots directives, Open Graph, and Twitter `summary_large_image`.
- **Generated OG image** (`opengraph-image` + `twitter-image`, `next/og`): a branded 1200×630 card matching the hero — "The payment layer. For AI agents." — so links unfurl properly on X, Slack, Discord, iMessage.
- **Favicon** (`icon.svg`) with the brand 't'.
- **`robots.txt` + `sitemap.xml`** listing the home + docs routes.
- **JSON-LD** `Organization` + `WebSite` (name "Tael", alternateName "Tael Protocol", logo, `sameAs` X/GitHub/Discord) — helps Google attribute the brand and can surface docs as **sitelinks**.

## Verified

- `typecheck`, `lint`, `format`, `build` green. Build prerenders `/opengraph-image`, `/twitter-image`, `/icon.svg`, `/robots.txt`, `/sitemap.xml`.
- Check the OG card on the Vercel preview, then test unfurling with the [OG debugger](https://www.opengraph.xyz/).

## Not code — you'll need to do these for discoverability

1. **Google Search Console**: add `taelprotocol.xyz`, verify, submit `sitemap.xml`. New domains take days/weeks to index; GSC is the fastest path.
2. **Canonical host**: make sure `www` and apex resolve to one (301 the other) so Google doesn't split ranking. Metadata canonical points to the apex `https://taelprotocol.xyz`.
3. Sitelinks are Google's call — the sitemap + structured data + clear nav maximize the odds; they can't be forced.