### PR TITLE
fix(dashboard): restore agent-wallet follow-ups (provision + detail page)

### DIFF
--- a/apps/dashboard/app/(dashboard)/agents/[id]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/agents/[id]/page.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, Bot } from "lucide-react";
+import { getAgentDetail } from "../../../../features/agents/queries";
+import { AgentManage } from "../../../../features/agents/agent-manage";
+
+export const dynamic = "force-dynamic";
+
+export default async function AgentDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const agent = await getAgentDetail(id);
+  if (!agent) notFound();
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-8">
+      <Link
+        href="/agents"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" /> My Agents
+      </Link>
+
+      <div className="flex items-start gap-4">
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-muted">
+          <Bot className="h-6 w-6" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-2xl font-semibold tracking-tight">{agent.name}</h1>
+          <p className="mt-1 text-sm tabular-nums text-muted-foreground">
+            Balance: ${Number(agent.usdc).toFixed(2)} USDC
+            {agent.policy ? (
+              <>
+                {" · "}max ${agent.policy.maxPerCall}/call{" · "}${agent.policy.dailyLimit}/day
+              </>
+            ) : null}
+          </p>
+        </div>
+        {agent.ready ? (
+          <span className="rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-600">
+            Ready
+          </span>
+        ) : (
+          <span className="rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-600">
+            Not ready
+          </span>
+        )}
+      </div>
+
+      <AgentManage agent={agent} />
+    </div>
+  );
+}

