### PR TITLE
fix(dashboard): run-flow UX + real Overview page

### DIFF
--- a/apps/dashboard/app/(dashboard)/page.tsx
+++ b/apps/dashboard/app/(dashboard)/page.tsx
@@ -1,33 +1,129 @@
-import { Activity, ArrowLeftRight, Bot, TrendingUp, Wallet } from "lucide-react";
-import { EmptyState } from "../../components/empty-state";
+import Link from "next/link";
+import { Activity, ArrowDownLeft, ArrowLeftRight, ArrowUpRight, Bot, Boxes } from "lucide-react";
 import { PageHeader } from "../../components/page-header";
 import { StatCard } from "../../components/stat-card";
+import { getPaymentsData } from "../../features/payments/queries";
+import { getOverviewCounts } from "../../features/overview/queries";
 
-export default function OverviewPage() {
+export const dynamic = "force-dynamic";
+
+function usd(v: string): string {
+  return Number(v).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 });
+}
+
+function truncate(addr: string): string {
+  return addr.length > 14 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+}
+
+function timeAgo(d: Date): string {
+  const s = Math.floor((Date.now() - d.getTime()) / 1000);
+  for (const [sec, label] of [
+    [86400, "d"],
+    [3600, "h"],
+    [60, "m"],
+  ] as const) {
+    if (s >= sec) return `${Math.floor(s / sec)}${label} ago`;
+  }
+  return "just now";
+}
+
+export default async function OverviewPage() {
+  const [{ earned, spent, activity }, counts] = await Promise.all([
+    getPaymentsData(),
+    getOverviewCounts(),
+  ]);
+
   return (
     <>
-      <PageHeader title="Overview" description="Your wallets, spend, and revenue at a glance." />
+      <PageHeader title="Overview" description="Your earnings, spend, and activity at a glance." />
+
       <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <StatCard label="Wallet balance" value="$20.00" hint="USDC" icon={Wallet} />
         <StatCard
-          label="Spend (30d)"
-          value="$0.71"
-          hint="Across 4 capabilities"
+          label="Earned"
+          value={`$${usd(earned)}`}
+          hint="USDC, all-time"
+          icon={ArrowDownLeft}
+        />
+        <StatCard
+          label="Spent"
+          value={`$${usd(spent)}`}
+          hint="By your agents"
           icon={ArrowLeftRight}
         />
         <StatCard
-          label="Revenue (30d)"
-          value="$0.00"
-          hint="Publish to start earning"
-          icon={TrendingUp}
+          label="Agents"
+          value={String(counts.agents)}
+          hint={counts.agents === 0 ? "Create your first agent" : "Funded, capped wallets"}
+          icon={Bot}
         />
-        <StatCard label="Active agents" value="0" hint="Create your first agent" icon={Bot} />
+        <StatCard
+          label="Capabilities"
+          value={String(counts.capabilities)}
+          hint={counts.capabilities === 0 ? "Publish to start earning" : "Published by you"}
+          icon={Boxes}
+        />
       </section>
-      <EmptyState
-        icon={Activity}
-        title="No recent activity"
-        description="Payments and settlements appear here once your agents start transacting."
-      />
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+            Recent activity
+          </h2>
+          {activity.length > 0 ? (
+            <Link href="/payments" className="text-sm text-muted-foreground hover:text-foreground">
+              View all
+            </Link>
+          ) : null}
+        </div>
+
+        {activity.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed py-12 text-center">
+            <Activity className="h-6 w-6 text-muted-foreground" />
+            <p className="text-sm font-medium">No activity yet</p>
+            <p className="max-w-xs text-sm text-muted-foreground">
+              Payments appear here once your agents start transacting or someone uses your
+              capabilities.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y rounded-xl border">
+            {activity.slice(0, 6).map((row) => {
+              const inbound = row.direction === "earned";
+              return (
+                <div key={row.id} className="flex items-center gap-3 px-4 py-3">
+                  <span
+                    className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
+                      inbound ? "bg-emerald-500/10" : "bg-muted"
+                    }`}
+                  >
+                    {inbound ? (
+                      <ArrowDownLeft className="h-4 w-4 text-emerald-600" />
+                    ) : (
+                      <ArrowUpRight className="h-4 w-4 text-muted-foreground" />
+                    )}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{row.capability}</p>
+                    <p className="truncate font-mono text-xs text-muted-foreground">
+                      {inbound ? "from" : "to"} {truncate(row.counterparty)}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p
+                      className={`text-sm font-semibold tabular-nums ${
+                        inbound ? "text-emerald-600" : "text-foreground"
+                      }`}
+                    >
+                      {inbound ? "+" : "−"}${usd(row.amount)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">{timeAgo(row.createdAt)}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
     </>
   );
 }

--- a/apps/dashboard/features/agents/queries.ts
+++ b/apps/dashboard/features/agents/queries.ts
@@ -61,20 +61,35 @@ export interface AgentOption {
   agentId: string;
   name: string;
   policy: SpendingPolicy | null;
+  /** Live on-chain USDC balance, so the picker can flag unfunded agents. */
+  usdc: string;
 }
 
 /**
- * Lean list of the user's agents for a picker (name + policy only, no live
- * balance calls — kept fast so it doesn't block the page).
+ * List the user's agents for the run picker, with each wallet's live USDC
+ * balance so the UI can flag ones that can't pay. Balance calls run in parallel.
  */
 export async function listAgentsForRun(): Promise<AgentOption[]> {
   const user = await getCurrentUser();
   if (!user) return [];
-  return db
-    .select({ agentId: agents.id, name: agents.name, policy: agents.policy })
+  const rows = await db
+    .select({
+      agentId: agents.id,
+      name: agents.name,
+      policy: agents.policy,
+      address: wallets.address,
+    })
     .from(agents)
+    .innerJoin(wallets, eq(agents.walletId, wallets.id))
     .where(eq(agents.ownerId, user.id))
     .orderBy(desc(agents.createdAt));
+
+  return Promise.all(
+    rows.map(async (r) => {
+      const { usdc } = await fetchUsdcBalance(r.address);
+      return { agentId: r.agentId, name: r.name, policy: r.policy, usdc };
+    }),
+  );
 }
 
 /** Fetch a single agent (ownership-checked) with its live wallet state. */

--- a/apps/dashboard/features/agents/run-capability-dialog.tsx
+++ b/apps/dashboard/features/agents/run-capability-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { Bot, Check, Play, Sparkles, TriangleAlert } from "lucide-react";
+import { useMemo, useState, useTransition } from "react";
+import { Bot, Check, Play, Search, Sparkles, TriangleAlert } from "lucide-react";
 import {
   Button,
   Dialog,
@@ -9,15 +9,15 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  Input,
 } from "@tael/ui";
 import { runCapability, type RunResult } from "./run-capability";
 import type { AgentOption } from "./queries";
 
 /**
- * Pay for a capability from one of your agents, from the UI. Picks an agent,
- * shows the price against its per-call cap, then signs + settles + calls in one
- * action. Motion follows the design rules: ease-out entrances, press feedback,
- * a fast step loader (perceived performance), tabular numbers.
+ * Pay for a capability from one of your agents, in the UI. Only agents that can
+ * actually pay (enough balance, within their per-call cap) are offered. Motion
+ * follows the design rules: ease-out entrances, press feedback, a fast loader.
  */
 export function RunCapabilityDialog({
   slug,
@@ -29,26 +29,42 @@ export function RunCapabilityDialog({
   agents: AgentOption[];
 }) {
   const [open, setOpen] = useState(false);
-  const [agentId, setAgentId] = useState(agents[0]?.agentId ?? "");
   const [pending, startTransition] = useTransition();
   const [result, setResult] = useState<RunResult | null>(null);
+  const [query, setQuery] = useState("");
 
-  const selected = agents.find((a) => a.agentId === agentId);
   const priceNum = Number(price);
-  const overCap = selected?.policy ? priceNum > Number(selected.policy.maxPerCall) : false;
+
+  // Only agents that can actually pay for this call.
+  const eligible = useMemo(
+    () =>
+      agents.filter((a) => {
+        const funded = Number(a.usdc) >= priceNum;
+        const withinCap = a.policy ? priceNum <= Number(a.policy.maxPerCall) : true;
+        return funded && withinCap;
+      }),
+    [agents, priceNum],
+  );
+
+  const filtered = useMemo(
+    () => eligible.filter((a) => a.name.toLowerCase().includes(query.trim().toLowerCase())),
+    [eligible, query],
+  );
+
+  const [agentId, setAgentId] = useState("");
+  const selectedId = agentId || eligible[0]?.agentId || "";
 
   function reset() {
     setResult(null);
+    setQuery("");
   }
 
   function run() {
     setResult(null);
     startTransition(async () => {
-      setResult(await runCapability({ agentId, slug }));
+      setResult(await runCapability({ agentId: selectedId, slug }));
     });
   }
-
-  const hasAgents = agents.length > 0;
 
   return (
     <>
@@ -71,81 +87,94 @@ export function RunCapabilityDialog({
           <DialogHeader className="min-w-0">
             <DialogTitle>Run with an agent</DialogTitle>
             <DialogDescription>
-              Your agent pays {price ? `$${price}` : "the fee"} in USDC from its wallet and returns
-              the result. Nothing exceeds the caps you set.
+              Your agent pays ${price} in USDC from its wallet and returns the result. Nothing
+              exceeds the caps you set.
             </DialogDescription>
           </DialogHeader>
 
-          {!hasAgents ? (
+          {result?.ok ? (
+            <ResultView
+              result={result}
+              onAgain={() => setResult(null)}
+              onClose={() => setOpen(false)}
+            />
+          ) : eligible.length === 0 ? (
             <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-              You have no agents yet.{" "}
-              <a href="/agents" className="font-medium text-foreground hover:underline">
-                Create one
-              </a>{" "}
-              to run capabilities.
+              No agent can pay ${price} for this call.
+              <br />
+              <a
+                href="/agents"
+                className="mt-1 inline-block font-medium text-foreground hover:underline"
+              >
+                Fund an agent or raise its cap
+              </a>
             </div>
-          ) : result?.ok ? (
-            <ResultView result={result} onClose={() => setOpen(false)} />
           ) : (
             <div className="min-w-0 space-y-4">
-              {/* Agent picker */}
-              <div className="space-y-1.5">
-                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Pay from
-                </span>
-                <div className="space-y-1.5">
-                  {agents.map((a) => (
+              {/* Search — only when there are enough agents to warrant it. */}
+              {eligible.length > 5 ? (
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search agents…"
+                    className="pl-9"
+                  />
+                </div>
+              ) : null}
+
+              {/* Agent list — compact + scrollable so it scales. */}
+              <div className="max-h-64 space-y-1 overflow-y-auto pr-1">
+                {filtered.map((a) => {
+                  const active = a.agentId === selectedId;
+                  return (
                     <button
                       key={a.agentId}
                       type="button"
                       onClick={() => setAgentId(a.agentId)}
-                      className={`flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-[border-color,background-color] duration-150 ${
-                        a.agentId === agentId
-                          ? "border-foreground/30 bg-muted/50"
-                          : "hover:bg-muted/30"
+                      className={`flex w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-[border-color,background-color] duration-150 ${
+                        active ? "border-foreground/30 bg-muted/50" : "hover:bg-muted/30"
                       }`}
                     >
-                      <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-muted">
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted">
                         <Bot className="h-4 w-4" />
                       </span>
                       <span className="min-w-0 flex-1">
-                        <span className="block truncate font-medium">{a.name}</span>
+                        <span className="block truncate text-sm font-medium">{a.name}</span>
                         {a.policy ? (
                           <span className="block text-xs tabular-nums text-muted-foreground">
-                            max ${a.policy.maxPerCall}/call · ${a.policy.dailyLimit}/day
+                            max ${a.policy.maxPerCall}/call
                           </span>
                         ) : null}
                       </span>
-                      {a.agentId === agentId ? (
-                        <Check className="h-4 w-4 shrink-0 text-foreground" />
-                      ) : null}
+                      <span className="shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+                        ${Number(a.usdc).toFixed(2)}
+                      </span>
+                      {active ? <Check className="h-4 w-4 shrink-0 text-foreground" /> : null}
                     </button>
-                  ))}
-                </div>
+                  );
+                })}
+                {filtered.length === 0 ? (
+                  <p className="py-4 text-center text-sm text-muted-foreground">No match.</p>
+                ) : null}
               </div>
 
