### PR TITLE
feat(dashboard): capability reviews

### DIFF
--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { formatPrice, kindMeta, timeAgo } from "../../../../features/capabilitie
 import { UseCapabilityDialog } from "../../../../features/capabilities/use-capability-dialog";
 import { RunCapabilityDialog } from "../../../../features/agents/run-capability-dialog";
 import { listAgentsForRun } from "../../../../features/agents/queries";
+import { ReviewsSection } from "../../../../features/reviews/reviews-section";
 import { VerificationTimeline } from "../../../../features/capabilities/verification-timeline";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
@@ -177,6 +178,9 @@ export default async function CapabilityDetailPage({
           </div>
         </section>
       ) : null}
+
+      {/* Reviews */}
+      <ReviewsSection capabilityId={capability.id} slug={capability.slug} />
     </div>
   );
 }

--- a/apps/dashboard/app/(dashboard)/reviews/page.tsx
+++ b/apps/dashboard/app/(dashboard)/reviews/page.tsx
@@ -1,19 +1,51 @@
 import { Star } from "lucide-react";
 import { EmptyState } from "../../../components/empty-state";
 import { PageHeader } from "../../../components/page-header";
+import { listMyReviews } from "../../../features/reviews/queries";
+import { Stars } from "../../../features/reviews/stars";
 
