### PR TITLE
feat(dashboard): agent hot wallets (create + fund + view)

### DIFF
--- a/apps/dashboard/app/(dashboard)/agents/page.tsx
+++ b/apps/dashboard/app/(dashboard)/agents/page.tsx
@@ -1,21 +1,31 @@
 import { Bot } from "lucide-react";
-import { Button } from "@tael/ui";
 import { EmptyState } from "../../../components/empty-state";
 import { PageHeader } from "../../../components/page-header";
+import { listAgentWallets } from "../../../features/agents/queries";
+import { AgentsList } from "../../../features/agents/agents-list";
+import { CreateAgentDialog } from "../../../features/agents/create-agent-dialog";
 
-export default function AgentsPage() {
+export const dynamic = "force-dynamic";
+
+export default async function AgentsPage() {
+  const agents = await listAgentWallets();
+
   return (
     <>
       <PageHeader
         title="My Agents"
         description="Create agents, fund them, and scope their spending."
-        action={<Button>New agent</Button>}
+        action={<CreateAgentDialog />}
       />
-      <EmptyState
-        icon={Bot}
-        title="No agents yet"
-        description="Create an agent wallet, set a spending policy, and let it purchase capabilities autonomously."
-      />
+      {agents.length === 0 ? (
+        <EmptyState
+          icon={Bot}
+          title="No agents yet"
+          description="Create an agent wallet, set a spending policy, and let it purchase capabilities autonomously."
+        />
+      ) : (
+        <AgentsList agents={agents} />
+      )}
     </>
   );
 }

--- a/apps/dashboard/features/agents/actions.ts
+++ b/apps/dashboard/features/agents/actions.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { agents, encryptSecret, wallets } from "@tael/database";
+import { generateKeypair } from "@tael/stellar";
+import { db } from "../../lib/db";
+import { getCurrentUser } from "../capabilities/current-user";
+
+const createAgentSchema = z.object({
+  name: z.string().trim().min(1, "Name is required").max(60),
+  maxPerCall: z.string().regex(/^\d+(\.\d+)?$/, "Enter an amount, e.g. 0.10"),
+  dailyLimit: z.string().regex(/^\d+(\.\d+)?$/, "Enter an amount, e.g. 5.00"),
+});
+
+export interface CreateAgentResult {
+  ok: boolean;
+  /** The new hot wallet's public address to fund. */
+  address?: string;
+  error?: string;
+}
+
+/**
+ * Create an agent with a fresh hot wallet: generate a Stellar keypair, encrypt
+ * the secret at rest, and store the wallet + agent (with its spending policy).
+ * Returns only the PUBLIC address — the secret never leaves the server.
+ */
+export async function createAgent(input: {
+  name: string;
+  maxPerCall: string;
+  dailyLimit: string;
+}): Promise<CreateAgentResult> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  const parsed = createAgentSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input." };
+  }
+  const { name, maxPerCall, dailyLimit } = parsed.data;
+
+  const keypair = generateKeypair();
+
+  try {
+    await db.transaction(async (tx) => {
+      const [wallet] = await tx
+        .insert(wallets)
+        .values({
+          ownerId: user.id,
+          address: keypair.publicKey,
+          label: name,
+          secretEnc: encryptSecret(keypair.secret),
+        })
+        .returning({ id: wallets.id });
+
+      await tx.insert(agents).values({
+        ownerId: user.id,
+        name,
+        walletId: wallet!.id,
+        policy: { maxPerCall, dailyLimit, blockedPublishers: [] },
+      });
+    });
+  } catch (error) {
+    console.error("[agents] create failed:", error);
+    return { ok: false, error: "Could not create the agent. Try again." };
+  }
+
+  revalidatePath("/agents");
+  return { ok: true, address: keypair.publicKey };
+}

