### PR TITLE
feat(dashboard): real Analytics page (charts)

### DIFF
--- a/apps/dashboard/app/(dashboard)/analytics/page.tsx
+++ b/apps/dashboard/app/(dashboard)/analytics/page.tsx
@@ -1,26 +1,79 @@
-import { AlertTriangle, BarChart3, Gauge, PhoneCall, TrendingUp } from "lucide-react";
-import { EmptyState } from "../../../components/empty-state";
+import { ArrowDownLeft, ArrowLeftRight, PhoneCall, Receipt } from "lucide-react";
 import { PageHeader } from "../../../components/page-header";
 import { StatCard } from "../../../components/stat-card";
+import { getAnalytics } from "../../../features/analytics/queries";
+import { BarChart } from "../../../features/analytics/bar-chart";
 
-export default function AnalyticsPage() {
+export const dynamic = "force-dynamic";
+
+function usd(v: string): string {
+  return Number(v).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+}
+
+export default async function AnalyticsPage() {
+  const a = await getAnalytics();
+  const hasData = a.series.some((p) => p.earned || p.spent || p.calls);
+
   return (
     <>
       <PageHeader
         title="Analytics"
-        description="Usage, performance, and revenue for your capabilities."
+        description="Your earnings, spend, and call volume (last 30 days)."
       />
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <StatCard label="Calls (30d)" value="0" icon={PhoneCall} />
-        <StatCard label="Success rate" value="—" icon={Gauge} />
-        <StatCard label="Avg latency" value="—" icon={TrendingUp} />
-        <StatCard label="Errors" value="0" icon={AlertTriangle} />
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <StatCard label="Earned (30d)" value={`$${usd(a.totalEarned)}`} icon={ArrowDownLeft} />
+        <StatCard label="Spent (30d)" value={`$${usd(a.totalSpent)}`} icon={ArrowLeftRight} />
+        <StatCard
+          label="Calls (30d)"
+          value={String(a.totalCalls + a.earnedCalls)}
+          icon={PhoneCall}
+        />
       </section>
-      <EmptyState
-        icon={BarChart3}
-        title="No data to chart yet"
-        description="Revenue and call-volume charts render here once your capabilities receive traffic."
-      />
+
+      {!hasData ? (
+        <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed py-16 text-center">
+          <Receipt className="h-6 w-6 text-muted-foreground" />
+          <p className="text-sm font-medium">No data to chart yet</p>
+          <p className="max-w-xs text-sm text-muted-foreground">
+            Charts fill in once your capabilities receive traffic or your agents make calls.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-2">
+          <ChartCard title="Earnings" subtitle="USDC received per day">
+            <BarChart data={a.series} metric="earned" color="#059669" />
+          </ChartCard>
+          <ChartCard title="Spend" subtitle="USDC paid by your agents">
+            <BarChart data={a.series} metric="spent" color="#6b7280" />
+          </ChartCard>
+          <ChartCard title="Call volume" subtitle="Paid calls per day" className="lg:col-span-2">
+            <BarChart data={a.series} metric="calls" color="#156DFC" />
+          </ChartCard>
+        </div>
+      )}
     </>
+  );
+}
+
+function ChartCard({
+  title,
+  subtitle,
+  className,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`rounded-xl border p-5 ${className ?? ""}`}>
+      <div className="mb-4">
+        <p className="text-sm font-medium">{title}</p>
+        <p className="text-xs text-muted-foreground">{subtitle}</p>
+      </div>
+      {children}
+    </div>
   );
 }