-export default function ReviewsPage() {
+export const dynamic = "force-dynamic";
+
+function timeAgo(d: Date): string {
+  const s = Math.floor((Date.now() - new Date(d).getTime()) / 1000);
+  for (const [sec, label] of [
+    [86400, "d"],
+    [3600, "h"],
+    [60, "m"],
+  ] as const) {
+    if (s >= sec) return `${Math.floor(s / sec)}${label} ago`;
+  }
+  return "just now";
+}
+
+export default async function ReviewsPage() {
+  const reviews = await listMyReviews();
+
   return (
     <>
-      <PageHeader
-        title="Reviews"
-        description="Ratings and trust scores agents leave for your capabilities."
-      />
-      <EmptyState
-        icon={Star}
-        title="No reviews yet"
-        description="Once agents use your capabilities, their ratings and reviews appear here."
-      />
+      <PageHeader title="Reviews" description="Reviews you've left on capabilities you've used." />
+      {reviews.length === 0 ? (
+        <EmptyState
+          icon={Star}
+          title="No reviews yet"
+          description="After an agent pays for a capability, you can rate it from the capability page. Your reviews show up here."
+        />
+      ) : (
+        <div className="divide-y rounded-xl border">
+          {reviews.map((r) => (
+            <div key={r.id} className="space-y-1.5 p-4">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <Stars value={r.rating} />
+                  <span className="text-sm font-medium">{r.capability}</span>
+                </div>
+                <span className="text-xs text-muted-foreground">{timeAgo(r.createdAt)}</span>
+              </div>
+              {r.comment ? <p className="text-sm text-muted-foreground">{r.comment}</p> : null}
+            </div>
+          ))}
+        </div>
+      )}
     </>
   );
 }

--- a/apps/dashboard/features/reviews/actions.ts
+++ b/apps/dashboard/features/reviews/actions.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { and, eq, inArray, payments as paymentsTable, reviews, wallets } from "@tael/database";
+import { db } from "../../lib/db";
+import { getCurrentUser } from "../capabilities/current-user";
+
+const reviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().max(500).optional(),
+});
+
+/**
+ * Leave a review for a capability. Only a user whose wallet has actually paid for
+ * the capability may review it, and only once. The slug is used to revalidate the
+ * capability page.
+ */
+export async function submitReview(input: {
+  capabilityId: string;
+  slug: string;
+  rating: number;
+  comment?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  const parsed = reviewSchema.safeParse({ rating: input.rating, comment: input.comment });
+  if (!parsed.success) return { ok: false, error: "Pick a rating from 1 to 5." };
+
+  // Verify the user has paid for this capability from one of their wallets.
+  const addresses = (
+    await db.select({ address: wallets.address }).from(wallets).where(eq(wallets.ownerId, user.id))
+  ).map((r) => r.address);
+  if (!addresses.length) {
+    return { ok: false, error: "Only buyers can review. Pay for a call first." };
+  }
+  const paid = await db
+    .select({ id: paymentsTable.id })
+    .from(paymentsTable)
+    .where(
+      and(
+        eq(paymentsTable.capabilityId, input.capabilityId),
+        inArray(paymentsTable.payer, addresses),
+      ),
+    )
+    .limit(1);
+  if (!paid[0]) return { ok: false, error: "Only buyers can review. Pay for a call first." };
+
+  try {
+    await db
+      .insert(reviews)
+      .values({
+        capabilityId: input.capabilityId,
+        reviewerId: user.id,
+        rating: parsed.data.rating,
+        comment: parsed.data.comment || null,
+      })
+      .onConflictDoUpdate({
+        target: [reviews.capabilityId, reviews.reviewerId],
+        set: { rating: parsed.data.rating, comment: parsed.data.comment || null },
+      });
+  } catch (error) {
+    console.error("[reviews] submit failed:", error);
+    return { ok: false, error: "Could not save the review. Try again." };
+  }
+
+  revalidatePath(`/marketplace/${input.slug}`);
+  revalidatePath("/reviews");
+  return { ok: true };
+}

--- a/apps/dashboard/features/reviews/queries.ts
+++ b/apps/dashboard/features/reviews/queries.ts
@@ -1,0 +1,105 @@
+import "server-only";
+import {
+  and,
+  capabilities,
+  desc,
+  eq,
+  inArray,
+  payments as paymentsTable,
+  reviews,
+  users,
+  wallets,
+} from "@tael/database";
+import { db } from "../../lib/db";
+import { getCurrentUser } from "../capabilities/current-user";
+
+export interface ReviewRow {
+  id: string;
+  rating: number;
+  comment: string | null;
+  reviewer: string;
+  createdAt: Date;
+}
+
+export interface ReviewSummary {
+  average: number;
+  count: number;
+  reviews: ReviewRow[];
+}
+
+/** Reviews + average for a capability (public). Reviewer shown by wallet address. */
+export async function getCapabilityReviews(capabilityId: string): Promise<ReviewSummary> {
+  const rows = await db
+    .select({
+      id: reviews.id,
+      rating: reviews.rating,
+      comment: reviews.comment,
+      reviewer: users.walletAddress,
+      createdAt: reviews.createdAt,
+    })
+    .from(reviews)
+    .innerJoin(users, eq(reviews.reviewerId, users.id))
+    .where(eq(reviews.capabilityId, capabilityId))
+    .orderBy(desc(reviews.createdAt));
+
+  const list: ReviewRow[] = rows.map((r) => ({
+    id: r.id,
+    rating: r.rating,
+    comment: r.comment,
+    reviewer: r.reviewer,
+    createdAt: r.createdAt,
+  }));
+
+  const count = list.length;
+  const average = count ? list.reduce((s, r) => s + r.rating, 0) / count : 0;
+  return { average, count, reviews: list };
+}
+
+/** Whether the signed-in user may review this capability (paid + not yet reviewed). */
+export async function canReview(capabilityId: string): Promise<{ canReview: boolean }> {
+  const user = await getCurrentUser();
+  if (!user) return { canReview: false };
+
+  const already = await db
+    .select({ id: reviews.id })
+    .from(reviews)
+    .where(and(eq(reviews.capabilityId, capabilityId), eq(reviews.reviewerId, user.id)))
+    .limit(1);
+  if (already[0]) return { canReview: false };
+
+  // Has any of the user's wallets paid for this capability?
+  const addresses = (
+    await db.select({ address: wallets.address }).from(wallets).where(eq(wallets.ownerId, user.id))
+  ).map((r) => r.address);
+  if (!addresses.length) return { canReview: false };
+
+  const hit = await db
+    .select({ id: paymentsTable.id })
+    .from(paymentsTable)
+    .where(
+      and(eq(paymentsTable.capabilityId, capabilityId), inArray(paymentsTable.payer, addresses)),
+    )
+    .limit(1);
+
+  return { canReview: Boolean(hit[0]) };
+}
+
+/** The signed-in user's own reviews, for the Reviews page. */
+export async function listMyReviews(): Promise<
+  { id: string; rating: number; comment: string | null; capability: string; createdAt: Date }[]
+> {
+  const user = await getCurrentUser();
+  if (!user) return [];
+  return db
+    .select({
+      id: reviews.id,
+      rating: reviews.rating,
+      comment: reviews.comment,
+      capability: capabilities.name,
+      createdAt: reviews.createdAt,
+    })
+    .from(reviews)
+    .innerJoin(capabilities, eq(reviews.capabilityId, capabilities.id))
+    .where(eq(reviews.reviewerId, user.id))
+    .orderBy(desc(reviews.createdAt));
+}

--- a/apps/dashboard/features/reviews/review-form.tsx
+++ b/apps/dashboard/features/reviews/review-form.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Star } from "lucide-react";
+import { Button } from "@tael/ui";
+import { submitReview } from "./actions";
+
+/** Inline form for a buyer to leave a rating + optional comment. */
+export function ReviewForm({ capabilityId, slug }: { capabilityId: string; slug: string }) {
+  const router = useRouter();
+  const [rating, setRating] = useState(0);
+  const [hover, setHover] = useState(0);
+  const [comment, setComment] = useState("");
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function submit() {
+    setError(null);
+    startTransition(async () => {
+      const res = await submitReview({ capabilityId, slug, rating, comment });
+      if (res.ok) router.refresh();
+      else setError(res.error ?? "Could not save.");
+    });
+  }
+
+  return (
+    <div className="space-y-3 rounded-xl border p-4">
+      <p className="text-sm font-medium">Leave a review</p>
+      <div className="flex items-center gap-1">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <button
+            key={i}
+            type="button"
+            onMouseEnter={() => setHover(i)}
+            onMouseLeave={() => setHover(0)}
+            onClick={() => setRating(i)}
+            aria-label={`${i} star${i === 1 ? "" : "s"}`}
+            className="rounded p-0.5 transition-transform duration-100 ease-out active:scale-90"
+          >
+            <Star
+              className={
+                i <= (hover || rating)
+                  ? "h-6 w-6 fill-amber-400 text-amber-400"
+                  : "h-6 w-6 fill-muted text-muted-foreground/40"
+              }
+            />
+          </button>
+        ))}
+      </div>
+      <textarea
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        rows={2}
+        maxLength={500}
+        placeholder="Share how it worked (optional)…"
+        className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+      />
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <Button
+        size="sm"
+        onClick={submit}
+        disabled={pending || rating === 0}
+        className="transition-transform duration-100 ease-out active:scale-[0.97]"
+      >
+        {pending ? "Saving…" : "Submit review"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/dashboard/features/reviews/reviews-section.tsx
+++ b/apps/dashboard/features/reviews/reviews-section.tsx
@@ -1,0 +1,78 @@
+import { Star } from "lucide-react";
+import { canReview, getCapabilityReviews } from "./queries";
+import { Stars } from "./stars";
+import { ReviewForm } from "./review-form";
+
+function truncate(addr: string): string {
+  return addr.length > 14 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+}
+
+function timeAgo(d: Date): string {
+  const s = Math.floor((Date.now() - new Date(d).getTime()) / 1000);
+  for (const [sec, label] of [
+    [86400, "d"],
+    [3600, "h"],
+    [60, "m"],
+  ] as const) {
+    if (s >= sec) return `${Math.floor(s / sec)}${label} ago`;
+  }
+  return "just now";
+}
+
+/** Reviews block for a capability page: average, the buyer's form, and the list. */
+export async function ReviewsSection({
+  capabilityId,
+  slug,
+}: {
+  capabilityId: string;
+  slug: string;
+}) {
+  const [summary, eligibility] = await Promise.all([
+    getCapabilityReviews(capabilityId),
+    canReview(capabilityId),
+  ]);
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <h2 className="flex items-center gap-1.5 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          <Star className="h-4 w-4" /> Reviews
+        </h2>
+        {summary.count > 0 ? (
+          <span className="flex items-center gap-1.5 text-sm">
+            <Stars value={summary.average} />
+            <span className="font-medium tabular-nums">{summary.average.toFixed(1)}</span>
+            <span className="text-muted-foreground">
+              ({summary.count} review{summary.count === 1 ? "" : "s"})
+            </span>
+          </span>
+        ) : null}
+      </div>
+
+      {eligibility.canReview ? <ReviewForm capabilityId={capabilityId} slug={slug} /> : null}
+
+      {summary.count === 0 ? (
+        <p className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+          No reviews yet. Buyers can rate this capability after paying for a call.
+        </p>
+      ) : (
+        <div className="divide-y rounded-xl border">
+          {summary.reviews.map((r) => (
+            <div key={r.id} className="space-y-1.5 p-4">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <Stars value={r.rating} />
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {truncate(r.reviewer)}
+                  </span>
+                </div>
+                <span className="text-xs text-muted-foreground">{timeAgo(r.createdAt)}</span>
+              </div>
+              {r.comment ? <p className="text-sm text-foreground/90">{r.comment}</p> : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/dashboard/features/reviews/stars.tsx
+++ b/apps/dashboard/features/reviews/stars.tsx
@@ -1,0 +1,20 @@
+import { Star } from "lucide-react";
+
+/** Read-only star rating (supports halves via rounding for the average). */
+export function Stars({ value, size = 14 }: { value: number; size?: number }) {
+  return (
+    <span className="inline-flex items-center gap-0.5">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Star
+          key={i}
+          style={{ width: size, height: size }}
+          className={
+            i <= Math.round(value)
+              ? "fill-amber-400 text-amber-400"
+              : "fill-muted text-muted-foreground/40"
+          }
+        />
+      ))}
+    </span>
+  );
+}

--- a/packages/database/drizzle/0005_parched_misty_knight.sql
+++ b/packages/database/drizzle/0005_parched_misty_knight.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "reviews" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"capability_id" uuid NOT NULL,
+	"reviewer_id" uuid NOT NULL,
+	"rating" integer NOT NULL,
+	"comment" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "reviews_capability_reviewer_unique" UNIQUE("capability_id","reviewer_id")
+);
+--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_capability_id_capabilities_id_fk" FOREIGN KEY ("capability_id") REFERENCES "public"."capabilities"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_reviewer_id_users_id_fk" FOREIGN KEY ("reviewer_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "reviews_capability_id_idx" ON "reviews" USING btree ("capability_id");

--- a/packages/database/drizzle/meta/0005_snapshot.json
+++ b/packages/database/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,943 @@
+{
+  "id": "e67e04bc-ba85-4308-85ec-332ce6dac063",
+  "prevId": "91d035f1-090b-4532-b899-e7ba2a04e504",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_wallet_address_idx": {
+          "name": "users_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Main'"
+        },
+        "secret_enc": {
+          "name": "secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_cached": {
+          "name": "balance_cached",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallets_owner_id_idx": {
+          "name": "wallets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallets_owner_id_users_id_fk": {
+          "name": "wallets_owner_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_address_unique": {
+          "name": "wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "capability_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "capability_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "capability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "faqs": {
+          "name": "faqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pay_to": {
+          "name": "pay_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_secret_enc": {
+          "name": "upstream_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capabilities_publisher_id_idx": {
+          "name": "capabilities_publisher_id_idx",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_kind_idx": {
+          "name": "capabilities_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_visibility_idx": {
+          "name": "capabilities_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capabilities_publisher_id_users_id_fk": {
+          "name": "capabilities_publisher_id_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capabilities_slug_unique": {
+          "name": "capabilities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_wallet_id_wallets_id_fk": {
+          "name": "agents_wallet_id_wallets_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer": {
+          "name": "payer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_capability_id_idx": {
+          "name": "payments_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_agent_id_idx": {
+          "name": "payments_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payer_idx": {
+          "name": "payments_payer_idx",
+          "columns": [
+            {
+              "expression": "payer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payee_idx": {
+          "name": "payments_payee_idx",
+          "columns": [
+            {
+              "expression": "payee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_status_idx": {
+          "name": "payments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_capability_id_capabilities_id_fk": {
+          "name": "payments_capability_id_capabilities_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_agent_id_agents_id_fk": {
+          "name": "payments_agent_id_agents_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_owner_id_idx": {
+          "name": "api_keys_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_owner_id_users_id_fk": {
+          "name": "api_keys_owner_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_capability_id_idx": {
+          "name": "reviews_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_capability_id_capabilities_id_fk": {
+          "name": "reviews_capability_id_capabilities_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_reviewer_id_users_id_fk": {
+          "name": "reviews_reviewer_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_capability_reviewer_unique": {
+          "name": "reviews_capability_reviewer_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "capability_id",
+            "reviewer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.capability_kind": {
+      "name": "capability_kind",
+      "schema": "public",
+      "values": [
+        "api",
+        "mcp",
+        "agent",
+        "model",
+        "dataset"
+      ]
+    },
+    "public.capability_status": {
+      "name": "capability_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "verified"
+      ]
+    },
+    "public.capability_visibility": {
+      "name": "capability_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "private"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "settled",
+        "failed",
+        "refunded"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1784039707623,
       "tag": "0004_sad_mikhail_rasputin",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1784088551644,
+      "tag": "0005_parched_misty_knight",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -7,4 +7,5 @@ export * from "./capabilities";
 export * from "./agents";
 export * from "./payments";
 export * from "./api-keys";
+export * from "./reviews";
 export * from "./relations";

--- a/packages/database/src/schema/reviews.ts
+++ b/packages/database/src/schema/reviews.ts
@@ -1,0 +1,33 @@
+import { index, integer, pgTable, text, unique, uuid } from "drizzle-orm/pg-core";
+import { primaryId, timestamps } from "./_shared";
+import { capabilities } from "./capabilities";
+import { users } from "./users";
+
+/**
+ * A buyer's review of a capability: a 1–5 star rating and an optional comment.
+ * One review per (capability, reviewer); a reviewer may only review a capability
+ * they have paid for (enforced in the action, not the schema).
+ */
+export const reviews = pgTable(
+  "reviews",
+  {
+    id: primaryId(),
+    capabilityId: uuid("capability_id")
+      .notNull()
+      .references(() => capabilities.id, { onDelete: "cascade" }),
+    reviewerId: uuid("reviewer_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /** 1–5 stars. */
+    rating: integer("rating").notNull(),
+    comment: text("comment"),
+    ...timestamps,
+  },
+  (table) => [
+    index("reviews_capability_id_idx").on(table.capabilityId),
+    unique("reviews_capability_reviewer_unique").on(table.capabilityId, table.reviewerId),
+  ],
+);
+
+export type Review = typeof reviews.$inferSelect;
+export type NewReview = typeof reviews.$inferInsert;


### PR DESCRIPTION
Turns the placeholder Reviews page into real reviews, and adds them to the capability page.

- **New `reviews` table** (migration 0005): 1-5 stars + optional comment, unique per (capability, reviewer).
- **Buyers only**: a user can review a capability only if one of their wallets has actually **paid** for it (verified against the payments ledger), and only **once** (upsert on re-submit).
- **Capability page**: average rating + star breakdown, an inline **review form** for eligible buyers, and the list of reviews.
- **Reviews page**: the reviews the signed-in user has left.
- Design-skill polish: interactive star picker with press feedback, `tabular-nums`, restraint.

Verified: typecheck, lint, build green; migration 0005 applied to the dev DB.