-              {/* Price + policy check */}
               <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-3 py-2.5 text-sm">
                 <span className="text-muted-foreground">This call costs</span>
                 <span className="font-semibold tabular-nums">${price} USDC</span>
               </div>
 
-              {overCap ? (
-                <p className="flex items-center gap-1.5 text-sm text-amber-600">
-                  <TriangleAlert className="h-4 w-4 shrink-0" /> Over this agent&apos;s per-call
-                  cap.
-                </p>
-              ) : null}
               {result?.error ? (
-                <p className="flex items-center gap-1.5 text-sm text-destructive">
-                  <TriangleAlert className="h-4 w-4 shrink-0" /> {result.error}
+                <p className="flex items-start gap-1.5 text-sm text-destructive">
+                  <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" /> {result.error}
                 </p>
               ) : null}
 
               <Button
                 className="w-full transition-transform duration-100 ease-out active:scale-[0.99]"
                 onClick={run}
-                disabled={pending || !agentId || overCap}
+                disabled={pending || !selectedId}
               >
                 {pending ? <RunningLabel /> : <>Pay &amp; run</>}
               </Button>
@@ -167,7 +196,15 @@ function RunningLabel() {
   );
 }
 
-function ResultView({ result, onClose }: { result: RunResult; onClose: () => void }) {
+function ResultView({
+  result,
+  onAgain,
+  onClose,
+}: {
+  result: RunResult;
+  onAgain: () => void;
+  onClose: () => void;
+}) {
   let pretty = result.body ?? "";
   try {
     pretty = JSON.stringify(JSON.parse(result.body ?? ""), null, 2);
@@ -190,12 +227,27 @@ function ResultView({ result, onClose }: { result: RunResult; onClose: () => voi
         </pre>
       </div>
 
-      <Button
-        className="w-full transition-transform duration-100 ease-out active:scale-[0.99]"
-        onClick={onClose}
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          className="flex-1 transition-transform duration-100 ease-out active:scale-[0.99]"
+          onClick={onAgain}
+        >
+          Run again
+        </Button>
+        <Button
+          className="flex-1 transition-transform duration-100 ease-out active:scale-[0.99]"
+          onClick={onClose}
+        >
+          Done
+        </Button>
+      </div>
+      <a
+        href="/payments"
+        className="block text-center text-xs text-muted-foreground hover:underline"
       >
-        Done
-      </Button>
+        See all calls in Payments
+      </a>
     </div>
   );
 }

--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -14,6 +14,7 @@ import { Money } from "@tael/types";
 import { buildSignedPayment } from "@tael/stellar";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "../capabilities/current-user";
+import { fetchUsdcBalance } from "./balance";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 const STELLAR_NETWORK = process.env.STELLAR_NETWORK === "mainnet" ? "mainnet" : "testnet";
@@ -108,6 +109,15 @@ export async function runCapability(input: { agentId: string; slug: string }): P
     }
   }
 
+  // 3b. Make sure the wallet actually holds enough USDC (clear error, not a 500).
+  const { usdc } = await fetchUsdcBalance(agent.address);
+  if (Money.parse(total.toDecimalString()).isGreaterThan(Money.parse(usdc))) {
+    return {
+      ok: false,
+      error: `Not enough USDC. This agent has $${usdc}, the call costs $${total.toDecimalString()}. Fund it first.`,
+    };
+  }
+
   // 4. Sign the payment from the agent's hot wallet.
   let xPayment: string;
   try {
@@ -142,10 +152,19 @@ export async function runCapability(input: { agentId: string; slug: string }): P
     });
     const body = await res.text();
     if (!res.ok) {
-      return { ok: false, status: res.status, body, error: `Call failed (${res.status}).` };
+      return { ok: false, status: res.status, body, error: friendlyError(res.status) };
     }
     return { ok: true, status: res.status, body, paid: total.toDecimalString() };
   } catch {
-    return { ok: false, error: "The paid call failed." };
+    return { ok: false, error: "Couldn't reach the capability. Try again." };
   }