--- a/apps/dashboard/features/agents/actions.ts
+++ b/apps/dashboard/features/agents/actions.ts
@@ -2,10 +2,14 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { agents, encryptSecret, wallets } from "@tael/database";
-import { generateKeypair } from "@tael/stellar";
+import { agents, and, decryptSecret, encryptSecret, eq, wallets } from "@tael/database";
+import { generateKeypair, provisionHotWallet } from "@tael/stellar";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "../capabilities/current-user";
+
+const STELLAR_NETWORK = process.env.STELLAR_NETWORK === "mainnet" ? "mainnet" : "testnet";
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+const USDC_ISSUER = process.env.USDC_ISSUER ?? "";
 
 const createAgentSchema = z.object({
   name: z.string().trim().min(1, "Name is required").max(60),
@@ -17,6 +21,10 @@ export interface CreateAgentResult {
   ok: boolean;
   /** The new hot wallet's public address to fund. */
   address?: string;
+  /** True once the wallet is provisioned (funded + USDC trustline) and can receive USDC. */
+  ready?: boolean;
+  /** Set when the agent was created but provisioning didn't complete (retryable). */
+  provisionError?: string;
   error?: string;
 }
 
@@ -65,6 +73,49 @@ export async function createAgent(input: {
     return { ok: false, error: "Could not create the agent. Try again." };
   }
 
+  // Provision the wallet so it can actually receive USDC (fund XLM + add the
+  // trustline). If this fails, the agent still exists — it's retryable from the
+  // card, so we surface the error rather than failing the whole create.
+  const provision = await provisionHotWallet({
+    secret: keypair.secret,
+    network: STELLAR_NETWORK,
+    horizonUrl: HORIZON_URL,
+    usdcIssuer: USDC_ISSUER,
+  });
+
   revalidatePath("/agents");
-  return { ok: true, address: keypair.publicKey };
+  return {
+    ok: true,
+    address: keypair.publicKey,
+    ready: provision.ready,
+    provisionError: provision.ok ? undefined : provision.error,
+  };
+}
+
+/**
+ * Retry provisioning an existing agent's hot wallet (fund + trustline). Used by
+ * the "Provision wallet" action on an unprovisioned card. Ownership-checked.
+ */
+export async function provisionAgent(agentId: string): Promise<{ ok: boolean; error?: string }> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  const [row] = await db
+    .select({ secretEnc: wallets.secretEnc })
+    .from(agents)
+    .innerJoin(wallets, eq(agents.walletId, wallets.id))
+    .where(and(eq(agents.id, agentId), eq(agents.ownerId, user.id)))
+    .limit(1);
+
+  if (!row?.secretEnc) return { ok: false, error: "Wallet not found." };
+
+  const result = await provisionHotWallet({
+    secret: decryptSecret(row.secretEnc),
+    network: STELLAR_NETWORK,
+    horizonUrl: HORIZON_URL,
+    usdcIssuer: USDC_ISSUER,
+  });
+
+  revalidatePath("/agents");
+  return result.ok ? { ok: true } : { ok: false, error: result.error };
 }

--- a/apps/dashboard/features/agents/actions.ts
+++ b/apps/dashboard/features/agents/actions.ts
@@ -11,10 +11,13 @@ const STELLAR_NETWORK = process.env.STELLAR_NETWORK === "mainnet" ? "mainnet" : 
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
 const USDC_ISSUER = process.env.USDC_ISSUER ?? "";
 
+const nameSchema = z.string().trim().min(1, "Name is required").max(60);
+const amountSchema = z.string().regex(/^\d+(\.\d+)?$/, "Enter an amount, e.g. 0.10");
+
 const createAgentSchema = z.object({
-  name: z.string().trim().min(1, "Name is required").max(60),
-  maxPerCall: z.string().regex(/^\d+(\.\d+)?$/, "Enter an amount, e.g. 0.10"),
-  dailyLimit: z.string().regex(/^\d+(\.\d+)?$/, "Enter an amount, e.g. 5.00"),
+  name: nameSchema,
+  maxPerCall: amountSchema,
+  dailyLimit: amountSchema,
 });
 
 export interface CreateAgentResult {
@@ -118,4 +121,59 @@ export async function provisionAgent(agentId: string): Promise<{ ok: boolean; er
 
   revalidatePath("/agents");
   return result.ok ? { ok: true } : { ok: false, error: result.error };
+}
+
+const updateAgentSchema = z.object({
+  name: nameSchema,
+  maxPerCall: amountSchema,
+  dailyLimit: amountSchema,
+});
+
+/** Update an agent's name and spending policy. Ownership-checked. */
+export async function updateAgent(
+  agentId: string,
+  input: { name: string; maxPerCall: string; dailyLimit: string },
+): Promise<{ ok: boolean; error?: string }> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  const parsed = updateAgentSchema.safeParse(input);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input." };
+  }
+  const { name, maxPerCall, dailyLimit } = parsed.data;
+
+  try {
+    await db
+      .update(agents)
+      .set({ name, policy: { maxPerCall, dailyLimit, blockedPublishers: [] } })
+      .where(and(eq(agents.id, agentId), eq(agents.ownerId, user.id)));
+  } catch (error) {
+    console.error("[agents] update failed:", error);
+    return { ok: false, error: "Could not save. Try again." };
+  }
+
+  revalidatePath("/agents");
+  revalidatePath(`/agents/${agentId}`);
+  return { ok: true };
+}
+
+/**
+ * Delete an agent the signed-in user owns. The wallet row (and its encrypted
+ * key) is left intact so any on-chain funds remain recoverable; only the agent
+ * binding is removed.
+ */
+export async function deleteAgent(agentId: string): Promise<{ ok: boolean; error?: string }> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  try {
+    await db.delete(agents).where(and(eq(agents.id, agentId), eq(agents.ownerId, user.id)));
+  } catch (error) {
+    console.error("[agents] delete failed:", error);
+    return { ok: false, error: "Could not delete. Try again." };
+  }
+
+  revalidatePath("/agents");
+  return { ok: true };
 }

