### PR TITLE
chore(api): deploy the API on Vercel (serverless)

### DIFF
--- a/apps/api/api/index.js
+++ b/apps/api/api/index.js
@@ -1,0 +1,6 @@
+// Vercel serverless function entry (root: apps/api). Deliberately plain JS so
+// Vercel's @vercel/node builder does NOT run tsc over it (which fails on the Web
+// Request/Response globals in our monorepo). It re-exports the tsup-bundled
+// handler from dist/vercel.js (plain JS, every @tael/* inlined). vercel.json
+// rewrites every path here and builds dist/ first.
+export { default } from "../dist/vercel.js";

--- a/apps/api/api/index.ts
+++ b/apps/api/api/index.ts
@@ -1,7 +1,0 @@
-// Vercel serverless function entry (root: apps/api). Vercel treats files under
-// /api as functions. This one re-exports the tsup-bundled handler from
-// dist/vercel.js (plain JS, @tael/* inlined) so Vercel never bundles the raw
-// TypeScript workspace packages. vercel.json rewrites every path to here.
-export { default } from "../dist/vercel.js";
-
-export const config = { runtime: "nodejs" };

--- a/apps/api/api/index.ts
+++ b/apps/api/api/index.ts
@@ -1,0 +1,7 @@
+// Vercel serverless function entry (root: apps/api). Vercel treats files under
+// /api as functions. This one re-exports the tsup-bundled handler from
+// dist/vercel.js (plain JS, @tael/* inlined) so Vercel never bundles the raw
+// TypeScript workspace packages. vercel.json rewrites every path to here.
+export { default } from "../dist/vercel.js";
+
+export const config = { runtime: "nodejs" };

--- a/apps/api/src/modules/gateway/upstream.ts
+++ b/apps/api/src/modules/gateway/upstream.ts
@@ -1,8 +1,12 @@
 import { decryptSecret } from "@tael/database";
 import { type ServableCapability } from "../capabilities/capability.repository";
 
-/** How long we wait on the upstream before giving up. */
-const UPSTREAM_TIMEOUT_MS = 30_000;
+/**
+ * How long we wait on the upstream before giving up. Kept under the serverless
+ * function's max duration (Vercel) so the gateway returns a clean 502 rather than
+ * the platform killing the whole invocation.
+ */
+const UPSTREAM_TIMEOUT_MS = 25_000;
 
 /**
  * Basic SSRF guard: reject non-http(s) URLs and obviously-internal hosts. Mirrors

--- a/apps/api/src/vercel.ts
+++ b/apps/api/src/vercel.ts
@@ -1,0 +1,14 @@
+import { handle } from "hono/vercel";
+import { createContainer } from "./container";
+import { env } from "./env";
+import { createServer } from "./server";
+
+/**
+ * Vercel serverless entry. tsup bundles this file (with every @tael/* package
+ * inlined) into `dist/vercel.js`, so the Vercel function that imports it only
+ * ever sees plain JS with npm deps external. The always-on `index.ts` (used
+ * locally and on Node hosts) is a separate entry.
+ */
+const app = createServer(createContainer(env));
+
+export default handle(app);

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  // index.ts = always-on Node server (local / Render); vercel.ts = serverless
+  // handler for Vercel functions. Both bundle @tael/* inline.
+  entry: ["src/index.ts", "src/vercel.ts"],
   format: ["esm"],
   platform: "node",
   target: "node22",

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd ../.. && pnpm install --frozen-lockfile --prod=false && pnpm --filter @tael/api build",
+  "outputDirectory": ".",
+  "functions": {
+    "api/index.ts": {
+      "maxDuration": 30
+    }
+  },
+  "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
+}

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -3,7 +3,7 @@
   "buildCommand": "cd ../.. && pnpm install --frozen-lockfile --prod=false && pnpm --filter @tael/api build",
   "outputDirectory": ".",
   "functions": {
-    "api/index.ts": {
+    "api/index.js": {
       "maxDuration": 30
     }
   },


### PR DESCRIPTION
Makes `apps/api` (the capability gateway) deployable on Vercel, free, alongside the web + dashboard.

## Why not the obvious way
Our `@tael/*` packages export **raw TypeScript**, which Vercel's function bundler can't resolve cleanly (a common monorepo footgun). So instead of importing workspace TS from the function, we pre-bundle it.

## How
- `src/vercel.ts` — serverless entry using `hono/vercel`'s `handle(app)`. tsup bundles it to `dist/vercel.js` with every `@tael/*` package **inlined** (npm deps external).
- `api/index.ts` — thin Vercel function that re-exports `dist/vercel.js`, so Vercel only ever sees plain JS.
- `vercel.json` — builds from the repo root (`pnpm install` + `pnpm --filter @tael/api build`) and rewrites every path to the function.
- Gateway upstream timeout lowered 30s → 25s for function-duration headroom.
- `index.ts` (always-on Node server) stays for local dev and Render as a fallback.

## Verify locally
`format`, `lint`, `typecheck`, `test` (10/10), and full `build` all green; tsup emits both `dist/index.js` and `dist/vercel.js`.

## Deploy steps (Vercel dashboard, after merge)
1. New Project → import the repo → **Root Directory: `apps/api`**, Framework preset: **Other**.
2. Env vars: `DATABASE_URL`, `DIRECT_URL`, `ENCRYPTION_KEY`, `STELLAR_NETWORK=testnet`, `STELLAR_HORIZON_URL`, `USDC_ISSUER`, `TAEL_FEE_ADDRESS`, `TAEL_FEE_BPS`. (No `NODE_ENV`; set it via a var only when you want the real Stellar verifier.)
3. Deploy → hit `/health`.

Free (Hobby) tier is fine for testnet / MVP; move to Pro ($20/mo) when real money flows on mainnet.