### PR TITLE
feat(web): /blog + first article ("Agents can think. They can't pay.")

### DIFF
--- a/apps/web/app/_components/site-header.tsx
+++ b/apps/web/app/_components/site-header.tsx
@@ -3,11 +3,12 @@
 import { useEffect, useState } from "react";
 import { WaitlistTrigger } from "./waitlist-trigger";
 
-const NAV_LINKS = ["Products", "Community", "Docs"];
+const NAV_LINKS = ["Products", "Community", "Blog", "Docs"];
 
 // Real destinations for nav links that have one; others fall back to "#".
 const NAV_HREFS: Record<string, string> = {
   Community: "https://discord.gg/tcb6b7ZYha",
+  Blog: "/blog",
   Docs: "/docs",
 };
 

--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -57,7 +57,7 @@ export default async function ArticlePage({ params }: { params: Promise<{ slug: 
   };
 
   return (
-    <main className="mx-auto max-w-[720px] px-6 pb-28 pt-16">
+    <main className="mx-auto max-w-[680px] px-6 pb-28 pt-16">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getPost, posts } from "../_posts";
+
+export function generateStaticParams() {
+  return posts.map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getPost(slug);
+  if (!post) return {};
+  const url = `https://taelprotocol.xyz/blog/${post.slug}`;
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `/blog/${post.slug}` },
+    openGraph: {
+      type: "article",
+      url,
+      siteName: "Tael",
+      title: post.title,
+      description: post.description,
+      publishedTime: post.date,
+    },
+    twitter: { card: "summary_large_image", title: post.title, description: post.description },
+  };
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export default async function ArticlePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = getPost(slug);
+  if (!post) notFound();
+
+  const Body = post.body;
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.description,
+    datePublished: post.date,
+    author: { "@type": "Organization", name: "Tael", url: "https://taelprotocol.xyz" },
+    publisher: { "@type": "Organization", name: "Tael", url: "https://taelprotocol.xyz" },
+    mainEntityOfPage: `https://taelprotocol.xyz/blog/${post.slug}`,
+  };
+
+  return (
+    <main className="mx-auto max-w-[720px] px-6 pb-28 pt-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <a
+        href="/blog"
+        className="inline-flex items-center gap-1.5 text-[14px] text-white/45 transition-colors hover:text-white"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+          <path
+            d="M15 18l-6-6 6-6"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        Blog
+      </a>
+
+      <article className="mt-8">
+        <div className="flex items-center gap-3 text-[13px] text-white/40">
+          <time dateTime={post.date}>{formatDate(post.date)}</time>
+          <span aria-hidden>·</span>
+          <span>{post.readingTime}</span>
+        </div>
+        <h1 className="mt-3 text-[38px] font-semibold leading-[1.08] tracking-[-0.03em] text-white sm:text-[46px]">
+          {post.title}
+        </h1>
+        <div className="mt-10">
+          <Body />
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/apps/web/app/blog/_components/faq.tsx
+++ b/apps/web/app/blog/_components/faq.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+export interface FaqItem {
+  q: string;
+  a: ReactNode;
+}
+
+export interface FaqGroup {
+  title: string;
+  items: FaqItem[];
+}
+
+/** Grouped FAQ accordion — categories with collapsible questions (native
+ *  <details>, closed by default), dark editorial styling. */
+export function Faq({ groups }: { groups: FaqGroup[] }) {
+  return (
+    <section className="mt-20">
+      {groups.map((group) => (
+        <div key={group.title} className="mt-12 first:mt-0">
+          <p className="text-[13px] font-medium uppercase tracking-[0.14em] text-white/40">
+            {group.title}
+          </p>
+          <div className="mt-4 border-t border-white/10">
+            {group.items.map((item, i) => (
+              <details key={i} className="group border-b border-white/10">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-6 py-5 text-[17px] font-medium text-white/90 transition-colors hover:text-white">
+                  {item.q}
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    className="shrink-0 text-white/40 transition-transform group-open:rotate-180"
+                    aria-hidden
+                  >
+                    <path
+                      d="M6 9l6 6 6-6"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </summary>
+                <div className="pb-5 pr-8 text-[16px] leading-[1.65] text-white/55">{item.a}</div>
+              </details>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/apps/web/app/blog/_components/prose.tsx
+++ b/apps/web/app/blog/_components/prose.tsx
@@ -63,12 +63,15 @@ export function Ul({ children }: { children: ReactNode }) {
   );
 }
 
-/** A pulled-out line for emphasis — big, white, breathing room around it. */
+/** A pulled-out line for emphasis: centered, framed by hairline rules, with a
+ *  muted lead and a white payoff (wrap the lead in a text-white/50 span). */
 export function Pullquote({ children }: { children: ReactNode }) {
   return (
-    <p className="my-12 text-[24px] font-medium leading-[1.4] tracking-[-0.02em] text-white sm:text-[28px]">
-      {children}
-    </p>
+    <div className="my-14 border-y border-white/10 py-10 text-center">
+      <p className="mx-auto max-w-[32ch] text-[24px] font-medium leading-[1.4] tracking-[-0.02em] text-white sm:text-[27px]">
+        {children}
+      </p>
+    </div>
   );
 }
 

--- a/apps/web/app/blog/_components/prose.tsx
+++ b/apps/web/app/blog/_components/prose.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from "react";
+
+/**
+ * Editorial prose primitives for the blog — a dark, spacious reading experience
+ * (inspired by animations.dev) on Tael's brand: near-black canvas, generous
+ * line-height, serif italics for emphasis, and the blue accent for links.
+ */
+
+export function Lead({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-[21px] leading-[1.7] tracking-[-0.01em] text-white/80 sm:text-[23px]">
+      {children}
+    </p>
+  );
+}
+
+export function P({ children }: { children: ReactNode }) {
+  return (
+    <p className="mt-6 text-[18px] leading-[1.75] tracking-[-0.005em] text-white/65 sm:text-[19px]">
+      {children}
+    </p>
+  );
+}
+
+/** Serif italic emphasis — the animations.dev "hard" treatment. */
+export function Em({ children }: { children: ReactNode }) {
+  return <em className="font-serif italic text-white/90">{children}</em>;
+}
+
+export function Strong({ children }: { children: ReactNode }) {
+  return <strong className="font-semibold text-white">{children}</strong>;
+}
+
+export function H2({ id, children }: { id?: string; children: ReactNode }) {
+  return (
+    <h2
+      id={id}
+      className="mt-16 scroll-mt-24 text-[26px] font-semibold tracking-[-0.02em] text-white sm:text-[30px]"
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function A({ href, children }: { href: string; children: ReactNode }) {
+  const external = href.startsWith("http");
+  return (
+    <a
+      href={href}
+      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      className="font-medium text-accent underline decoration-accent/30 underline-offset-2 transition-colors hover:decoration-accent"
+    >
+      {children}
+    </a>
+  );
+}
+
+export function Ul({ children }: { children: ReactNode }) {
+  return (
+    <ul className="mt-6 flex list-disc flex-col gap-3 pl-6 text-[18px] leading-[1.7] tracking-[-0.005em] text-white/65 marker:text-white/30 sm:text-[19px]">
+      {children}
+    </ul>
+  );
+}
+
+/** A pulled-out line for emphasis — big, white, breathing room around it. */
+export function Pullquote({ children }: { children: ReactNode }) {
+  return (
+    <p className="my-12 text-[24px] font-medium leading-[1.4] tracking-[-0.02em] text-white sm:text-[28px]">
+      {children}
+    </p>
+  );
+}
+
+export function Code({ children }: { children: ReactNode }) {
+  return (
+    <code className="rounded-md border border-white/10 bg-white/[0.06] px-1.5 py-0.5 font-mono text-[0.85em] text-white/80">
+      {children}
+    </code>
+  );
+}
+
+/** A subtle bordered aside for a note or definition. */
+export function Note({ children }: { children: ReactNode }) {
+  return (
+    <div className="my-8 rounded-2xl border border-white/10 bg-white/[0.03] px-6 py-5 text-[16px] leading-[1.65] text-white/60">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/app/blog/_components/waitlist-cta.tsx
+++ b/apps/web/app/blog/_components/waitlist-cta.tsx
@@ -17,7 +17,7 @@ export function WaitlistCTA() {
         The payment layer for autonomous AI agents.
       </h3>
       <p className="mt-3 max-w-[46ch] text-[16px] leading-[1.6] text-white/55">
-        We&apos;re building the rails that let agents pay for any API, tool, or dataset — per call,
+        We&apos;re building the rails that let agents pay for any API, tool, or dataset, per call,
         in USDC on Stellar. Join the waitlist for early access and updates.
       </p>
 

--- a/apps/web/app/blog/_components/waitlist-cta.tsx
+++ b/apps/web/app/blog/_components/waitlist-cta.tsx
@@ -1,0 +1,27 @@
+import { WaitlistForm } from "../../_components/waitlist-form";
+
+/**
+ * In-article call to action — a dark card with the Tael mark, a short pitch, and
+ * the real waitlist form (posts to /api/waitlist). Mirrors the animations.dev
+ * "join the waitlist" block, on Tael's brand.
+ */
+export function WaitlistCTA() {
+  return (
+    <div className="my-14 rounded-[28px] border border-white/10 bg-white/[0.02] p-8 sm:p-10">
+      <div className="flex items-center gap-2">
+        <span className="font-display text-[26px] leading-none text-accent">t</span>
+        <span className="text-[24px] font-medium tracking-[0.01em] text-white">tael</span>
+      </div>
+
+      <h3 className="mt-6 text-[24px] font-semibold leading-[1.25] tracking-[-0.02em] text-white sm:text-[28px]">
+        The payment layer for autonomous AI agents.
+      </h3>
+      <p className="mt-3 max-w-[46ch] text-[16px] leading-[1.6] text-white/55">
+        We&apos;re building the rails that let agents pay for any API, tool, or dataset — per call,
+        in USDC on Stellar. Join the waitlist for early access and updates.
+      </p>
+
+      <WaitlistForm className="mt-7 max-w-[440px]" />
+    </div>
+  );
+}

--- a/apps/web/app/blog/_posts/agents-cant-pay.tsx
+++ b/apps/web/app/blog/_posts/agents-cant-pay.tsx
@@ -1,0 +1,196 @@
+import { A, Code, Em, H2, Lead, Note, P, Pullquote, Strong, Ul } from "../_components/prose";
+import { Faq } from "../_components/faq";
+import { WaitlistCTA } from "../_components/waitlist-cta";
+
+export function AgentsCantPay() {
+  return (
+    <>
+      <Lead>
+        An AI agent can research a market, write the code, and ship it. But the moment it needs
+        something behind a paywall — a data feed, an OCR endpoint, a better model — it stops cold
+        and waits for a human to paste in a credit card.
+      </Lead>
+
+      <P>
+        We spend all our attention on making agents <Em>smarter</Em>. Bigger context windows, better
+        tools, sharper reasoning. But the thing that most often ends an agent&apos;s run isn&apos;t
+        intelligence. It&apos;s money. An agent that can&apos;t pay for what it needs isn&apos;t
+        autonomous — it&apos;s an intern that has to come find you every time there&apos;s a bill.
+      </P>
+
+      <H2 id="human">Everything on the internet assumes a human is buying</H2>
+      <P>
+        Every paid API you&apos;ve ever used was designed for a person. You create an account. You
+        verify an email. You paste a card into a Stripe form. You get an API key, a dashboard, and a
+        monthly invoice. That flow is completely reasonable — for a human who signs up once and uses
+        the service for months.
+      </P>
+      <P>
+        An agent has none of that. It doesn&apos;t have an account. It can&apos;t be handed your
+        card without becoming a liability. And it discovers what it needs <Em>at runtime</Em> — the
+        whole point is that you didn&apos;t know in advance it would need a currency API at 2am. The
+        billing model of the web and the way agents actually work are fundamentally mismatched.
+      </P>
+
+      <H2 id="fixes">The obvious fixes all break</H2>
+      <P>Every team hits this wall and tries the same three things first. They all fall apart:</P>
+      <Ul>
+        <li>
+          <Strong>Give the agent your API key.</Strong> Works until the agent — or a prompt
+          injection riding in on some webpage — burns your quota, hits a rate limit at the worst
+          moment, or leaks the key into a log.
+        </li>
+        <li>
+          <Strong>Give it your credit card.</Strong> Now there are no per-call limits, no real
+          visibility into what it bought, and unbounded downside if it loops.
+        </li>
+        <li>
+          <Strong>Pre-buy credits with every vendor.</Strong> Fine for two or three services.
+          Hopeless across the long tail of tools an agent might reach for — and it defeats the point
+          of an agent that finds what it needs on its own.
+        </li>
+      </Ul>
+      <P>
+        Each of these is a workaround for the same missing primitive: a way for software to pay for
+        one thing, once, without a standing relationship.
+      </P>
+
+      <Pullquote>Agents don&apos;t need accounts. They need to pay per request.</Pullquote>
+
+      <H2 id="requirements">What machine-native payments actually require</H2>
+      <P>
+        If you design payments for agents from scratch — not for humans — you arrive at a short,
+        strict list:
+      </P>
+      <Ul>
+        <li>
+          <Strong>Instant settlement.</Strong> The call happens now; the money has to move now. No
+          three-day holds, no chargebacks weeks later.
+        </li>
+        <li>
+          <Strong>Real micropayments.</Strong> A single call might cost a fifth of a cent. Card
+          rails — with their fixed ~30¢ minimum — make that economically impossible.
+        </li>
+        <li>
+          <Strong>No accounts.</Strong> Identity is a wallet the agent controls, not an email and a
+          password it can&apos;t manage.
+        </li>
+        <li>
+          <Strong>Programmable limits.</Strong> Spend caps the agent literally cannot exceed, set by
+          you, enforced before the money moves.
+        </li>
+      </Ul>
+      <P>
+        That list quietly rules out cards and bank transfers, and points at something specific: a{" "}
+        <Strong>stablecoin on a fast, cheap chain</Strong> — USDC on Stellar — settling in seconds
+        for a fraction of a cent, plus an open protocol for paying as you go over plain HTTP.
+      </P>
+
+      <H2 id="x402">402: the status code the web forgot</H2>
+      <P>
+        HTTP has always had a status code reserved for exactly this moment:{" "}
+        <Strong>402 Payment Required</Strong>. It&apos;s been sitting in the spec, unused, for 25
+        years — because there was never a clean way to actually pay in the flow of a request. The{" "}
+        <A href="/docs/accept-payments">x402</A> protocol finally wires it up. The exchange is four
+        steps and one round trip:
+      </P>
+      <Ul>
+        <li>The agent calls an endpoint with no payment.</li>
+        <li>
+          The server replies <Code>402</Code> with a price and a pay-to address.
+        </li>
+        <li>
+          The agent signs a USDC payment and retries, carrying the proof in an{" "}
+          <Code>X-PAYMENT</Code> header.
+        </li>
+        <li>The server verifies it, does the work, and returns the result with a receipt.</li>
+      </Ul>
+      <Note>
+        No signup. No API key. No invoice at the end of the month. And it&apos;s non-custodial — the
+        payment settles straight from the agent&apos;s wallet to the provider&apos;s, in the same
+        transaction. Nobody holds the money in between.
+      </Note>
+
+      <H2 id="unlocks">What this unlocks</H2>
+      <P>
+        A payment primitive this small changes what an agent is capable of — and what a developer
+        can sell:
+      </P>
+      <Ul>
+        <li>
+          <Strong>Agents buy exactly what they need,</Strong> the moment they need it, inside limits
+          you set — no human in the loop, no standing subscriptions.
+        </li>
+        <li>
+          <Strong>Any developer can monetize an API</Strong> by wrapping it once and getting paid
+          per call. No accounts to manage, no billing system to build, no Stripe integration.
+        </li>
+        <li>
+          <Strong>A real marketplace of capabilities</Strong> becomes possible — APIs, tools,
+          models, and datasets that agents can discover and pay for on their own.
+        </li>
+      </Ul>
+
+      <P>
+        This is the layer we&apos;re building at <Strong>Tael</Strong>: wrap any capability, give it
+        a price, and let agents pay per call in USDC on Stellar. The agent brings its own wallet;
+        the builder gets paid automatically. That&apos;s the whole idea — give agents the one thing
+        they were missing, and get out of the way.
+      </P>
+
+      <WaitlistCTA />
+
+      <Faq
+        groups={[
+          {
+            title: "The basics",
+            items: [
+              {
+                q: "What is a payment layer for AI agents?",
+                a: "It's infrastructure that lets software pay for a single request — an API call, a tool use, a dataset query — without an account, an API key, or a subscription. The agent pays per call from its own wallet, and the provider gets the money instantly.",
+              },
+              {
+                q: "Why USDC on Stellar, and not cards or another chain?",
+                a: "Agent payments need instant settlement, sub-cent micropayments, and no accounts. Card rails can't do a fifth-of-a-cent charge economically, and bank transfers are slow. USDC settles in seconds on Stellar for a fraction of a cent — which is exactly the shape of one API call.",
+              },
+              {
+                q: "Is there a token to buy?",
+                a: "No. Payments are made in USDC — a regulated dollar stablecoin. There is no Tael token, ICO, or coin to speculate on.",
+              },
+            ],
+          },
+          {
+            title: "For developers",
+            items: [
+              {
+                q: "How do I monetize my API with this?",
+                a: "You wrap your existing endpoint once and give it a price. From then on, every call is gated by an x402 payment — no accounts, no keys, no billing system to build. You get paid per call, automatically.",
+              },
+              {
+                q: "Do I have to build billing, invoices, or Stripe?",
+                a: "None of it. The payment happens inside the request itself, so there are no invoices to send, no subscriptions to manage, and no payment provider to integrate.",
+              },
+              {
+                q: "Is it custodial? Does anyone hold my funds?",
+                a: "No. The agent's payment settles directly to your wallet in the same transaction that authorizes the call. Nobody sits in the middle holding your money.",
+              },
+            ],
+          },
+          {
+            title: "For agents & buyers",
+            items: [
+              {
+                q: "How does an agent actually pay?",
+                a: "It calls the endpoint, gets a 402 with the price, signs a USDC payment from its wallet, and retries with the proof attached. The server verifies the payment and returns the result. One round trip, no signup.",
+              },
+              {
+                q: "Can I put a limit on what an agent spends?",
+                a: "Yes — spending policies are enforced before any money moves, so an agent can't exceed the caps you set. That's the difference between handing an agent a card and giving it a budget it can't blow past.",
+              },
+            ],
+          },
+        ]}
+      />
+    </>
+  );
+}

--- a/apps/web/app/blog/_posts/agents-cant-pay.tsx
+++ b/apps/web/app/blog/_posts/agents-cant-pay.tsx
@@ -7,37 +7,38 @@ export function AgentsCantPay() {
     <>
       <Lead>
         An AI agent can research a market, write the code, and ship it. But the moment it needs
-        something behind a paywall — a data feed, an OCR endpoint, a better model — it stops cold
-        and waits for a human to paste in a credit card.
+        something behind a paywall, like a data feed, an OCR endpoint, or a better model, it stops
+        cold and waits for a human to paste in a credit card.
       </Lead>
 
       <P>
-        We spend all our attention on making agents <Em>smarter</Em>. Bigger context windows, better
-        tools, sharper reasoning. But the thing that most often ends an agent&apos;s run isn&apos;t
-        intelligence. It&apos;s money. An agent that can&apos;t pay for what it needs isn&apos;t
-        autonomous — it&apos;s an intern that has to come find you every time there&apos;s a bill.
+        We spend all of our attention on making agents <Em>smarter</Em>. Bigger context windows,
+        better tools, sharper reasoning. But the thing that most often ends an agent&apos;s run
+        isn&apos;t intelligence. It&apos;s money. An agent that can&apos;t pay for what it needs
+        isn&apos;t autonomous. It&apos;s an intern who has to come find you every time there&apos;s
+        a bill.
       </P>
 
       <H2 id="human">Everything on the internet assumes a human is buying</H2>
       <P>
-        Every paid API you&apos;ve ever used was designed for a person. You create an account. You
+        Every paid API you have ever used was designed for a person. You create an account. You
         verify an email. You paste a card into a Stripe form. You get an API key, a dashboard, and a
-        monthly invoice. That flow is completely reasonable — for a human who signs up once and uses
+        monthly invoice. That flow is completely reasonable for a human who signs up once and uses
         the service for months.
       </P>
       <P>
         An agent has none of that. It doesn&apos;t have an account. It can&apos;t be handed your
-        card without becoming a liability. And it discovers what it needs <Em>at runtime</Em> — the
-        whole point is that you didn&apos;t know in advance it would need a currency API at 2am. The
-        billing model of the web and the way agents actually work are fundamentally mismatched.
+        card without becoming a liability. And it discovers what it needs <Em>at runtime</Em>, so
+        the whole point is that you didn&apos;t know in advance it would need a currency API at 2am.
+        The billing model of the web and the way agents actually work are fundamentally mismatched.
       </P>
 
       <H2 id="fixes">The obvious fixes all break</H2>
-      <P>Every team hits this wall and tries the same three things first. They all fall apart:</P>
+      <P>Every team hits this wall and tries the same three things first. They all fall apart.</P>
       <Ul>
         <li>
-          <Strong>Give the agent your API key.</Strong> Works until the agent — or a prompt
-          injection riding in on some webpage — burns your quota, hits a rate limit at the worst
+          <Strong>Give the agent your API key.</Strong> This works until the agent, or a prompt
+          injection riding in on some webpage, burns your quota, hits a rate limit at the worst
           moment, or leaks the key into a log.
         </li>
         <li>
@@ -45,9 +46,9 @@ export function AgentsCantPay() {
           visibility into what it bought, and unbounded downside if it loops.
         </li>
         <li>
-          <Strong>Pre-buy credits with every vendor.</Strong> Fine for two or three services.
-          Hopeless across the long tail of tools an agent might reach for — and it defeats the point
-          of an agent that finds what it needs on its own.
+          <Strong>Pre-buy credits with every vendor.</Strong> This is fine for two or three
+          services. It is hopeless across the long tail of tools an agent might reach for, and it
+          defeats the point of an agent that finds what it needs on its own.
         </li>
       </Ul>
       <P>
@@ -55,21 +56,24 @@ export function AgentsCantPay() {
         one thing, once, without a standing relationship.
       </P>
 
-      <Pullquote>Agents don&apos;t need accounts. They need to pay per request.</Pullquote>
+      <Pullquote>
+        <span className="text-white/50">Agents don&apos;t need accounts. </span>
+        They need to pay per request.
+      </Pullquote>
 
       <H2 id="requirements">What machine-native payments actually require</H2>
       <P>
-        If you design payments for agents from scratch — not for humans — you arrive at a short,
-        strict list:
+        If you design payments for agents from scratch, rather than for humans, you arrive at a
+        short, strict list.
       </P>
       <Ul>
         <li>
-          <Strong>Instant settlement.</Strong> The call happens now; the money has to move now. No
-          three-day holds, no chargebacks weeks later.
+          <Strong>Instant settlement.</Strong> The call happens now, so the money has to move now.
+          No three-day holds, no chargebacks weeks later.
         </li>
         <li>
           <Strong>Real micropayments.</Strong> A single call might cost a fifth of a cent. Card
-          rails — with their fixed ~30¢ minimum — make that economically impossible.
+          rails, with their fixed minimum of around 30 cents, make that economically impossible.
         </li>
         <li>
           <Strong>No accounts.</Strong> Identity is a wallet the agent controls, not an email and a
@@ -82,17 +86,17 @@ export function AgentsCantPay() {
       </Ul>
       <P>
         That list quietly rules out cards and bank transfers, and points at something specific: a{" "}
-        <Strong>stablecoin on a fast, cheap chain</Strong> — USDC on Stellar — settling in seconds
-        for a fraction of a cent, plus an open protocol for paying as you go over plain HTTP.
+        <Strong>stablecoin on a fast, cheap chain</Strong>. USDC on Stellar settles in seconds for a
+        fraction of a cent, and pairs with an open protocol for paying as you go over plain HTTP.
       </P>
 
       <H2 id="x402">402: the status code the web forgot</H2>
       <P>
         HTTP has always had a status code reserved for exactly this moment:{" "}
-        <Strong>402 Payment Required</Strong>. It&apos;s been sitting in the spec, unused, for 25
-        years — because there was never a clean way to actually pay in the flow of a request. The{" "}
+        <Strong>402 Payment Required</Strong>. It has been sitting in the spec, unused, for 25
+        years, because there was never a clean way to actually pay inside the flow of a request. The{" "}
         <A href="/docs/accept-payments">x402</A> protocol finally wires it up. The exchange is four
-        steps and one round trip:
+        steps and one round trip.
       </P>
       <Ul>
         <li>The agent calls an endpoint with no payment.</li>
@@ -106,35 +110,35 @@ export function AgentsCantPay() {
         <li>The server verifies it, does the work, and returns the result with a receipt.</li>
       </Ul>
       <Note>
-        No signup. No API key. No invoice at the end of the month. And it&apos;s non-custodial — the
+        No signup. No API key. No invoice at the end of the month. And it is non-custodial: the
         payment settles straight from the agent&apos;s wallet to the provider&apos;s, in the same
         transaction. Nobody holds the money in between.
       </Note>
 
       <H2 id="unlocks">What this unlocks</H2>
       <P>
-        A payment primitive this small changes what an agent is capable of — and what a developer
-        can sell:
+        A payment primitive this small changes what an agent is capable of, and what a developer can
+        sell.
       </P>
       <Ul>
         <li>
           <Strong>Agents buy exactly what they need,</Strong> the moment they need it, inside limits
-          you set — no human in the loop, no standing subscriptions.
+          you set. No human in the loop, and no standing subscriptions.
         </li>
         <li>
           <Strong>Any developer can monetize an API</Strong> by wrapping it once and getting paid
           per call. No accounts to manage, no billing system to build, no Stripe integration.
         </li>
         <li>
-          <Strong>A real marketplace of capabilities</Strong> becomes possible — APIs, tools,
-          models, and datasets that agents can discover and pay for on their own.
+          <Strong>A real marketplace of capabilities</Strong> becomes possible. APIs, tools, models,
+          and datasets that agents can discover and pay for on their own.
         </li>
       </Ul>
 
       <P>
-        This is the layer we&apos;re building at <Strong>Tael</Strong>: wrap any capability, give it
-        a price, and let agents pay per call in USDC on Stellar. The agent brings its own wallet;
-        the builder gets paid automatically. That&apos;s the whole idea — give agents the one thing
+        This is the layer we are building at <Strong>Tael</Strong>. You wrap any capability, give it
+        a price, and let agents pay per call in USDC on Stellar. The agent brings its own wallet,
+        and the builder gets paid automatically. That is the whole idea: give agents the one thing
         they were missing, and get out of the way.
       </P>
 
@@ -147,15 +151,15 @@ export function AgentsCantPay() {
             items: [
               {
                 q: "What is a payment layer for AI agents?",
-                a: "It's infrastructure that lets software pay for a single request — an API call, a tool use, a dataset query — without an account, an API key, or a subscription. The agent pays per call from its own wallet, and the provider gets the money instantly.",
+                a: "It is infrastructure that lets software pay for a single request, such as an API call, a tool use, or a dataset query, without an account, an API key, or a subscription. The agent pays per call from its own wallet, and the provider gets the money instantly.",
               },
               {
                 q: "Why USDC on Stellar, and not cards or another chain?",
-                a: "Agent payments need instant settlement, sub-cent micropayments, and no accounts. Card rails can't do a fifth-of-a-cent charge economically, and bank transfers are slow. USDC settles in seconds on Stellar for a fraction of a cent — which is exactly the shape of one API call.",
+                a: "Agent payments need instant settlement, sub-cent micropayments, and no accounts. Card rails cannot do a fifth-of-a-cent charge economically, and bank transfers are slow. USDC settles in seconds on Stellar for a fraction of a cent, which is exactly the shape of one API call.",
               },
               {
                 q: "Is there a token to buy?",
-                a: "No. Payments are made in USDC — a regulated dollar stablecoin. There is no Tael token, ICO, or coin to speculate on.",
+                a: "No. Payments are made in USDC, a regulated dollar stablecoin. There is no Tael token, ICO, or coin to speculate on.",
               },
             ],
           },
@@ -164,7 +168,7 @@ export function AgentsCantPay() {
             items: [
               {
                 q: "How do I monetize my API with this?",
-                a: "You wrap your existing endpoint once and give it a price. From then on, every call is gated by an x402 payment — no accounts, no keys, no billing system to build. You get paid per call, automatically.",
+                a: "You wrap your existing endpoint once and give it a price. From then on, every call is gated by an x402 payment. There are no accounts, no keys, and no billing system to build. You get paid per call, automatically.",
               },
               {
                 q: "Do I have to build billing, invoices, or Stripe?",
@@ -177,7 +181,7 @@ export function AgentsCantPay() {
             ],
           },
           {
-            title: "For agents & buyers",
+            title: "For agents and buyers",
             items: [
               {
                 q: "How does an agent actually pay?",
@@ -185,7 +189,7 @@ export function AgentsCantPay() {
               },
               {
                 q: "Can I put a limit on what an agent spends?",
-                a: "Yes — spending policies are enforced before any money moves, so an agent can't exceed the caps you set. That's the difference between handing an agent a card and giving it a budget it can't blow past.",
+                a: "Yes. Spending policies are enforced before any money moves, so an agent cannot exceed the caps you set. That is the difference between handing an agent a card and giving it a budget it cannot blow past.",
               },
             ],
           },

--- a/apps/web/app/blog/_posts/index.tsx
+++ b/apps/web/app/blog/_posts/index.tsx
@@ -17,7 +17,7 @@ export const posts: Post[] = [
     slug: "agents-can-think-they-cant-pay",
     title: "Agents can think. They can't pay.",
     description:
-      "AI agents can reason, plan, and ship code — but the moment they need to buy something, a human has to step in. Here's why, and what a payment layer for agents actually looks like.",
+      "AI agents can reason, plan, and ship code, but the moment they need to buy something, a human has to step in. Here's why, and what a payment layer for agents actually looks like.",
     date: "2026-07-12",
     readingTime: "6 min read",
     body: AgentsCantPay,

--- a/apps/web/app/blog/_posts/index.tsx
+++ b/apps/web/app/blog/_posts/index.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import { AgentsCantPay } from "./agents-cant-pay";
+
+export interface Post {
+  slug: string;
+  title: string;
+  /** One-line summary — used on the index, in metadata, and social previews. */
+  description: string;
+  /** ISO date. */
+  date: string;
+  readingTime: string;
+  body: () => ReactNode;
+}
+
+export const posts: Post[] = [
+  {
+    slug: "agents-can-think-they-cant-pay",
+    title: "Agents can think. They can't pay.",
+    description:
+      "AI agents can reason, plan, and ship code — but the moment they need to buy something, a human has to step in. Here's why, and what a payment layer for agents actually looks like.",
+    date: "2026-07-12",
+    readingTime: "6 min read",
+    body: AgentsCantPay,
+  },
+];
+
+export function getPost(slug: string): Post | undefined {
+  return posts.find((p) => p.slug === slug);
+}

--- a/apps/web/app/blog/layout.tsx
+++ b/apps/web/app/blog/layout.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description:
+    "Notes on machine-native payments — how AI agents pay for APIs, tools, and data with x402 and USDC on Stellar.",
+  alternates: { canonical: "/blog" },
+  openGraph: {
+    type: "website",
+    url: "https://taelprotocol.xyz/blog",
+    siteName: "Tael",
+    title: "Tael Blog",
+    description:
+      "Notes on machine-native payments — how AI agents pay for APIs, tools, and data with x402 and USDC on Stellar.",
+  },
+};
+
+export default function BlogLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] text-white">
+      {/* Top nav */}
+      <header className="sticky top-0 z-40 border-b border-white/10 bg-[#0a0a0a]/85 backdrop-blur">
+        <div className="mx-auto flex h-14 max-w-[1100px] items-center justify-between px-6">
+          <a href="/" className="flex items-center gap-1">
+            <span className="font-display text-[20px] leading-none text-accent">t</span>
+            <span className="text-[20px] font-medium tracking-[0.01em] text-white">tael</span>
+          </a>
+          <nav className="flex items-center gap-6 text-[14px] font-medium">
+            <a href="/blog" className="text-white transition-colors">
+              Blog
+            </a>
+            <a href="/docs" className="text-white/55 transition-colors hover:text-white">
+              Docs
+            </a>
+            <a
+              href="/"
+              className="rounded-full bg-white px-4 py-1.5 text-[13px] font-semibold text-black transition-opacity hover:opacity-90"
+            >
+              Join waitlist
+            </a>
+          </nav>
+        </div>
+      </header>
+
+      {children}
+
+      <footer className="border-t border-white/10">
+        <div className="mx-auto flex max-w-[1100px] flex-col items-center gap-2 px-6 py-10 text-center">
+          <div className="flex items-center gap-1">
+            <span className="font-display text-[18px] leading-none text-accent">t</span>
+            <span className="text-[16px] font-medium tracking-[0.01em] text-white">tael</span>
+          </div>
+          <p className="text-[13px] text-white/40">The payment layer for autonomous AI agents.</p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/app/blog/layout.tsx
+++ b/apps/web/app/blog/layout.tsx
@@ -35,7 +35,7 @@ export default function BlogLayout({ children }: { children: ReactNode }) {
             </a>
             <a
               href="/"
-              className="rounded-full bg-white px-4 py-1.5 text-[13px] font-semibold text-black transition-opacity hover:opacity-90"
+              className="rounded-full bg-white px-4 py-1.5 text-[13px] font-semibold text-black transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.97]"
             >
               Join waitlist
             </a>

--- a/apps/web/app/blog/layout.tsx
+++ b/apps/web/app/blog/layout.tsx
@@ -1,26 +1,27 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+const BLOG_DESCRIPTION =
+  "Notes on machine-native payments, and how AI agents pay for APIs, tools, and data with x402 and USDC on Stellar.";
+
 export const metadata: Metadata = {
   title: "Blog",
-  description:
-    "Notes on machine-native payments — how AI agents pay for APIs, tools, and data with x402 and USDC on Stellar.",
+  description: BLOG_DESCRIPTION,
   alternates: { canonical: "/blog" },
   openGraph: {
     type: "website",
     url: "https://taelprotocol.xyz/blog",
     siteName: "Tael",
     title: "Tael Blog",
-    description:
-      "Notes on machine-native payments — how AI agents pay for APIs, tools, and data with x402 and USDC on Stellar.",
+    description: BLOG_DESCRIPTION,
   },
 };
 
 export default function BlogLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-[#0a0a0a] text-white">
+    <div className="min-h-screen bg-[#0e0e11] text-white">
       {/* Top nav */}
-      <header className="sticky top-0 z-40 border-b border-white/10 bg-[#0a0a0a]/85 backdrop-blur">
+      <header className="sticky top-0 z-40 border-b border-white/10 bg-[#0e0e11]/85 backdrop-blur">
         <div className="mx-auto flex h-14 max-w-[1100px] items-center justify-between px-6">
           <a href="/" className="flex items-center gap-1">
             <span className="font-display text-[20px] leading-none text-accent">t</span>

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -16,7 +16,7 @@ export default function BlogIndex() {
         Notes on machine-native payments.
       </h1>
       <p className="mt-4 max-w-[52ch] text-[18px] leading-[1.6] text-white/55">
-        How autonomous agents pay for APIs, tools, and data — the ideas behind Tael and the x402
+        How autonomous agents pay for APIs, tools, and data. The ideas behind Tael and the x402
         protocol.
       </p>
 

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -1,0 +1,54 @@
+import { posts } from "./_posts";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export default function BlogIndex() {
+  return (
+    <main className="mx-auto max-w-[720px] px-6 pb-28 pt-20">
+      <p className="text-[13px] font-medium uppercase tracking-[0.16em] text-white/40">Blog</p>
+      <h1 className="mt-3 text-[40px] font-semibold leading-[1.05] tracking-[-0.03em] text-white sm:text-[52px]">
+        Notes on machine-native payments.
+      </h1>
+      <p className="mt-4 max-w-[52ch] text-[18px] leading-[1.6] text-white/55">
+        How autonomous agents pay for APIs, tools, and data — the ideas behind Tael and the x402
+        protocol.
+      </p>
+
+      <div className="mt-16 flex flex-col divide-y divide-white/10 border-t border-white/10">
+        {posts.map((post) => (
+          <a key={post.slug} href={`/blog/${post.slug}`} className="group block py-8">
+            <div className="flex items-center gap-3 text-[13px] text-white/40">
+              <time dateTime={post.date}>{formatDate(post.date)}</time>
+              <span aria-hidden>·</span>
+              <span>{post.readingTime}</span>
+            </div>
+            <h2 className="mt-2 text-[24px] font-semibold tracking-[-0.02em] text-white transition-colors group-hover:text-accent sm:text-[28px]">
+              {post.title}
+            </h2>
+            <p className="mt-2 max-w-[58ch] text-[16px] leading-[1.6] text-white/55">
+              {post.description}
+            </p>
+            <span className="mt-3 inline-flex items-center gap-1.5 text-[14px] font-medium text-accent">
+              Read
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path
+                  d="M5 12h14M13 6l6 6-6 6"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
+          </a>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,9 +1,11 @@
 import type { MetadataRoute } from "next";
+import { posts } from "./blog/_posts";
 
 const SITE_URL = "https://taelprotocol.xyz";
 
 const paths = [
   "",
+  "/blog",
   "/docs",
   "/docs/quickstart",
   "/docs/authentication",
@@ -11,6 +13,7 @@ const paths = [
   "/docs/wrap-an-api",
   "/docs/sdk/node",
   "/docs/sdk/curl",
+  ...posts.map((post) => `/blog/${post.slug}`),
 ];
 
 export default function sitemap(): MetadataRoute.Sitemap {


### PR DESCRIPTION
## What

Adds a real, editorial **/blog** to the marketing site — the owned, indexable content asset for SEO and distribution (post it on r/Stellar, X, HN; it drives readers *and* backlinks).

- **Design:** dark, spacious reading experience inspired by animations.dev, on Tael's brand (black canvas, blue accent, serif-italic emphasis). Reusable prose primitives, pull quotes, notes.
- **Waitlist CTA card** in-article — reuses the real `WaitlistForm` (posts to `/api/waitlist`).
- **Grouped FAQ accordion** (The basics / For developers / For agents & buyers).
- **Data-driven posts registry** → static article route (`generateStaticParams`, per-post metadata + Open Graph + `BlogPosting` JSON-LD).
- Blog linked from the header nav and added to the sitemap.

## First article — "Agents can think. They can't pay."

A genuine, non-salesy piece: agents can reason and ship code but can't buy anything; why the obvious fixes (share your API key / card / pre-buy credits) break; what machine-native payments actually require; how x402 + USDC on Stellar solves it; and what it unlocks. Tael is mentioned lightly at the end + the CTA.

## Verified

- typecheck / lint / format / build green. `/blog` and `/blog/agents-can-think-they-cant-pay` prerender; added to `sitemap.xml`.
- Review the styling on the Vercel preview.

## Next

I can iterate on the copy or visuals after you see the preview, and add per-article OG images if you want each post to unfurl with its own card.