--- a/apps/dashboard/features/agents/agents-list.tsx
+++ b/apps/dashboard/features/agents/agents-list.tsx
@@ -1,0 +1,55 @@
+import { Bot } from "lucide-react";
+import type { AgentWallet } from "./queries";
+
+function truncate(addr: string): string {
+  return `${addr.slice(0, 6)}…${addr.slice(-6)}`;
+}
+
+/** A single agent card: name, hot-wallet balance, funding address, spending cap. */
+export function AgentsList({ agents }: { agents: AgentWallet[] }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {agents.map((a) => (
+        <div key={a.agentId} className="rounded-xl border p-5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted">
+                <Bot className="h-4.5 w-4.5" />
+              </span>
+              <div>
+                <p className="font-medium leading-tight">{a.name}</p>
+                <p className="font-mono text-xs text-muted-foreground">{truncate(a.address)}</p>
+              </div>
+            </div>
+            {!a.funded ? (
+              <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
+                Unfunded
+              </span>
+            ) : null}
+          </div>
+
+          <div className="mt-5 flex items-end justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Balance</p>
+              <p className="mt-0.5 text-xl font-semibold tabular-nums">
+                ${Number(a.usdc).toFixed(2)}{" "}
+                <span className="text-sm font-normal text-muted-foreground">USDC</span>
+              </p>
+            </div>
+            {a.policy ? (
+              <div className="text-right text-xs text-muted-foreground">
+                <p>
+                  max <span className="tabular-nums text-foreground">${a.policy.maxPerCall}</span>
+                  /call
+                </p>
+                <p>
+                  <span className="tabular-nums text-foreground">${a.policy.dailyLimit}</span>/day
+                </p>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/dashboard/features/agents/balance.ts
+++ b/apps/dashboard/features/agents/balance.ts
@@ -1,0 +1,36 @@
+import "server-only";
+
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+const USDC_ISSUER = process.env.USDC_ISSUER ?? "";
+
+interface HorizonBalance {
+  asset_type: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  balance: string;
+}
+
+/**
+ * Read a wallet's on-chain USDC balance from Horizon. The chain is the source of
+ * truth (we don't trust the cached column for anything that matters). Returns
+ * "0" for an unfunded account or on any error, plus whether it exists yet.
+ */
+export async function fetchUsdcBalance(
+  address: string,
+): Promise<{ usdc: string; funded: boolean }> {
+  try {
+    const res = await fetch(`${HORIZON_URL}/accounts/${address}`, {
+      headers: { accept: "application/json" },
+      cache: "no-store",
+    });
+    if (res.status === 404) return { usdc: "0", funded: false };
+    if (!res.ok) return { usdc: "0", funded: false };
+    const data = (await res.json()) as { balances?: HorizonBalance[] };
+    const usdc = (data.balances ?? []).find(
+      (b) => b.asset_code === "USDC" && (USDC_ISSUER === "" || b.asset_issuer === USDC_ISSUER),
+    );
+    return { usdc: usdc?.balance ?? "0", funded: true };
+  } catch {
+    return { usdc: "0", funded: false };
+  }
+}

--- a/apps/dashboard/features/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/features/agents/create-agent-dialog.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Check, Copy, Wallet } from "lucide-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from "@tael/ui";
+import { createAgent } from "./actions";
+
+/**
+ * Create an agent with a fresh hot wallet. Two steps: (1) name + spending caps,
+ * (2) show the public funding address. The secret key is generated + encrypted
+ * server-side and never reaches the browser.
+ */
+export function CreateAgentDialog() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [address, setAddress] = useState<string | null>(null);
+
+  const [name, setName] = useState("");
+  const [maxPerCall, setMaxPerCall] = useState("0.10");
+  const [dailyLimit, setDailyLimit] = useState("5.00");
+
+  function reset() {
+    setError(null);
+    setAddress(null);
+    setName("");
+    setMaxPerCall("0.10");
+    setDailyLimit("5.00");
+  }
+
+  function submit() {
+    setError(null);
+    startTransition(async () => {
+      const res = await createAgent({ name, maxPerCall, dailyLimit });
+      if (res.ok && res.address) {
+        setAddress(res.address);
+        router.refresh();
+      } else {
+        setError(res.error ?? "Could not create the agent.");
+      }
+    });
+  }
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>New agent</Button>
+      <Dialog
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          if (!o) reset();
+        }}
+      >
+        <DialogContent className="max-w-md overflow-hidden">
+          {address ? (
+            <FundStep address={address} onDone={() => setOpen(false)} />
+          ) : (
+            <>
+              <DialogHeader className="min-w-0">
+                <DialogTitle>New agent</DialogTitle>
+                <DialogDescription>
+                  Tael creates a wallet the agent pays from. You fund it and set a spending cap it
+                  cannot exceed.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="min-w-0 space-y-4">
+                <Field label="Name">
+                  <Input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Research agent"
+                    autoFocus
+                  />
+                </Field>
+                <div className="grid grid-cols-2 gap-3">
+                  <Field label="Max per call (USDC)">
+                    <Input value={maxPerCall} onChange={(e) => setMaxPerCall(e.target.value)} />
+                  </Field>
+                  <Field label="Daily limit (USDC)">
+                    <Input value={dailyLimit} onChange={(e) => setDailyLimit(e.target.value)} />
+                  </Field>
+                </div>
+
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+                <Button className="w-full" onClick={submit} disabled={pending || !name.trim()}>
+                  {pending ? "Creating…" : "Create agent wallet"}
+                </Button>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function FundStep({ address, onDone }: { address: string; onDone: () => void }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // no-op
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader className="min-w-0">
+        <div className="flex h-11 w-11 items-center justify-center rounded-full bg-emerald-500/10">
+          <Wallet className="h-5 w-5 text-emerald-600" />
+        </div>
+        <DialogTitle className="pt-2">Agent created</DialogTitle>
+        <DialogDescription>
+          Fund this wallet with USDC (testnet for now). The agent pays from it, up to your cap.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="min-w-0 space-y-4">
+        <div className="space-y-1.5">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Funding address
+          </span>
+          <div className="relative min-w-0 overflow-hidden rounded-lg border bg-muted/40">
+            <button
+              type="button"
+              onClick={copy}
+              aria-label={copied ? "Copied" : "Copy"}
+              className="absolute right-2 top-2 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+            >
+              {copied ? (
+                <Check className="h-4 w-4 text-emerald-600" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </button>
+            <p className="break-all p-3 pr-10 font-mono text-sm">{address}</p>
+          </div>
+        </div>
+
+        <Button className="w-full" onClick={onDone}>
+          Done
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/apps/dashboard/features/agents/queries.ts
+++ b/apps/dashboard/features/agents/queries.ts
@@ -1,0 +1,55 @@
+import "server-only";
+import { agents, desc, eq, wallets } from "@tael/database";
+import type { SpendingPolicy } from "@tael/types";
+import { db } from "../../lib/db";
+import { getCurrentUser } from "../capabilities/current-user";
+import { fetchUsdcBalance } from "./balance";
+
+export interface AgentWallet {
+  agentId: string;
+  name: string;
+  address: string;
+  policy: SpendingPolicy | null;
+  /** Live on-chain USDC balance. */
+  usdc: string;
+  funded: boolean;
+  createdAt: Date;
+}
+
+/**
+ * List the signed-in user's agents with their hot wallet + live chain balance.
+ * Deliberately selects only non-sensitive columns — `secret_enc` never leaves
+ * the server, let alone reaches a query the page can serialize to the client.
+ */
+export async function listAgentWallets(): Promise<AgentWallet[]> {
+  const user = await getCurrentUser();
+  if (!user) return [];
+
+  const rows = await db
+    .select({
+      agentId: agents.id,
+      name: agents.name,
+      policy: agents.policy,
+      address: wallets.address,
+      createdAt: agents.createdAt,
+    })
+    .from(agents)
+    .innerJoin(wallets, eq(agents.walletId, wallets.id))
+    .where(eq(agents.ownerId, user.id))
+    .orderBy(desc(agents.createdAt));
+
+  return Promise.all(
+    rows.map(async (r) => {
+      const { usdc, funded } = await fetchUsdcBalance(r.address);
+      return {
+        agentId: r.agentId,
+        name: r.name,
+        address: r.address,
+        policy: r.policy,
+        usdc,
+        funded,
+        createdAt: r.createdAt,
+      };
+    }),
+  );
+}

--- a/packages/database/drizzle/0004_sad_mikhail_rasputin.sql
+++ b/packages/database/drizzle/0004_sad_mikhail_rasputin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wallets" ADD COLUMN "secret_enc" text;

--- a/packages/database/drizzle/meta/0004_snapshot.json
+++ b/packages/database/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,833 @@
+{
+  "id": "91d035f1-090b-4532-b899-e7ba2a04e504",
+  "prevId": "c335b93b-19d5-4671-a22d-7c84b41cb7b1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_wallet_address_idx": {
+          "name": "users_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Main'"
+        },
+        "secret_enc": {
+          "name": "secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_cached": {
+          "name": "balance_cached",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallets_owner_id_idx": {
+          "name": "wallets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallets_owner_id_users_id_fk": {
+          "name": "wallets_owner_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_address_unique": {
+          "name": "wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "capability_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "capability_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "capability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "faqs": {
+          "name": "faqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pay_to": {
+          "name": "pay_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_secret_enc": {
+          "name": "upstream_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capabilities_publisher_id_idx": {
+          "name": "capabilities_publisher_id_idx",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_kind_idx": {
+          "name": "capabilities_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_visibility_idx": {
+          "name": "capabilities_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capabilities_publisher_id_users_id_fk": {
+          "name": "capabilities_publisher_id_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capabilities_slug_unique": {
+          "name": "capabilities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_wallet_id_wallets_id_fk": {
+          "name": "agents_wallet_id_wallets_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer": {
+          "name": "payer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_capability_id_idx": {
+          "name": "payments_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_agent_id_idx": {
+          "name": "payments_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payer_idx": {
+          "name": "payments_payer_idx",
+          "columns": [
+            {
+              "expression": "payer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payee_idx": {
+          "name": "payments_payee_idx",
+          "columns": [
+            {
+              "expression": "payee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_status_idx": {
+          "name": "payments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_capability_id_capabilities_id_fk": {
+          "name": "payments_capability_id_capabilities_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_agent_id_agents_id_fk": {
+          "name": "payments_agent_id_agents_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_owner_id_idx": {
+          "name": "api_keys_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_owner_id_users_id_fk": {
+          "name": "api_keys_owner_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.capability_kind": {
+      "name": "capability_kind",
+      "schema": "public",
+      "values": [
+        "api",
+        "mcp",
+        "agent",
+        "model",
+        "dataset"
+      ]
+    },
+    "public.capability_status": {
+      "name": "capability_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "verified"
+      ]
+    },
+    "public.capability_visibility": {
+      "name": "capability_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "private"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "settled",
+        "failed",
+        "refunded"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1783853490304,
       "tag": "0003_high_living_lightning",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1784039707623,
+      "tag": "0004_sad_mikhail_rasputin",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/wallets.ts
+++ b/packages/database/src/schema/wallets.ts
@@ -17,6 +17,12 @@ export const wallets = pgTable(
     address: text("address").notNull().unique(),
     /** Human label, e.g. "Main" / "Research agent". */
     label: text("label").notNull().default("Main"),
+    /**
+     * Encrypted Stellar secret key (AES-256-GCM, via @tael/database crypto) for
+     * hot wallets Tael signs from on the agent's behalf. Null for watch-only /
+     * externally-held wallets. NEVER selected into client-facing queries.
+     */
+    secretEnc: text("secret_enc"),
     /** Cached USDC balance as a decimal string (chain remains authoritative). */
     balanceCached: numeric("balance_cached", { precision: 20, scale: 7 }).notNull().default("0"),
     ...timestamps,

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -7,3 +7,4 @@ export * from "./usdc";
 export * from "./settlement";
 export * from "./verify";
 export * from "./payment-verify";
+export * from "./keypair";

--- a/packages/stellar/src/keypair.test.ts
+++ b/packages/stellar/src/keypair.test.ts
@@ -1,0 +1,17 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import { generateKeypair } from "./keypair";
+
+describe("generateKeypair", () => {
+  it("returns a valid, matching public key and secret", () => {
+    const { publicKey, secret } = generateKeypair();
+    expect(publicKey).toMatch(/^G[A-Z2-7]{55}$/);
+    expect(secret).toMatch(/^S[A-Z2-7]{55}$/);
+    // The secret must derive the same public key.
+    expect(Keypair.fromSecret(secret).publicKey()).toBe(publicKey);
+  });
+
+  it("generates a different keypair each call", () => {
+    expect(generateKeypair().publicKey).not.toBe(generateKeypair().publicKey);
+  });
+});

--- a/packages/stellar/src/keypair.ts
+++ b/packages/stellar/src/keypair.ts
@@ -1,0 +1,19 @@
+import { Keypair } from "@stellar/stellar-sdk";
+
+/** A freshly generated Stellar keypair. The secret must be encrypted at rest. */
+export interface GeneratedKeypair {
+  /** Public address (G...), safe to store and display. */
+  publicKey: string;
+  /** Secret seed (S...). Sensitive — encrypt before persisting, never log. */
+  secret: string;
+}
+
+/**
+ * Generate a new random Stellar keypair, e.g. for an agent hot wallet. The
+ * caller is responsible for encrypting `secret` (see @tael/database encryptSecret)
+ * before it touches the database, and for never returning it to a client.
+ */
+export function generateKeypair(): GeneratedKeypair {
+  const kp = Keypair.random();
+  return { publicKey: kp.publicKey(), secret: kp.secret() };
+}


### PR DESCRIPTION
Makes **'agents pay' real in the product** (not just via a script). An agent gets a Tael-managed hot wallet you fund and cap.

## What
- `@tael/stellar`: `generateKeypair()` helper (+ test).
- **DB:** `wallets.secret_enc` column — the agent's Stellar secret key, **AES-256-GCM encrypted** at rest (via the existing `@tael/database` crypto). Migration 0004. The chain remains the source of truth for balance.
- **Agents page:** 'New agent' → name + spending caps (max/call, daily) → the server generates a keypair, encrypts the secret, stores wallet + agent, and returns **only the public funding address**. Lists agents with **live on-chain USDC balance** + their policy.

## Security
- `secret_enc` is **never** selected into any client-facing query, never returned to the browser, never logged. Only the public address leaves the server.
- Verified with a round-trip test: the ciphertext does not contain the plaintext secret; decrypt only works server-side with `ENCRYPTION_KEY`.
- This is the agreed **custodial-lite, capped hot wallet** model: exposure is limited to what you fund into that one wallet, never your main funds.

## Verified
typecheck, lint, format, full dashboard build, keypair unit tests, encrypt/decrypt round-trip. Migration 0004 applied to the dev DB.

## Next (PR 2)
Agent pays **from** its hot wallet with **spending-policy enforcement before signing** (maxPerCall / dailyLimit), then calls the gateway. That closes the real 'agent autonomously pays' loop.