### PR TITLE
docs: sharpen README tagline (pay / get paid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 **The payment layer for autonomous AI agents**
 
-Let AI agents pay for APIs, MCP tools, and data with **USDC on Stellar** —
-no cards, no accounts, no human in the loop.
+**Pay for any API. Get paid for yours.**
+
+Agents, MCP tools, and APIs supported. Payments settled in USDC on Stellar.
 
 [Read the Docs](https://taelprotocol.xyz/docs) &nbsp;·&nbsp;
 [Live app](https://app.taelprotocol.xyz) &nbsp;·&nbsp;


### PR DESCRIPTION
Follow-up to #37. That PR was merged before this one-line tagline change was pushed, so it landed on the stale branch instead of `main`. This brings it over.

Updates the README header line to:

> **Pay for any API. Get paid for yours.**
> Agents, MCP tools, and APIs supported. Payments settled in USDC on Stellar.