### PR TITLE
fix(dashboard): rebuild Use-capability dialog (overflow)

### DIFF
--- a/apps/dashboard/features/capabilities/use-capability-dialog.tsx
+++ b/apps/dashboard/features/capabilities/use-capability-dialog.tsx
@@ -13,13 +13,13 @@ import {
 
 /**
  * Shows how to actually call a capability: its live gateway endpoint plus a
- * copy-paste x402 curl example. The payment *is* the auth — no keys, no signup.
+ * copy-paste x402 curl example. The payment is the auth (no keys, no signup).
  */
 export function UseCapabilityDialog({ endpoint, price }: { endpoint: string; price: string }) {
   const [open, setOpen] = useState(false);
 
   const curl = [
-    `# 1. Call it — you'll get a 402 with the price and pay-to address`,
+    `# 1. Call it: you'll get a 402 with the price and pay-to address`,
     `curl -i ${endpoint}`,
     ``,
     `# 2. Pay ${price} USDC, then retry with the signed payment proof`,
@@ -31,35 +31,47 @@ export function UseCapabilityDialog({ endpoint, price }: { endpoint: string; pri
     <>
       <Button onClick={() => setOpen(true)}>Use capability</Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
+        <DialogContent className="max-w-lg overflow-hidden">
+          <DialogHeader className="min-w-0">
             <DialogTitle>Use this capability</DialogTitle>
             <DialogDescription>
-              Point your agent at this endpoint. It pays per call in USDC over x402 — no accounts,
-              no API keys.
+              Point your agent at this endpoint. It pays per call in USDC over x402, with no
+              accounts and no API keys.
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4">
-            <div className="space-y-1.5">
+          <div className="min-w-0 space-y-4">
+            <div className="min-w-0 space-y-1.5">
               <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                 Endpoint
               </span>
-              <CopyRow value={endpoint} mono />
+              {/* Single-line, truncated: URLs are long, wrapping looks messy. */}
+              <div className="flex min-w-0 items-center gap-2 rounded-lg border bg-muted/40 py-2 pl-3 pr-2">
+                <span className="min-w-0 flex-1 truncate font-mono text-sm">{endpoint}</span>
+                <CopyButton value={endpoint} />
+              </div>
             </div>
 
-            <div className="space-y-1.5">
+            <div className="min-w-0 space-y-1.5">
               <span className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
                 <Terminal className="h-3.5 w-3.5" /> Quick start
               </span>
-              <CopyRow value={curl} block />
+              {/* Multi-line code: scrolls horizontally inside a clipped box. */}
+              <div className="relative min-w-0 overflow-hidden rounded-lg border bg-muted/40">
+                <div className="absolute right-2 top-2 z-10">
+                  <CopyButton value={curl} />
+                </div>
+                <pre className="min-w-0 overflow-x-auto p-3 pr-12 text-xs leading-relaxed">
+                  <code>{curl}</code>
+                </pre>
+              </div>
             </div>
 
             <a
               href="https://taelprotocol.xyz/docs/accept-payments"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground hover:underline"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground transition-colors hover:text-foreground/70"
             >
               How x402 payments work <ExternalLink className="h-3.5 w-3.5" />
             </a>
@@ -70,7 +82,7 @@ export function UseCapabilityDialog({ endpoint, price }: { endpoint: string; pri
   );
 }
 
-function CopyRow({ value, mono, block }: { value: string; mono?: boolean; block?: boolean }) {
+function CopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
 
   async function copy() {
@@ -79,27 +91,18 @@ function CopyRow({ value, mono, block }: { value: string; mono?: boolean; block?
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
-      // Clipboard unavailable — no-op.
+      // Clipboard unavailable, no-op.
     }
   }
 
   return (
-    <div className="relative rounded-lg border bg-muted/40">
-      <button
-        type="button"
-        onClick={copy}
-        aria-label={copied ? "Copied" : "Copy"}
-        className="absolute right-2 top-2 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
-      >
-        {copied ? <Check className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
-      </button>
-      {block ? (
-        <pre className="overflow-x-auto p-3 pr-10 text-xs leading-relaxed">
-          <code>{value}</code>
-        </pre>
-      ) : (
-        <p className={`p-3 pr-10 text-sm ${mono ? "font-mono" : ""} break-all`}>{value}</p>
-      )}
-    </div>
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={copied ? "Copied" : "Copy"}
+      className="shrink-0 rounded-md bg-muted/40 p-1.5 text-muted-foreground backdrop-blur transition-[color,transform] duration-100 ease-out hover:text-foreground active:scale-95"
+    >
+      {copied ? <Check className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
+    </button>
   );
 }


### PR DESCRIPTION
The Use-capability modal's copy rows spill out the right edge (still broken on prod). Root cause: `DialogContent` is a CSS grid, whose items default to `min-width:auto`, so the long endpoint URL + curl lines force the track wider than the modal.

Rebuilt with proper overflow handling + design polish:
- **Endpoint**: single-line **truncated** (URLs are long; wrapping is messy) with a copy button.
- **Quick start**: code **scrolls horizontally** inside a clipped box; copy button overlaid top-right.
- `min-w-0` discipline down the tree + `overflow-hidden` on the container.
- Copy buttons get **press feedback** (`active:scale`, ease-out). Em dashes removed.

Note: #24's earlier overflow fix never reached main (pushed after its squash merge, same timing issue as #25). This supersedes it. Verified: typecheck + build green.