--- a/apps/dashboard/features/agents/agent-manage.tsx
+++ b/apps/dashboard/features/agents/agent-manage.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Check, Copy, Trash2 } from "lucide-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from "@tael/ui";
+import { deleteAgent, provisionAgent, updateAgent } from "./actions";
+import type { AgentWallet } from "./queries";
+
+/** Fund / provision + edit + delete controls for a single agent. */
+export function AgentManage({ agent }: { agent: AgentWallet }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+
+  const [name, setName] = useState(agent.name);
+  const [maxPerCall, setMaxPerCall] = useState(agent.policy?.maxPerCall ?? "0.10");
+  const [dailyLimit, setDailyLimit] = useState(agent.policy?.dailyLimit ?? "5.00");
+  const [saved, setSaved] = useState(false);
+
+  const dirty =
+    name !== agent.name ||
+    maxPerCall !== (agent.policy?.maxPerCall ?? "") ||
+    dailyLimit !== (agent.policy?.dailyLimit ?? "");
+
+  async function copyAddress() {
+    try {
+      await navigator.clipboard.writeText(agent.address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // no-op
+    }
+  }
+
+  function provision() {
+    setError(null);
+    startTransition(async () => {
+      const res = await provisionAgent(agent.agentId);
+      if (res.ok) router.refresh();
+      else setError(res.error ?? "Could not provision.");
+    });
+  }
+
+  function save() {
+    setError(null);
+    setSaved(false);
+    startTransition(async () => {
+      const res = await updateAgent(agent.agentId, { name, maxPerCall, dailyLimit });
+      if (res.ok) {
+        setSaved(true);
+        router.refresh();
+        setTimeout(() => setSaved(false), 2000);
+      } else {
+        setError(res.error ?? "Could not save.");
+      }
+    });
+  }
+
+  function remove() {
+    startTransition(async () => {
+      const res = await deleteAgent(agent.agentId);
+      if (res.ok) router.push("/agents");
+      else setError(res.error ?? "Could not delete.");
+    });
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Fund / provision */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          Funding
+        </h2>
+        {agent.ready ? (
+          <>
+            <p className="text-sm text-muted-foreground">
+              Send USDC on Stellar to this address. The agent pays from it, up to its cap.
+            </p>
+            <div className="flex items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2.5">
+              <span className="min-w-0 flex-1 break-all font-mono text-sm">{agent.address}</span>
+              <button
+                type="button"
+                onClick={copyAddress}
+                aria-label={copied ? "Copied" : "Copy address"}
+                className="shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4 text-emerald-600" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          </>
+        ) : (
+          <div className="space-y-2 rounded-lg border border-amber-500/20 bg-amber-500/[0.04] p-4">
+            <p className="text-sm text-muted-foreground">
+              This wallet isn&apos;t provisioned yet, so it can&apos;t receive USDC. Provision it to
+              set up the on-chain account and USDC trustline.
+            </p>
+            <Button size="sm" onClick={provision} disabled={pending}>
+              {pending ? "Provisioning…" : "Provision wallet"}
+            </Button>
+          </div>
+        )}
+      </section>
+
+      {/* Edit */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          Settings
+        </h2>
+        <div className="space-y-4 rounded-xl border p-5">
+          <Field label="Name">
+            <Input value={name} onChange={(e) => setName(e.target.value)} />
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Max per call (USDC)">
+              <Input value={maxPerCall} onChange={(e) => setMaxPerCall(e.target.value)} />
+            </Field>
+            <Field label="Daily limit (USDC)">
+              <Input value={dailyLimit} onChange={(e) => setDailyLimit(e.target.value)} />
+            </Field>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button onClick={save} disabled={pending || !dirty || !name.trim()}>
+              {pending ? "Saving…" : "Save changes"}
+            </Button>
+            {saved ? <span className="text-sm text-emerald-600">Saved</span> : null}
+          </div>
+        </div>
+      </section>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      {/* Danger */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          Danger zone
+        </h2>
+        <div className="flex items-center justify-between rounded-xl border border-destructive/20 p-4">
+          <div>
+            <p className="text-sm font-medium">Delete this agent</p>
+            <p className="text-sm text-muted-foreground">
+              Removes the agent. Any on-chain funds stay recoverable.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => setConfirmOpen(true)}>
+            <Trash2 className="h-4 w-4" /> Delete
+          </Button>
+        </div>
+      </section>
+
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={(o) => {
+          setConfirmOpen(o);
+          if (!o) setConfirmText("");
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete agent</DialogTitle>
+            <DialogDescription>
+              This removes <span className="font-medium text-foreground">{agent.name}</span>. Type{" "}
+              <span className="font-mono font-semibold text-foreground">delete</span> to confirm.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            placeholder="delete"
+            autoFocus
+          />
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={() => setConfirmOpen(false)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              className="flex-1"
+              onClick={remove}
+              disabled={pending || confirmText.trim().toLowerCase() !== "delete"}
+            >
+              {pending ? "Deleting…" : "Delete agent"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/apps/dashboard/features/agents/agents-list.tsx
+++ b/apps/dashboard/features/agents/agents-list.tsx
@@ -1,10 +1,5 @@
-"use client";
-
-import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
-import { Bot, Check, Copy } from "lucide-react";
-import { Button } from "@tael/ui";
-import { provisionAgent } from "./actions";
+import Link from "next/link";
+import { Bot, ChevronRight } from "lucide-react";
 import type { AgentWallet } from "./queries";
 
 function truncate(addr: string): string {
@@ -15,108 +10,57 @@ export function AgentsList({ agents }: { agents: AgentWallet[] }) {
   return (
     <div className="grid gap-4 sm:grid-cols-2">
       {agents.map((a) => (
-        <AgentCard key={a.agentId} agent={a} />
+        <Link
+          key={a.agentId}
+          href={`/agents/${a.agentId}`}
+          className="group rounded-xl border p-5 transition-colors hover:border-foreground/20 hover:bg-muted/30"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted">
+                <Bot className="h-[18px] w-[18px]" />
+              </span>
+              <div>
+                <p className="font-medium leading-tight">{a.name}</p>
+                <p className="font-mono text-xs text-muted-foreground">{truncate(a.address)}</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {a.ready ? (
+                <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+                  Ready
+                </span>
+              ) : (
+                <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
+                  Not ready
+                </span>
+              )}
+              <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+            </div>
+          </div>
+
+          <div className="mt-5 flex items-end justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Balance</p>
+              <p className="mt-0.5 text-xl font-semibold tabular-nums">
+                ${Number(a.usdc).toFixed(2)}{" "}
+                <span className="text-sm font-normal text-muted-foreground">USDC</span>
+              </p>
+            </div>
+            {a.policy ? (
+              <div className="text-right text-xs text-muted-foreground">
+                <p>
+                  max <span className="tabular-nums text-foreground">${a.policy.maxPerCall}</span>
+                  /call
+                </p>
+                <p>
+                  <span className="tabular-nums text-foreground">${a.policy.dailyLimit}</span>/day
+                </p>
+              </div>
+            ) : null}
+          </div>
+        </Link>
       ))}
-    </div>
-  );
-}
-
-function AgentCard({ agent: a }: { agent: AgentWallet }) {
-  const router = useRouter();
-  const [copied, setCopied] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [pending, startTransition] = useTransition();
-
-  async function copyAddress() {
-    try {
-      await navigator.clipboard.writeText(a.address);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // no-op
-    }
-  }
-
-  function provision() {
-    setError(null);
-    startTransition(async () => {
-      const res = await provisionAgent(a.agentId);
-      if (res.ok) router.refresh();
-      else setError(res.error ?? "Could not provision.");
-    });
-  }
-
-  return (
-    <div className="rounded-xl border p-5">
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex items-center gap-2.5">
-          <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted">
-            <Bot className="h-[18px] w-[18px]" />
-          </span>
-          <div>
-            <p className="font-medium leading-tight">{a.name}</p>
-            <p className="font-mono text-xs text-muted-foreground">{truncate(a.address)}</p>
-          </div>
-        </div>
-        {a.ready ? (
-          <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
-            Ready
-          </span>
-        ) : (
-          <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
-            Not ready
-          </span>
-        )}
-      </div>
-
-      <div className="mt-5 flex items-end justify-between">
-        <div>
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">Balance</p>
-          <p className="mt-0.5 text-xl font-semibold tabular-nums">
-            ${Number(a.usdc).toFixed(2)}{" "}
-            <span className="text-sm font-normal text-muted-foreground">USDC</span>
-          </p>
-        </div>
-        {a.policy ? (
-          <div className="text-right text-xs text-muted-foreground">
-            <p>
-              max <span className="tabular-nums text-foreground">${a.policy.maxPerCall}</span>/call
-            </p>
-            <p>
-              <span className="tabular-nums text-foreground">${a.policy.dailyLimit}</span>/day
-            </p>
-          </div>
-        ) : null}
-      </div>
-
-      {a.ready ? (
-        <div className="mt-4 flex items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2">
-          <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
-            {a.address}
-          </span>
-          <button
-            type="button"
-            onClick={copyAddress}
-            aria-label={copied ? "Copied" : "Copy funding address"}
-            className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
-          >
-            {copied ? <Check className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
-          </button>
-        </div>
-      ) : (
-        <div className="mt-4 space-y-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={provision}
-            disabled={pending}
-          >
-            {pending ? "Provisioning…" : "Provision wallet"}
-          </Button>
-          {error ? <p className="text-xs text-destructive">{error}</p> : null}
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/dashboard/features/agents/agents-list.tsx
+++ b/apps/dashboard/features/agents/agents-list.tsx
@@ -1,55 +1,122 @@
-import { Bot } from "lucide-react";
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Bot, Check, Copy } from "lucide-react";
+import { Button } from "@tael/ui";
+import { provisionAgent } from "./actions";
 import type { AgentWallet } from "./queries";
 
 function truncate(addr: string): string {
   return `${addr.slice(0, 6)}…${addr.slice(-6)}`;
 }
 
-/** A single agent card: name, hot-wallet balance, funding address, spending cap. */
 export function AgentsList({ agents }: { agents: AgentWallet[] }) {
   return (
     <div className="grid gap-4 sm:grid-cols-2">
       {agents.map((a) => (
-        <div key={a.agentId} className="rounded-xl border p-5">
-          <div className="flex items-start justify-between gap-3">
-            <div className="flex items-center gap-2.5">
-              <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted">
-                <Bot className="h-4.5 w-4.5" />
-              </span>
-              <div>
-                <p className="font-medium leading-tight">{a.name}</p>
-                <p className="font-mono text-xs text-muted-foreground">{truncate(a.address)}</p>
-              </div>
-            </div>
-            {!a.funded ? (
-              <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
-                Unfunded
-              </span>
-            ) : null}
-          </div>
+        <AgentCard key={a.agentId} agent={a} />
+      ))}
+    </div>
+  );
+}
 
-          <div className="mt-5 flex items-end justify-between">
-            <div>
-              <p className="text-xs uppercase tracking-wide text-muted-foreground">Balance</p>
-              <p className="mt-0.5 text-xl font-semibold tabular-nums">
-                ${Number(a.usdc).toFixed(2)}{" "}
-                <span className="text-sm font-normal text-muted-foreground">USDC</span>
-              </p>
-            </div>
-            {a.policy ? (
-              <div className="text-right text-xs text-muted-foreground">
-                <p>
-                  max <span className="tabular-nums text-foreground">${a.policy.maxPerCall}</span>
-                  /call
-                </p>
-                <p>
-                  <span className="tabular-nums text-foreground">${a.policy.dailyLimit}</span>/day
-                </p>
-              </div>
-            ) : null}
+function AgentCard({ agent: a }: { agent: AgentWallet }) {
+  const router = useRouter();
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  async function copyAddress() {
+    try {
+      await navigator.clipboard.writeText(a.address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // no-op
+    }
+  }
+
+  function provision() {
+    setError(null);
+    startTransition(async () => {
+      const res = await provisionAgent(a.agentId);
+      if (res.ok) router.refresh();
+      else setError(res.error ?? "Could not provision.");
+    });
+  }
+
+  return (
+    <div className="rounded-xl border p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted">
+            <Bot className="h-[18px] w-[18px]" />
+          </span>
+          <div>
+            <p className="font-medium leading-tight">{a.name}</p>
+            <p className="font-mono text-xs text-muted-foreground">{truncate(a.address)}</p>
           </div>
         </div>
-      ))}
+        {a.ready ? (
+          <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+            Ready
+          </span>
+        ) : (
+          <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
+            Not ready
+          </span>
+        )}
+      </div>
+
+      <div className="mt-5 flex items-end justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Balance</p>
+          <p className="mt-0.5 text-xl font-semibold tabular-nums">
+            ${Number(a.usdc).toFixed(2)}{" "}
+            <span className="text-sm font-normal text-muted-foreground">USDC</span>
+          </p>
+        </div>
+        {a.policy ? (
+          <div className="text-right text-xs text-muted-foreground">
+            <p>
+              max <span className="tabular-nums text-foreground">${a.policy.maxPerCall}</span>/call
+            </p>
+            <p>
+              <span className="tabular-nums text-foreground">${a.policy.dailyLimit}</span>/day
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      {a.ready ? (
+        <div className="mt-4 flex items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2">
+          <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
+            {a.address}
+          </span>
+          <button
+            type="button"
+            onClick={copyAddress}
+            aria-label={copied ? "Copied" : "Copy funding address"}
+            className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+          >
+            {copied ? <Check className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
+          </button>
+        </div>
+      ) : (
+        <div className="mt-4 space-y-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={provision}
+            disabled={pending}
+          >
+            {pending ? "Provisioning…" : "Provision wallet"}
+          </Button>
+          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/dashboard/features/agents/balance.ts
+++ b/apps/dashboard/features/agents/balance.ts
@@ -10,27 +10,34 @@ interface HorizonBalance {
   balance: string;
 }
 
+export interface WalletBalance {
+  /** On-chain USDC balance as a decimal string. */
+  usdc: string;
+  /** The account exists on-chain (has XLM). */
+  funded: boolean;
+  /** The account has a USDC trustline, so it can receive USDC. */
+  ready: boolean;
+}
+
 /**
- * Read a wallet's on-chain USDC balance from Horizon. The chain is the source of
- * truth (we don't trust the cached column for anything that matters). Returns
- * "0" for an unfunded account or on any error, plus whether it exists yet.
+ * Read a wallet's on-chain state from Horizon. The chain is the source of truth
+ * (we don't trust the cached column for anything that matters). Returns "0" and
+ * not-ready for an unfunded account or on any error.
  */
-export async function fetchUsdcBalance(
-  address: string,
-): Promise<{ usdc: string; funded: boolean }> {
+export async function fetchUsdcBalance(address: string): Promise<WalletBalance> {
   try {
     const res = await fetch(`${HORIZON_URL}/accounts/${address}`, {
       headers: { accept: "application/json" },
       cache: "no-store",
     });
-    if (res.status === 404) return { usdc: "0", funded: false };
-    if (!res.ok) return { usdc: "0", funded: false };
+    if (!res.ok) return { usdc: "0", funded: false, ready: false };
     const data = (await res.json()) as { balances?: HorizonBalance[] };
     const usdc = (data.balances ?? []).find(
       (b) => b.asset_code === "USDC" && (USDC_ISSUER === "" || b.asset_issuer === USDC_ISSUER),
     );
-    return { usdc: usdc?.balance ?? "0", funded: true };
+    // A USDC balance entry (even 0) means the trustline exists → can receive USDC.
+    return { usdc: usdc?.balance ?? "0", funded: true, ready: Boolean(usdc) };
   } catch {
-    return { usdc: "0", funded: false };
+    return { usdc: "0", funded: false, ready: false };
   }
 }

--- a/apps/dashboard/features/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/features/agents/create-agent-dialog.tsx
@@ -25,6 +25,8 @@ export function CreateAgentDialog() {
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [address, setAddress] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [provisionError, setProvisionError] = useState<string | null>(null);
 
   const [name, setName] = useState("");
   const [maxPerCall, setMaxPerCall] = useState("0.10");
@@ -33,6 +35,8 @@ export function CreateAgentDialog() {
   function reset() {
     setError(null);
     setAddress(null);
+    setReady(false);
+    setProvisionError(null);
     setName("");
     setMaxPerCall("0.10");
     setDailyLimit("5.00");
@@ -44,6 +48,8 @@ export function CreateAgentDialog() {
       const res = await createAgent({ name, maxPerCall, dailyLimit });
       if (res.ok && res.address) {
         setAddress(res.address);
+        setReady(Boolean(res.ready));
+        setProvisionError(res.provisionError ?? null);
         router.refresh();
       } else {
         setError(res.error ?? "Could not create the agent.");
@@ -63,7 +69,12 @@ export function CreateAgentDialog() {
       >
         <DialogContent className="max-w-md overflow-hidden">
           {address ? (
-            <FundStep address={address} onDone={() => setOpen(false)} />
+            <FundStep
+              address={address}
+              ready={ready}
+              provisionError={provisionError}
+              onDone={() => setOpen(false)}
+            />
           ) : (
             <>
               <DialogHeader className="min-w-0">
@@ -106,7 +117,17 @@ export function CreateAgentDialog() {
   );
 }
 
-function FundStep({ address, onDone }: { address: string; onDone: () => void }) {
+function FundStep({
+  address,
+  ready,
+  provisionError,
+  onDone,
+}: {
+  address: string;
+  ready: boolean;
+  provisionError: string | null;
+  onDone: () => void;
+}) {
   const [copied, setCopied] = useState(false);
 
   async function copy() {
@@ -127,7 +148,9 @@ function FundStep({ address, onDone }: { address: string; onDone: () => void }) 
         </div>
         <DialogTitle className="pt-2">Agent created</DialogTitle>
         <DialogDescription>
-          Fund this wallet with USDC (testnet for now). The agent pays from it, up to your cap.
+          {ready
+            ? "The wallet is ready. Send it USDC (testnet for now) and the agent pays from it, up to your cap."
+            : "The agent is created, but its wallet still needs provisioning before it can receive USDC. Retry it from the agent card."}
         </DialogDescription>
       </DialogHeader>
 
@@ -152,6 +175,8 @@ function FundStep({ address, onDone }: { address: string; onDone: () => void }) 
             <p className="break-all p-3 pr-10 font-mono text-sm">{address}</p>
           </div>
         </div>
+
+        {provisionError ? <p className="text-sm text-amber-600">{provisionError}</p> : null}
 
         <Button className="w-full" onClick={onDone}>
           Done

--- a/apps/dashboard/features/agents/queries.ts
+++ b/apps/dashboard/features/agents/queries.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { agents, desc, eq, wallets } from "@tael/database";
+import { agents, and, desc, eq, wallets } from "@tael/database";
 import type { SpendingPolicy } from "@tael/types";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "../capabilities/current-user";
@@ -55,4 +55,36 @@ export async function listAgentWallets(): Promise<AgentWallet[]> {
       };
     }),
   );
+}
+
+/** Fetch a single agent (ownership-checked) with its live wallet state. */
+export async function getAgentDetail(agentId: string): Promise<AgentWallet | null> {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  const [r] = await db
+    .select({
+      agentId: agents.id,
+      name: agents.name,
+      policy: agents.policy,
+      address: wallets.address,
+      createdAt: agents.createdAt,
+    })
+    .from(agents)
+    .innerJoin(wallets, eq(agents.walletId, wallets.id))
+    .where(and(eq(agents.id, agentId), eq(agents.ownerId, user.id)))
+    .limit(1);
+
+  if (!r) return null;
+  const { usdc, funded, ready } = await fetchUsdcBalance(r.address);
+  return {
+    agentId: r.agentId,
+    name: r.name,
+    address: r.address,
+    policy: r.policy,
+    usdc,
+    funded,
+    ready,
+    createdAt: r.createdAt,
+  };
 }

--- a/apps/dashboard/features/agents/queries.ts
+++ b/apps/dashboard/features/agents/queries.ts
@@ -13,6 +13,8 @@ export interface AgentWallet {
   /** Live on-chain USDC balance. */
   usdc: string;
   funded: boolean;
+  /** Has a USDC trustline, so it can receive USDC. */
+  ready: boolean;
   createdAt: Date;
 }
 
@@ -40,7 +42,7 @@ export async function listAgentWallets(): Promise<AgentWallet[]> {
 
   return Promise.all(
     rows.map(async (r) => {
-      const { usdc, funded } = await fetchUsdcBalance(r.address);
+      const { usdc, funded, ready } = await fetchUsdcBalance(r.address);
       return {
         agentId: r.agentId,
         name: r.name,
@@ -48,6 +50,7 @@ export async function listAgentWallets(): Promise<AgentWallet[]> {
         policy: r.policy,
         usdc,
         funded,
+        ready,
         createdAt: r.createdAt,
       };
     }),

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -8,3 +8,4 @@ export * from "./settlement";
 export * from "./verify";
 export * from "./payment-verify";
 export * from "./keypair";
+export * from "./provision";

--- a/packages/stellar/src/provision.ts
+++ b/packages/stellar/src/provision.ts
@@ -1,0 +1,90 @@
+import { BASE_FEE, Horizon, Keypair, Operation, TransactionBuilder } from "@stellar/stellar-sdk";
+import { networkPassphrase, type StellarNetwork } from "./config";
+import { usdcAsset } from "./usdc";
+
+const FRIENDBOT_URL = "https://friendbot.stellar.org";
+
+export interface ProvisionResult {
+  ok: boolean;
+  /** True if the account now holds a USDC trustline and can receive USDC. */
+  ready: boolean;
+  error?: string;
+}
+
+/**
+ * Make a hot wallet able to *receive* USDC. A brand-new Stellar account can't
+ * hold an asset until it (a) exists on-chain (needs XLM for the base reserve) and
+ * (b) has a trustline to the asset. Both require the wallet's own signature, so
+ * only the server (which holds the encrypted key) can do this.
+ *
+ * Testnet: funds XLM via friendbot, then adds the USDC trustline.
+ * Mainnet: friendbot doesn't exist — the reserve XLM must come from a Tael
+ * treasury (not built yet); this returns ok:false with a clear error there.
+ */
+export async function provisionHotWallet(args: {
+  secret: string;
+  network: StellarNetwork;
+  horizonUrl: string;
+  usdcIssuer: string;
+}): Promise<ProvisionResult> {
+  const keypair = Keypair.fromSecret(args.secret);
+  const server = new Horizon.Server(args.horizonUrl);
+  const passphrase = networkPassphrase(args.network);
+  const usdc = usdcAsset(args.usdcIssuer);
+
+  try {
+    // 1. Ensure the account exists on-chain (needs XLM). Testnet-only via friendbot.
+    let account = await loadAccount(server, keypair.publicKey());
+    if (!account) {
+      if (args.network !== "testnet") {
+        return {
+          ok: false,
+          ready: false,
+          error:
+            "Wallet needs XLM before it can be provisioned (no treasury funding on mainnet yet).",
+        };
+      }
+      const res = await fetch(`${FRIENDBOT_URL}?addr=${encodeURIComponent(keypair.publicKey())}`);
+      if (!res.ok) {
+        return {
+          ok: false,
+          ready: false,
+          error: `Could not fund the wallet (friendbot ${res.status}).`,
+        };
+      }
+      account = await loadAccount(server, keypair.publicKey());
+      if (!account) return { ok: false, ready: false, error: "Wallet funding did not settle." };
+    }
+
+    // 2. Add the USDC trustline if it isn't there yet.
+    const hasTrustline = account.balances.some(
+      (b) => "asset_code" in b && b.asset_code === "USDC" && b.asset_issuer === args.usdcIssuer,
+    );
+    if (hasTrustline) return { ok: true, ready: true };
+
+    const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
+      .addOperation(Operation.changeTrust({ asset: usdc }))
+      .setTimeout(60)
+      .build();
+    tx.sign(keypair);
+    await server.submitTransaction(tx);
+    return { ok: true, ready: true };
+  } catch (error) {
+    return {
+      ok: false,
+      ready: false,
+      error: error instanceof Error ? error.message : "Provisioning failed.",
+    };
+  }
+}
+
+async function loadAccount(
+  server: Horizon.Server,
+  publicKey: string,
+): Promise<Horizon.AccountResponse | null> {
+  try {
+    return await server.loadAccount(publicKey);
+  } catch {
+    return null; // 404 = account not yet created on-chain
+  }
+}


### PR DESCRIPTION
PR #25 was squash-merged after only its first commit (create/fund/view). The two follow-up commits landed on the branch **after** the merge, so they never reached main:

- **auto-provision** hot wallets (fund XLM + USDC trustline so they can receive USDC)
- **agent detail page** (`/agents/[id]`): open a card → fund / edit caps / delete

This cherry-picks both onto current main. No conflicts; the #26 cache() fix is intact. Verified: typecheck + build (the `/agents/[id]` route builds).