--- a/apps/dashboard/features/analytics/bar-chart.tsx
+++ b/apps/dashboard/features/analytics/bar-chart.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import type { DayPoint } from "./queries";
+
+type Metric = "earned" | "spent" | "calls";
+
+function value(p: DayPoint, m: Metric): number {
+  return m === "earned" ? p.earned : m === "spent" ? p.spent : p.calls;
+}
+
+function label(p: DayPoint, m: Metric): string {
+  const v = value(p, m);
+  if (m === "calls") return `${v} call${v === 1 ? "" : "s"}`;
+  return `$${v.toLocaleString("en-US", { maximumFractionDigits: 7 })}`;
+}
+
+function dayLabel(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/**
+ * A dependency-free daily bar chart. Bars grow with a short ease-out on mount and
+ * lighten on hover, showing a value/date tooltip. Empty series render flat.
+ */
+export function BarChart({
+  data,
+  metric,
+  color,
+}: {
+  data: DayPoint[];
+  metric: Metric;
+  color: string;
+}) {
+  const [hover, setHover] = useState<number | null>(null);
+  const max = Math.max(...data.map((p) => value(p, metric)), 0);
+
+  return (
+    <div>
+      <div className="flex h-32 items-end gap-[3px]">
+        {data.map((p, i) => {
+          const v = value(p, metric);
+          const pct = max > 0 ? (v / max) * 100 : 0;
+          return (
+            <button
+              key={p.date}
+              type="button"
+              onMouseEnter={() => setHover(i)}
+              onMouseLeave={() => setHover(null)}
+              className="group relative flex h-full flex-1 items-end"
+              aria-label={`${dayLabel(p.date)}: ${label(p, metric)}`}
+            >
+              <span
+                className={`w-full rounded-sm transition-[height,opacity] duration-300 ease-out ${
+                  hover === i ? "opacity-100" : "opacity-80"
+                }`}
+                style={{ height: `${Math.max(pct, v > 0 ? 4 : 1.5)}%`, backgroundColor: color }}
+              />
+              {hover === i ? (
+                <span className="pointer-events-none absolute -top-1 left-1/2 z-10 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border bg-background px-2 py-1 text-xs shadow-md">
+                  <span className="font-medium tabular-nums">{label(p, metric)}</span>
+                  <span className="ml-1.5 text-muted-foreground">{dayLabel(p.date)}</span>
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-2 flex justify-between text-[11px] text-muted-foreground">
+        <span>{dayLabel(data[0]?.date ?? "")}</span>
+        <span>{dayLabel(data[data.length - 1]?.date ?? "")}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/features/analytics/queries.ts
+++ b/apps/dashboard/features/analytics/queries.ts
@@ -1,0 +1,122 @@
+import "server-only";
+import {
+  and,
+  capabilities,
+  eq,
+  gte,
+  inArray,
+  payments as paymentsTable,
+  sql,
+  wallets,
+} from "@tael/database";
+import { Money } from "@tael/types";
+import { db } from "../../lib/db";
+import { getCurrentUser } from "../capabilities/current-user";
+
+const DAYS = 30;
+
+export interface DayPoint {
+  /** ISO date (YYYY-MM-DD). */
+  date: string;
+  earned: number;
+  spent: number;
+  calls: number;
+}
+
+export interface AnalyticsData {
+  totalEarned: string;
+  totalSpent: string;
+  totalCalls: number;
+  earnedCalls: number;
+  series: DayPoint[];
+}
+
+/**
+ * Daily earnings, spend, and call counts over the last 30 days, from the
+ * settlement ledger. Earnings = payments for the user's capabilities; spend =
+ * payments made by the user's agent wallets.
+ */
+export async function getAnalytics(): Promise<AnalyticsData> {
+  const user = await getCurrentUser();
+  const empty: AnalyticsData = {
+    totalEarned: "0",
+    totalSpent: "0",
+    totalCalls: 0,
+    earnedCalls: 0,
+    series: buildSeries([], []),
+  };
+  if (!user) return empty;
+
+  const since = new Date(Date.now() - DAYS * 24 * 60 * 60 * 1000);
+  const day = sql<string>`to_char(${paymentsTable.createdAt}, 'YYYY-MM-DD')`;
+
+  // Earnings per day (payments for capabilities this user publishes).
+  const earnedRows = await db
+    .select({
+      date: day,
+      total: sql<string>`coalesce(sum(${paymentsTable.amount}), 0)`,
+      calls: sql<number>`count(*)::int`,
+    })
+    .from(paymentsTable)
+    .innerJoin(capabilities, eq(paymentsTable.capabilityId, capabilities.id))
+    .where(and(eq(capabilities.publisherId, user.id), gte(paymentsTable.createdAt, since)))
+    .groupBy(day);
+
+  // Spend per day (payments made by this user's agent wallets).
+  const addresses = (
+    await db.select({ address: wallets.address }).from(wallets).where(eq(wallets.ownerId, user.id))
+  ).map((r) => r.address);
+
+  const spentRows = addresses.length
+    ? await db
+        .select({
+          date: day,
+          total: sql<string>`coalesce(sum(${paymentsTable.amount} + ${paymentsTable.fee}), 0)`,
+          calls: sql<number>`count(*)::int`,
+        })
+        .from(paymentsTable)
+        .where(and(inArray(paymentsTable.payer, addresses), gte(paymentsTable.createdAt, since)))
+        .groupBy(day)
+    : [];
+
+  const series = buildSeries(earnedRows, spentRows);
+
+  const totalEarned = earnedRows.reduce((m, r) => m.add(Money.parse(r.total)), Money.zero());
+  const totalSpent = spentRows.reduce((m, r) => m.add(Money.parse(r.total)), Money.zero());
+  const earnedCalls = earnedRows.reduce((n, r) => n + r.calls, 0);
+  const totalCalls = spentRows.reduce((n, r) => n + r.calls, 0);
+
+  return {
+    totalEarned: totalEarned.toDecimalString(),
+    totalSpent: totalSpent.toDecimalString(),
+    totalCalls,
+    earnedCalls,
+    series,
+  };
+}
+
+interface DayAgg {
+  date: string;
+  total: string;
+  calls: number;
+}
+
+/** Fill a continuous 30-day series so gaps render as zero, not missing bars. */
+function buildSeries(earned: DayAgg[], spent: DayAgg[]): DayPoint[] {
+  const earnedMap = new Map(earned.map((r) => [r.date, r]));
+  const spentMap = new Map(spent.map((r) => [r.date, r]));
+  const out: DayPoint[] = [];
+  for (let i = DAYS - 1; i >= 0; i--) {
+    const d = new Date(Date.now() - i * 24 * 60 * 60 * 1000);
+    const date = d.toISOString().slice(0, 10);
+    const e = earnedMap.get(date);
+    const s = spentMap.get(date);
+    out.push({
+      date,
+      earned: e ? Number(e.total) : 0,
+      spent: s ? Number(s.total) : 0,
+      calls: (e?.calls ?? 0) + (s?.calls ?? 0),
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
Turns the placeholder Analytics page into real charts from the settlement ledger.

- Aggregates the ledger into a continuous **30-day series** (earnings, spend, calls), gap-filled with zeros.
- **Stat cards**: 30d earned / spent / calls.
- **Three bar charts** — Earnings, Spend, Call volume — built **dependency-free** (no recharts; keeps the bundle small, per the restraint design rule). Bars grow with a mount ease-out and show a value/date **tooltip** on hover.
- Earnings = payments for your published capabilities; spend = payments by your agent wallets. Empty series → clear placeholder.

Verified: typecheck, lint, build green; query returns real data against the live ledger.