+}
+
+/** Map a gateway/upstream status to a message a human can act on. */
+function friendlyError(status: number): string {
+  if (status === 402) return "The payment was rejected. Check the agent's balance and trustline.";
+  if (status === 429) return "The API is rate-limiting requests right now. Try again in a moment.";
+  if (status === 404) return "This capability is no longer available.";
+  if (status >= 500) return "The agent couldn't pay, or the upstream API is down. Try again.";
+  return `The call failed (${status}).`;
 }

--- a/apps/dashboard/features/overview/queries.ts
+++ b/apps/dashboard/features/overview/queries.ts
@@ -1,0 +1,18 @@
+import "server-only";
+import { agents, capabilities, count, eq } from "@tael/database";
+import { db } from "../../lib/db";
+import { getCurrentUser } from "../capabilities/current-user";
+
+/** Counts of the user's agents and published capabilities, for the overview. */
+export async function getOverviewCounts(): Promise<{ agents: number; capabilities: number }> {
+  const user = await getCurrentUser();
+  if (!user) return { agents: 0, capabilities: 0 };
+
+  const [a] = await db.select({ n: count() }).from(agents).where(eq(agents.ownerId, user.id));
+  const [c] = await db
+    .select({ n: count() })
+    .from(capabilities)
+    .where(eq(capabilities.publisherId, user.id));
+
+  return { agents: a?.n ?? 0, capabilities: c?.n ?? 0 };
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -25,4 +25,5 @@ export {
   gte,
   lt,
   lte,
+  count,
 } from "drizzle-orm";


### PR DESCRIPTION
Addresses the feedback from testing the run-with-agent flow.

## Run-with-agent
- **Only eligible agents shown** — enough USDC *and* within the per-call cap. Ineligible agents are hidden; if none qualify, a clear message points to funding. (Fixes picking an unfunded agent → confusing `Call failed (500)`.)
- **Scales to many agents** — compact rows with each agent's **balance**, scrollable list, and a **search** box once there are >5 agents.
- **Clear error messages** — 429 → 'API is rate-limiting, try again'; 5xx → 'agent couldn't pay or upstream is down'; 402 → 'payment rejected'. Plus a server-side **balance pre-check** for a precise 'not enough USDC' message.
- **'Run again'** in the result view + a link to **Payments** (where the full call history lives).

## Overview page
Replaced the hardcoded sample stats with **real data**: Earned, Spent, agent count, capability count, and a live recent-activity feed from the ledger.

Verified: typecheck, lint, clean build all green.