### PR TITLE
feat(dashboard): pay for a capability from an agent (in the UI)

### DIFF
--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { cn } from "@tael/ui";
 import { getPublicCapabilityBySlug } from "../../../../features/capabilities/queries";
 import { formatPrice, kindMeta, timeAgo } from "../../../../features/capabilities/kind-meta";
 import { UseCapabilityDialog } from "../../../../features/capabilities/use-capability-dialog";
+import { RunCapabilityDialog } from "../../../../features/agents/run-capability-dialog";
+import { listAgentsForRun } from "../../../../features/agents/queries";
 import { VerificationTimeline } from "../../../../features/capabilities/verification-timeline";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
@@ -20,6 +22,7 @@ export default async function CapabilityDetailPage({
   const capability = await getPublicCapabilityBySlug(slug);
   if (!capability) notFound();
 
+  const agentOptions = await listAgentsForRun();
   const verified = capability.status === "verified";
   const meta = kindMeta(capability.kind);
   const Icon = meta.icon;
@@ -51,10 +54,17 @@ export default async function CapabilityDetailPage({
             {verified ? <BadgeCheck className="h-5 w-5 text-emerald-600" /> : null}
           </h1>
         </div>
-        <UseCapabilityDialog
-          endpoint={`${API_URL}/c/${capability.slug}`}
-          price={`$${formatPrice(capability.price)}`}
-        />
+        <div className="flex items-center gap-2">
+          <RunCapabilityDialog
+            slug={capability.slug}
+            price={formatPrice(capability.price)}
+            agents={agentOptions}
+          />
+          <UseCapabilityDialog
+            endpoint={`${API_URL}/c/${capability.slug}`}
+            price={`$${formatPrice(capability.price)}`}
+          />
+        </div>
       </div>
 
       {/* Meta row */}

--- a/apps/dashboard/features/agents/queries.ts
+++ b/apps/dashboard/features/agents/queries.ts
@@ -57,6 +57,26 @@ export async function listAgentWallets(): Promise<AgentWallet[]> {
   );
 }
 
+export interface AgentOption {
+  agentId: string;
+  name: string;
+  policy: SpendingPolicy | null;
+}
+
+/**
+ * Lean list of the user's agents for a picker (name + policy only, no live
+ * balance calls — kept fast so it doesn't block the page).
+ */
+export async function listAgentsForRun(): Promise<AgentOption[]> {
+  const user = await getCurrentUser();
+  if (!user) return [];
+  return db
+    .select({ agentId: agents.id, name: agents.name, policy: agents.policy })
+    .from(agents)
+    .where(eq(agents.ownerId, user.id))
+    .orderBy(desc(agents.createdAt));
+}
+
 /** Fetch a single agent (ownership-checked) with its live wallet state. */
 export async function getAgentDetail(agentId: string): Promise<AgentWallet | null> {
   const user = await getCurrentUser();

--- a/apps/dashboard/features/agents/run-capability-dialog.tsx
+++ b/apps/dashboard/features/agents/run-capability-dialog.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Bot, Check, Play, Sparkles, TriangleAlert } from "lucide-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@tael/ui";
+import { runCapability, type RunResult } from "./run-capability";
+import type { AgentOption } from "./queries";
+
+/**
+ * Pay for a capability from one of your agents, from the UI. Picks an agent,
+ * shows the price against its per-call cap, then signs + settles + calls in one
+ * action. Motion follows the design rules: ease-out entrances, press feedback,
+ * a fast step loader (perceived performance), tabular numbers.
+ */
+export function RunCapabilityDialog({
+  slug,
+  price,
+  agents,
+}: {
+  slug: string;
+  price: string;
+  agents: AgentOption[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [agentId, setAgentId] = useState(agents[0]?.agentId ?? "");
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<RunResult | null>(null);
+
+  const selected = agents.find((a) => a.agentId === agentId);
+  const priceNum = Number(price);
+  const overCap = selected?.policy ? priceNum > Number(selected.policy.maxPerCall) : false;
+
+  function reset() {
+    setResult(null);
+  }
+
+  function run() {
+    setResult(null);
+    startTransition(async () => {
+      setResult(await runCapability({ agentId, slug }));
+    });
+  }
+
+  const hasAgents = agents.length > 0;
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => setOpen(true)}
+        className="transition-transform duration-100 ease-out active:scale-[0.97]"
+      >
+        <Play className="h-4 w-4" /> Run with agent
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          if (!o) reset();
+        }}
+      >
+        <DialogContent className="max-w-md overflow-hidden">
+          <DialogHeader className="min-w-0">
+            <DialogTitle>Run with an agent</DialogTitle>
+            <DialogDescription>
+              Your agent pays {price ? `$${price}` : "the fee"} in USDC from its wallet and returns
+              the result. Nothing exceeds the caps you set.
+            </DialogDescription>
+          </DialogHeader>
+
+          {!hasAgents ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              You have no agents yet.{" "}
+              <a href="/agents" className="font-medium text-foreground hover:underline">
+                Create one
+              </a>{" "}
+              to run capabilities.
+            </div>
+          ) : result?.ok ? (
+            <ResultView result={result} onClose={() => setOpen(false)} />
+          ) : (
+            <div className="min-w-0 space-y-4">
+              {/* Agent picker */}
+              <div className="space-y-1.5">
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Pay from
+                </span>
+                <div className="space-y-1.5">
+                  {agents.map((a) => (
+                    <button
+                      key={a.agentId}
+                      type="button"
+                      onClick={() => setAgentId(a.agentId)}
+                      className={`flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-[border-color,background-color] duration-150 ${
+                        a.agentId === agentId
+                          ? "border-foreground/30 bg-muted/50"
+                          : "hover:bg-muted/30"
+                      }`}
+                    >
+                      <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-muted">
+                        <Bot className="h-4 w-4" />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-medium">{a.name}</span>
+                        {a.policy ? (
+                          <span className="block text-xs tabular-nums text-muted-foreground">
+                            max ${a.policy.maxPerCall}/call · ${a.policy.dailyLimit}/day
+                          </span>
+                        ) : null}
+                      </span>
+                      {a.agentId === agentId ? (
+                        <Check className="h-4 w-4 shrink-0 text-foreground" />
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Price + policy check */}
+              <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-3 py-2.5 text-sm">
+                <span className="text-muted-foreground">This call costs</span>
+                <span className="font-semibold tabular-nums">${price} USDC</span>
+              </div>
+
+              {overCap ? (
+                <p className="flex items-center gap-1.5 text-sm text-amber-600">
+                  <TriangleAlert className="h-4 w-4 shrink-0" /> Over this agent&apos;s per-call
+                  cap.
+                </p>
+              ) : null}
+              {result?.error ? (
+                <p className="flex items-center gap-1.5 text-sm text-destructive">
+                  <TriangleAlert className="h-4 w-4 shrink-0" /> {result.error}
+                </p>
+              ) : null}
+
+              <Button
+                className="w-full transition-transform duration-100 ease-out active:scale-[0.99]"
+                onClick={run}
+                disabled={pending || !agentId || overCap}
+              >
+                {pending ? <RunningLabel /> : <>Pay &amp; run</>}
+              </Button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+/** A fast, alive loading label — perceived performance while the tx settles. */
+function RunningLabel() {
+  return (
+    <span className="flex items-center gap-2">
+      <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-background/40 border-t-background" />
+      Paying &amp; settling…
+    </span>
+  );
+}
+
+function ResultView({ result, onClose }: { result: RunResult; onClose: () => void }) {
+  let pretty = result.body ?? "";
+  try {
+    pretty = JSON.stringify(JSON.parse(result.body ?? ""), null, 2);
+  } catch {
+    // leave as-is
+  }
+
+  return (
+    <div className="min-w-0 space-y-4 duration-200 ease-out animate-in fade-in zoom-in-95">
+      <div className="flex items-center gap-2 text-sm font-medium text-emerald-600">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/10">
+          <Sparkles className="h-3.5 w-3.5" />
+        </span>
+        Paid ${result.paid} USDC · {result.status} OK
+      </div>
+
+      <div className="min-w-0 overflow-hidden rounded-lg border bg-muted/40">
+        <pre className="max-h-64 min-w-0 overflow-auto p-3 text-xs leading-relaxed">
+          <code>{pretty}</code>
+        </pre>
+      </div>
+
+      <Button
+        className="w-full transition-transform duration-100 ease-out active:scale-[0.99]"
+        onClick={onClose}
+      >
+        Done
+      </Button>
+    </div>
+  );
+}

--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -1,0 +1,151 @@
+"use server";
+
+import {
+  agents,
+  and,
+  decryptSecret,
+  eq,
+  gte,
+  payments as paymentsTable,
+  sql,
+  wallets,
+} from "@tael/database";
+import { Money } from "@tael/types";
+import { buildSignedPayment } from "@tael/stellar";
+import { db } from "../../lib/db";
+import { getCurrentUser } from "../capabilities/current-user";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+const STELLAR_NETWORK = process.env.STELLAR_NETWORK === "mainnet" ? "mainnet" : "testnet";
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+
+interface Requirement {
+  network: string;
+  maxAmountRequired: string;
+  payTo: string;
+  asset: { code: string; issuer: string };
+  fee?: { payTo: string; amount: string };
+}
+
+export interface RunResult {
+  ok: boolean;
+  /** HTTP status the capability returned. */
+  status?: number;
+  /** The capability's response body (text). */
+  body?: string;
+  /** Total USDC the agent paid for this call. */
+  paid?: string;
+  error?: string;
+}
+
+/** Sum the total (amount + fee) this wallet paid in the last 24h, from the ledger. */
+async function spentLast24h(payer: string): Promise<Money> {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const [row] = await db
+    .select({
+      total: sql<string>`coalesce(sum(${paymentsTable.amount} + ${paymentsTable.fee}), 0)`,
+    })
+    .from(paymentsTable)
+    .where(and(eq(paymentsTable.payer, payer), gte(paymentsTable.createdAt, since)));
+  return Money.parse(row?.total ?? "0");
+}
+
+/**
+ * Run a capability by paying for it FROM an agent's hot wallet. Enforces the
+ * agent's spending policy (max-per-call + rolling 24h limit) BEFORE signing, so
+ * a runaway agent can never exceed the caps the owner set. The signing key is
+ * decrypted only here, on the server, and never leaves it.
+ */
+export async function runCapability(input: { agentId: string; slug: string }): Promise<RunResult> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  const [agent] = await db
+    .select({
+      policy: agents.policy,
+      address: wallets.address,
+      secretEnc: wallets.secretEnc,
+    })
+    .from(agents)
+    .innerJoin(wallets, eq(agents.walletId, wallets.id))
+    .where(and(eq(agents.id, input.agentId), eq(agents.ownerId, user.id)))
+    .limit(1);
+
+  if (!agent?.secretEnc) return { ok: false, error: "Agent wallet not found." };
+
+  // 1. Ask the gateway what this call costs (the 402 challenge).
+  let req: Requirement;
+  try {
+    const res = await fetch(`${API_URL}/c/${input.slug}`, { cache: "no-store" });
+    if (res.status !== 402) {
+      return { ok: false, error: `Capability is not payable (got ${res.status}).` };
+    }
+    const body = (await res.json()) as { accepts: Requirement[] };
+    if (!body.accepts?.[0]) return { ok: false, error: "Invalid payment challenge." };
+    req = body.accepts[0];
+  } catch {
+    return { ok: false, error: "Could not reach the capability." };
+  }
+
+  // 2. Total price = builder share + fee.
+  const total = req.fee
+    ? Money.parse(req.maxAmountRequired).add(Money.parse(req.fee.amount))
+    : Money.parse(req.maxAmountRequired);
+
+  // 3. Enforce the spending policy BEFORE spending anything.
+  if (agent.policy) {
+    const maxPerCall = Money.parse(agent.policy.maxPerCall);
+    if (total.isGreaterThan(maxPerCall)) {
+      return {
+        ok: false,
+        error: `Over the per-call cap ($${total.toDecimalString()} > $${agent.policy.maxPerCall}).`,
+      };
+    }
+    const dailyLimit = Money.parse(agent.policy.dailyLimit);
+    const projected = (await spentLast24h(agent.address)).add(total);
+    if (projected.isGreaterThan(dailyLimit)) {
+      return { ok: false, error: `Would exceed the daily limit of $${agent.policy.dailyLimit}.` };
+    }
+  }
+
+  // 4. Sign the payment from the agent's hot wallet.
+  let xPayment: string;
+  try {
+    const legs = [{ to: req.payTo, amount: req.maxAmountRequired }];
+    if (req.fee) legs.push({ to: req.fee.payTo, amount: req.fee.amount });
+    const xdr = await buildSignedPayment({
+      secret: decryptSecret(agent.secretEnc),
+      network: STELLAR_NETWORK,
+      horizonUrl: HORIZON_URL,
+      usdcIssuer: req.asset.issuer,
+      legs,
+    });
+    xPayment = Buffer.from(
+      JSON.stringify({
+        x402Version: 1,
+        scheme: "exact",
+        network: req.network,
+        payload: { transaction: xdr },
+      }),
+      "utf8",
+    ).toString("base64");
+  } catch (error) {
+    console.error("[run] signing failed:", error);
+    return { ok: false, error: "Could not sign the payment (is the wallet funded?)." };
+  }
+
+  // 5. Retry the call with the payment proof.
+  try {
+    const res = await fetch(`${API_URL}/c/${input.slug}`, {
+      headers: { "X-PAYMENT": xPayment },
+      cache: "no-store",
+    });
+    const body = await res.text();
+    if (!res.ok) {
+      return { ok: false, status: res.status, body, error: `Call failed (${res.status}).` };
+    }
+    return { ok: true, status: res.status, body, paid: total.toDecimalString() };
+  } catch {
+    return { ok: false, error: "The paid call failed." };
+  }
+}

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -9,3 +9,4 @@ export * from "./verify";
 export * from "./payment-verify";
 export * from "./keypair";
 export * from "./provision";
+export * from "./pay";

--- a/packages/stellar/src/pay.ts
+++ b/packages/stellar/src/pay.ts
@@ -1,0 +1,49 @@
+import {
+  Asset,
+  BASE_FEE,
+  Horizon,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { networkPassphrase, type StellarNetwork } from "./config";
+
+/** One USDC payment leg the transaction must include. */
+export interface PaymentLeg {
+  to: string;
+  amount: string;
+}
+
+/**
+ * Build and sign a Stellar transaction that pays the given USDC legs (e.g. the
+ * builder's share + the marketplace fee) from `secret`. Returns the base64 XDR,
+ * ready to drop into an x402 `X-PAYMENT` proof.
+ *
+ * The tx is fetched-and-signed against the current account sequence, so the
+ * signer must be a funded account with a USDC trustline.
+ */
+export async function buildSignedPayment(args: {
+  secret: string;
+  network: StellarNetwork;
+  horizonUrl: string;
+  usdcIssuer: string;
+  legs: PaymentLeg[];
+}): Promise<string> {
+  const signer = Keypair.fromSecret(args.secret);
+  const server = new Horizon.Server(args.horizonUrl);
+  const usdc = new Asset("USDC", args.usdcIssuer);
+
+  const account = await server.loadAccount(signer.publicKey());
+  const builder = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: networkPassphrase(args.network),
+  });
+  for (const leg of args.legs) {
+    builder.addOperation(
+      Operation.payment({ destination: leg.to, asset: usdc, amount: leg.amount }),
+    );
+  }
+  const tx = builder.setTimeout(120).build();
+  tx.sign(signer);
+  return tx.toXDR();
+}


### PR DESCRIPTION
**The last piece: money moves from the dashboard, not a script.**

On a capability's page, **Run with agent** → pick an agent → **Pay & run**:
- `runCapability` action: fetches the 402, **enforces the spending policy** (max-per-call + rolling 24h limit read from the ledger) *before* signing, signs the payment from the agent's encrypted hot wallet, calls the live gateway, returns the result + amount paid.
- `@tael/stellar buildSignedPayment()`: reusable signed-USDC-payment builder (shared with the pay:testnet flow).
- Design-polished dialog (using the installed design skills): agent picker, price-vs-cap check, a fast 'paying & settling' spinner (perceived performance), and an ease-out result reveal. `tabular-nums`, `active:scale` press feedback.

**Security:** the agent's signing key is decrypted only server-side and never reaches the client. The policy is enforced before any money moves.

**Verified live:** the Research agent paid 0.01 USDC through the production gateway (policy check passed) and got the real API response back. Typecheck + lint + build green.