### PR TITLE
fix(agents): provisioning can never crash agent creation

### DIFF
--- a/apps/dashboard/features/agents/actions.ts
+++ b/apps/dashboard/features/agents/actions.ts
@@ -78,13 +78,20 @@ export async function createAgent(input: {
 
   // Provision the wallet so it can actually receive USDC (fund XLM + add the
   // trustline). If this fails, the agent still exists — it's retryable from the
-  // card, so we surface the error rather than failing the whole create.
-  const provision = await provisionHotWallet({
-    secret: keypair.secret,
-    network: STELLAR_NETWORK,
-    horizonUrl: HORIZON_URL,
-    usdcIssuer: USDC_ISSUER,
-  });
+  // card, so we surface the error rather than failing the whole create. Wrapped
+  // defensively so a provisioning fault can never crash the create action.
+  let provision: { ok: boolean; ready: boolean; error?: string };
+  try {
+    provision = await provisionHotWallet({
+      secret: keypair.secret,
+      network: STELLAR_NETWORK,
+      horizonUrl: HORIZON_URL,
+      usdcIssuer: USDC_ISSUER,
+    });
+  } catch (error) {
+    console.error("[agents] provision threw:", error);
+    provision = { ok: false, ready: false, error: "Provisioning failed. Retry from the agent." };
+  }
 
   revalidatePath("/agents");
   return {

--- a/packages/stellar/src/provision.ts
+++ b/packages/stellar/src/provision.ts
@@ -27,12 +27,20 @@ export async function provisionHotWallet(args: {
   horizonUrl: string;
   usdcIssuer: string;
 }): Promise<ProvisionResult> {
-  const keypair = Keypair.fromSecret(args.secret);
-  const server = new Horizon.Server(args.horizonUrl);
-  const passphrase = networkPassphrase(args.network);
-  const usdc = usdcAsset(args.usdcIssuer);
+  // A missing issuer would make `usdcAsset` throw ("Issuer cannot be null"); catch
+  // it here with a clear message rather than letting it escape as a 500.
+  if (!args.usdcIssuer) {
+    return { ok: false, ready: false, error: "USDC issuer is not configured (set USDC_ISSUER)." };
+  }
 
   try {
+    // Setup lives inside the try so a bad secret/issuer/network can never throw
+    // out of this function — provisioning always resolves to a ProvisionResult.
+    const keypair = Keypair.fromSecret(args.secret);
+    const server = new Horizon.Server(args.horizonUrl);
+    const passphrase = networkPassphrase(args.network);
+    const usdc = usdcAsset(args.usdcIssuer);
+
     // 1. Ensure the account exists on-chain (needs XLM). Testnet-only via friendbot.
     let account = await loadAccount(server, keypair.publicKey());
     if (!account) {


### PR DESCRIPTION
## The bug
Creating an agent on production crashed with a full-page "Application error: a server-side exception has occurred" (`/agents`, digest `1806020795`).

## Root cause
`provisionHotWallet` built the USDC asset with `usdcAsset(USDC_ISSUER)` **outside** its try/catch. On the production dashboard `USDC_ISSUER` is empty, so `new Asset("USDC", "")` throws `"Issuer cannot be null"`. `createAgent` called `provisionHotWallet` **unwrapped**, so that throw escaped the server action → the full-page server-side exception. It was production-only (env unset locally is set) and create-only (nothing else runs provisioning). Loading `/agents` was always fine — it never touches the issuer.

## Fix
- Move all of `provisionHotWallet`'s setup **inside** the try, plus an explicit empty-issuer guard, so it can never throw — it always resolves to a `ProvisionResult`.
- Wrap the `provisionHotWallet` call in `createAgent` defensively as well.

Net effect: a missing env now **degrades gracefully** (agent is created, marked "not ready", retryable from the card) instead of crashing the whole page.

## Also needed (ops, not code)
Set **`USDC_ISSUER`** (and confirm `STELLAR_NETWORK` / `STELLAR_HORIZON_URL`) on the Vercel dashboard project so provisioning actually succeeds. Setting it also stops the crash immediately, even before this ships.

## Verification
`pnpm typecheck` (11/11), `pnpm lint`, and `pnpm build` all pass. 2-file change, no schema/deps.