### PR TITLE
fix(dashboard): Use-capability dialog (docs link 404 + overflow)

### DIFF
--- a/apps/dashboard/features/capabilities/use-capability-dialog.tsx
+++ b/apps/dashboard/features/capabilities/use-capability-dialog.tsx
@@ -56,7 +56,9 @@ export function UseCapabilityDialog({ endpoint, price }: { endpoint: string; pri
             </div>
 
             <a
-              href="/docs/accept-payments"
+              href="https://taelprotocol.xyz/docs/accept-payments"
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:underline"
             >
               How x402 payments work <ExternalLink className="h-3.5 w-3.5" />


### PR DESCRIPTION
Two fixes to the Use-capability dialog:

1. **Docs link 404** — 'How x402 payments work' used a relative `/docs/accept-payments` that resolved to the dashboard domain (app.taelprotocol.xyz) and 404'd. Point it at `https://taelprotocol.xyz/docs/accept-payments`, open in a new tab.
2. **Overflow** — DialogContent is a CSS grid (items default to min-width:auto), so the long unbreakable endpoint URL / curl lines pushed the track wider than the modal and the copy rows bled out the right edge. Add `min-w-0` + `overflow-hidden` so `break-all`/`overflow-x-auto` take effect. Also removed em dashes from the copy.

Verified: dashboard typecheck + build green.