### PR TITLE
feat(dashboard): real earnings + spending (Payments page)

### DIFF
--- a/apps/dashboard/app/(dashboard)/payments/page.tsx
+++ b/apps/dashboard/app/(dashboard)/payments/page.tsx
@@ -1,70 +1,135 @@
-import { Badge, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@tael/ui";
+import { ArrowDownLeft, ArrowUpRight, Receipt } from "lucide-react";
 import { PageHeader } from "../../../components/page-header";
+import { EmptyState } from "../../../components/empty-state";
+import { getPaymentsData, type ActivityRow } from "../../../features/payments/queries";
 
-// Sample rows for the table UI only — replaced by live @tael/api data later.
-const samplePayments = [
-  {
-    id: "pay_1",
-    capability: "Document OCR",
-    direction: "Outgoing",
-    amount: "-$0.02",
-    status: "Settled",
-    date: "2026-07-03",
-  },
-  {
-    id: "pay_2",
-    capability: "Live Web Search",
-    direction: "Outgoing",
-    amount: "-$0.01",
-    status: "Settled",
-    date: "2026-07-03",
-  },
-  {
-    id: "pay_3",
-    capability: "Company Records API",
-    direction: "Outgoing",
-    amount: "-$0.05",
-    status: "Settled",
-    date: "2026-07-02",
-  },
-];
+export const dynamic = "force-dynamic";
 
-export default function PaymentsPage() {
+function money(v: string): string {
+  return Number(v).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+}
+
+function truncate(addr: string): string {
+  return addr.length > 14 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+}
+
+function timeAgo(d: Date): string {
+  const s = Math.floor((Date.now() - d.getTime()) / 1000);
+  const units: [number, string][] = [
+    [86400, "d"],
+    [3600, "h"],
+    [60, "m"],
+  ];
+  for (const [sec, label] of units) {
+    if (s >= sec) return `${Math.floor(s / sec)}${label} ago`;
+  }
+  return "just now";
+}
+
+export default async function PaymentsPage() {
+  const { earned, spent, activity } = await getPaymentsData();
+
   return (
     <>
-      <PageHeader
-        title="Payments"
-        description="Incoming and outgoing settlements across your wallets."
-      />
-      <div className="rounded-xl border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Capability</TableHead>
-              <TableHead>Direction</TableHead>
-              <TableHead>Amount</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Date</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {samplePayments.map((payment) => (
-              <TableRow key={payment.id}>
-                <TableCell className="font-medium">{payment.capability}</TableCell>
-                <TableCell>{payment.direction}</TableCell>
-                <TableCell>{payment.amount}</TableCell>
-                <TableCell>
-                  <Badge variant="secondary">{payment.status}</Badge>
-                </TableCell>
-                <TableCell className="text-muted-foreground">{payment.date}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+      <PageHeader title="Payments" description="Your earnings and spending across Tael." />
+
+      {/* Summary */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <StatCard
+          label="Earned"
+          value={earned}
+          hint="From capabilities you publish"
+          icon={<ArrowDownLeft className="h-4 w-4 text-emerald-600" />}
+          accent="text-emerald-600"
+        />
+        <StatCard
+          label="Spent"
+          value={spent}
+          hint="By your agents"
+          icon={<ArrowUpRight className="h-4 w-4 text-muted-foreground" />}
+        />
       </div>
-      <p className="text-xs text-muted-foreground">
-        Showing sample data — connect a wallet to see live settlements.
-      </p>
+
+      {/* Activity */}
+      {activity.length === 0 ? (
+        <EmptyState
+          icon={Receipt}
+          title="No payments yet"
+          description="Once an agent pays for one of your capabilities, or one of your agents pays for a call, it shows up here."
+        />
+      ) : (
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+            Recent activity
+          </h2>
+          <div className="divide-y rounded-xl border">
+            {activity.map((row) => (
+              <ActivityItem key={row.id} row={row} />
+            ))}
+          </div>
+        </section>
+      )}
     </>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  hint,
+  icon,
+  accent,
+}: {
+  label: string;
+  value: string;
+  hint: string;
+  icon: React.ReactNode;
+  accent?: string;
+}) {
+  return (
+    <div className="rounded-xl border p-5">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        {icon} {label}
+      </div>
+      <p className={`mt-2 text-2xl font-semibold tabular-nums ${accent ?? ""}`}>
+        ${money(value)} <span className="text-sm font-normal text-muted-foreground">USDC</span>
+      </p>
+      <p className="mt-1 text-xs text-muted-foreground">{hint}</p>
+    </div>
+  );
+}
+
+function ActivityItem({ row }: { row: ActivityRow }) {
+  const earned = row.direction === "earned";
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <span
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
+          earned ? "bg-emerald-500/10" : "bg-muted"
+        }`}
+      >
+        {earned ? (
+          <ArrowDownLeft className="h-4 w-4 text-emerald-600" />
+        ) : (
+          <ArrowUpRight className="h-4 w-4 text-muted-foreground" />
+        )}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{row.capability}</p>
+        <p className="truncate font-mono text-xs text-muted-foreground">
+          {earned ? "from" : "to"} {truncate(row.counterparty)}
+        </p>
+      </div>
+      <div className="text-right">
+        <p
+          className={`text-sm font-semibold tabular-nums ${
+            earned ? "text-emerald-600" : "text-foreground"
+          }`}
+        >
+          {earned ? "+" : "−"}${money(row.amount)}
+        </p>
+        <p className="text-xs text-muted-foreground">{timeAgo(row.createdAt)}</p>
+      </div>
+    </div>
   );
 }

--- a/apps/dashboard/features/payments/queries.ts
+++ b/apps/dashboard/features/payments/queries.ts
@@ -1,0 +1,122 @@
+import "server-only";
+import {
+  capabilities,
+  desc,
+  eq,
+  inArray,
+  payments as paymentsTable,
+  wallets,
+} from "@tael/database";
+import { Money } from "@tael/types";
+import { db } from "../../lib/db";
+import { getCurrentUser } from "../capabilities/current-user";
+
+export interface ActivityRow {
+  id: string;
+  direction: "earned" | "spent";
+  /** Capability the payment was for (or a fallback label). */
+  capability: string;
+  /** The other party's Stellar address. */
+  counterparty: string;
+  /** Signed total in USDC: what you earned (net) or spent (incl. fee). */
+  amount: string;
+  status: string;
+  createdAt: Date;
+}
+
+export interface PaymentsData {
+  earned: string;
+  spent: string;
+  activity: ActivityRow[];
+}
+
+/** Stellar addresses of the user's agent wallets (what "spent" is measured against). */
+async function myWalletAddresses(userId: string): Promise<string[]> {
+  const rows = await db
+    .select({ address: wallets.address })
+    .from(wallets)
+    .where(eq(wallets.ownerId, userId));
+  return rows.map((r) => r.address);
+}
+
+/**
+ * Earnings + spending for the signed-in user, from the settlement ledger.
+ *   - Earned: payments for capabilities they publish (net amount received).
+ *   - Spent: payments made by their agent wallets (amount + fee paid).
+ * Returns totals plus a merged, most-recent-first activity feed.
+ */
+export async function getPaymentsData(): Promise<PaymentsData> {
+  const user = await getCurrentUser();
+  if (!user) return { earned: "0", spent: "0", activity: [] };
+
+  // Earnings: join payments → capabilities the user publishes.
+  const earnedRows = await db
+    .select({
+      id: paymentsTable.id,
+      capability: capabilities.name,
+      counterparty: paymentsTable.payer,
+      amount: paymentsTable.amount,
+      status: paymentsTable.status,
+      createdAt: paymentsTable.createdAt,
+    })
+    .from(paymentsTable)
+    .innerJoin(capabilities, eq(paymentsTable.capabilityId, capabilities.id))
+    .where(eq(capabilities.publisherId, user.id))
+    .orderBy(desc(paymentsTable.createdAt))
+    .limit(50);
+
+  // Spending: payments made by any of the user's wallets.
+  const addresses = await myWalletAddresses(user.id);
+  const spentRows = addresses.length
+    ? await db
+        .select({
+          id: paymentsTable.id,
+          capability: capabilities.name,
+          counterparty: paymentsTable.payee,
+          amount: paymentsTable.amount,
+          fee: paymentsTable.fee,
+          status: paymentsTable.status,
+          createdAt: paymentsTable.createdAt,
+        })
+        .from(paymentsTable)
+        .leftJoin(capabilities, eq(paymentsTable.capabilityId, capabilities.id))
+        .where(inArray(paymentsTable.payer, addresses))
+        .orderBy(desc(paymentsTable.createdAt))
+        .limit(50)
+    : [];
+
+  let earned = Money.zero();
+  const earnedActivity: ActivityRow[] = earnedRows.map((r) => {
+    earned = earned.add(Money.parse(r.amount));
+    return {
+      id: `in-${r.id}`,
+      direction: "earned" as const,
+      capability: r.capability,
+      counterparty: r.counterparty,
+      amount: r.amount,
+      status: r.status,
+      createdAt: r.createdAt,
+    };
+  });
+
+  let spent = Money.zero();
+  const spentActivity: ActivityRow[] = spentRows.map((r) => {
+    const total = Money.parse(r.amount).add(Money.parse(r.fee));
+    spent = spent.add(total);
+    return {
+      id: `out-${r.id}`,
+      direction: "spent" as const,
+      capability: r.capability ?? "Capability",
+      counterparty: r.counterparty,
+      amount: total.toDecimalString(),
+      status: r.status,
+      createdAt: r.createdAt,
+    };
+  });
+
+  const activity = [...earnedActivity, ...spentActivity]
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    .slice(0, 50);
+
+  return { earned: earned.toDecimalString(), spent: spent.toDecimalString(), activity };
+}


### PR DESCRIPTION
Turns the placeholder Payments page into a live view from the settlement ledger.

- **Earned** — net USDC received for capabilities you publish (join payments → your capabilities).
- **Spent** — USDC (amount + fee) paid by your agent wallets.
- Two summary stat cards + a **merged activity feed** (most-recent-first) with in/out direction, capability, counterparty, signed amount, and relative time.

Design per the installed skills: `tabular-nums` for money, subtle green for incoming, restraint. Verified against real ledger rows (your account already has earnings from the demo + agent spending).

Typecheck, lint, build green.