### PR TITLE
chore(dashboard): add favicon

### DIFF
--- a/apps/dashboard/app/icon.svg
+++ b/apps/dashboard/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#000000" />
+  <text x="16" y="23" font-family="Georgia, serif" font-size="22" fill="#156DFC" text-anchor="middle">t</text>
+</svg>


### PR DESCRIPTION
The dashboard (app.taelprotocol.xyz) had no favicon. Add the same `icon.svg` the marketing site uses (the brand 't' mark) so the tab shows the Tael icon. Next.js serves it automatically via `app/icon.svg`.