### PR TITLE
polish(web): monochrome blog links (blue-on-blue fix)

### DIFF
--- a/apps/web/app/blog/_components/prose.tsx
+++ b/apps/web/app/blog/_components/prose.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 /**
  * Editorial prose primitives for the blog — a dark, spacious reading experience
  * (inspired by animations.dev) on Tael's brand: near-black canvas, generous
- * line-height, serif italics for emphasis, and the blue accent for links.
+ * line-height, serif italics for emphasis, and underlined (monochrome) links.
  */
 
 export function Lead({ children }: { children: ReactNode }) {
@@ -48,7 +48,7 @@ export function A({ href, children }: { href: string; children: ReactNode }) {
     <a
       href={href}
       {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-      className="font-medium text-accent underline decoration-accent/30 underline-offset-2 transition-colors hover:decoration-accent"
+      className="font-medium text-white underline decoration-white/30 underline-offset-2 transition-colors hover:decoration-white"
     >
       {children}
     </a>

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -28,15 +28,22 @@ export default function BlogIndex() {
               <span aria-hidden>·</span>
               <span>{post.readingTime}</span>
             </div>
-            <h2 className="mt-2 text-[24px] font-semibold tracking-[-0.02em] text-white transition-colors group-hover:text-accent sm:text-[28px]">
+            <h2 className="mt-2 text-[24px] font-semibold tracking-[-0.02em] text-white/90 transition-colors group-hover:text-white sm:text-[28px]">
               {post.title}
             </h2>
             <p className="mt-2 max-w-[58ch] text-[16px] leading-[1.6] text-white/55">
               {post.description}
             </p>
-            <span className="mt-3 inline-flex items-center gap-1.5 text-[14px] font-medium text-accent">
+            <span className="mt-3 inline-flex items-center gap-1.5 text-[14px] font-medium text-white/55 transition-colors group-hover:text-white">
               Read
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <svg
+                width="15"
+                height="15"
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden
+                className="transition-transform duration-150 group-hover:translate-x-0.5"
+              >
                 <path
                   d="M5 12h14M13 6l6 6-6 6"
                   stroke="currentColor"


### PR DESCRIPTION
The monochrome/blue fix landed on the blog branch *after* PR #18 was merged, so it never reached main. This carries just that commit over.

- Article titles and links are white with underlines (monochrome, animations.dev-style) instead of the harsh brand blue on the dark canvas.
- The 'Read' link gets a press-feedback arrow nudge on hover.
- Blue is reserved for the small brand 't' mark only.

Verified: build green.