### PR TITLE
feat: Cards, API-key↔Card linking, and callable capabilities (API-key gateway auth)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "testnet:setup": "tsx src/scripts/testnet-setup.ts",
+    "testnet:mint": "tsx src/scripts/testnet-mint.ts",
     "pay:testnet": "tsx src/scripts/testnet-pay.ts",
     "build": "tsup",
     "typecheck": "tsc --noEmit",

--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -24,6 +24,8 @@ import {
   DbCapabilityRepository,
   type CapabilityRepository,
 } from "./modules/capabilities/capability.repository";
+import { DbApiKeyRepository } from "./modules/keys/key.repository";
+import { KeyPaymentService } from "./modules/keys/key.service";
 
 /**
  * The composition root. This is the ONE place where concrete implementations are
@@ -35,6 +37,8 @@ export interface Container {
   wallets: WalletService;
   payments: PaymentService;
   capabilities: CapabilityRepository;
+  /** Authenticates Tael API keys and auto-pays from their linked Card. */
+  keys: KeyPaymentService;
   verifier: PaymentVerifier;
   /** Payment settings the gateway needs to build x402 challenges. */
   gateway: {
@@ -110,6 +114,16 @@ export function createContainer(env: Env): Container {
   );
   const capabilities = new DbCapabilityRepository(db);
 
+  // API-key auth: resolve a key to its Card and sign payments from that Card's
+  // hot wallet, within the Card's caps. Needs the same Stellar settings the
+  // verifier uses. Without a DB, key auth simply never authenticates.
+  const keys = new KeyPaymentService(new DbApiKeyRepository(db), {
+    network: env.STELLAR_NETWORK,
+    x402Network: toPaymentNetwork(env.STELLAR_NETWORK),
+    horizonUrl: env.STELLAR_HORIZON_URL,
+    usdcIssuer: env.USDC_ISSUER,
+  });
+
   // Real on-chain settlement in production; a mock keeps dev + tests hermetic.
   const verifier = isProd ? createStellarVerifier(env) : createMockVerifier();
 
@@ -117,6 +131,7 @@ export function createContainer(env: Env): Container {
     wallets,
     payments,
     capabilities,
+    keys,
     verifier,
     gateway: {
       issuer: env.USDC_ISSUER,

--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -1,16 +1,26 @@
 import { tael } from "@tael/sdk";
-import { splitFee } from "@tael/payments";
+import { PAYMENT_REQUEST_HEADER, splitFee } from "@tael/payments";
 import { type Container } from "../../container";
 import { proxyToUpstream, isBlockedUrl } from "./upstream";
 
 /** The slice of the container the gateway needs. */
-export type GatewayDeps = Pick<Container, "capabilities" | "payments" | "verifier" | "gateway">;
+export type GatewayDeps = Pick<
+  Container,
+  "capabilities" | "payments" | "verifier" | "gateway" | "keys"
+>;
 
 function json(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "content-type": "application/json" },
   });
+}
+
+/** Extract a Tael API key from an `Authorization: Bearer tael_live_…` header. */
+function parseTaelKey(header: string | null): string | null {
+  if (!header) return null;
+  const match = /^Bearer\s+(tael_live_[A-Za-z0-9]+)$/i.exec(header.trim());
+  return match ? match[1]! : null;
 }
 
 /**
@@ -45,6 +55,30 @@ export async function handleGatewayRequest(
       : undefined;
   const split = splitFee(capability.price, fee ? deps.gateway.feeBps : 0);
 
+  // API-key path: when the caller sends a Tael key (and hasn't already attached
+  // a signed payment), authenticate it and auto-pay from its linked Card, within
+  // the Card's caps. The wallet/x402 path below still works with no key.
+  let servedRequest = request;
+  const bearer = parseTaelKey(request.headers.get("authorization"));
+  if (bearer && !request.headers.has(PAYMENT_REQUEST_HEADER)) {
+    const key = await deps.keys.authorize(bearer);
+    if (!key) return json({ error: "Invalid or revoked API key" }, 401);
+    if (!key.card) {
+      return json({ error: "This API key has no Card linked. Link one to spend from it." }, 402);
+    }
+
+    const legs = [{ to: capability.payTo, amount: split.net }];
+    if (fee) legs.push({ to: fee.payTo, amount: split.fee });
+
+    const payment = await deps.keys.payForCall({ card: key.card, total: capability.price, legs });
+    if (!payment.ok) return json({ error: payment.error }, payment.status);
+
+    const headers = new Headers(request.headers);
+    headers.set(PAYMENT_REQUEST_HEADER, payment.xPayment);
+    servedRequest = new Request(request, { headers });
+    void deps.keys.touch(key.id).catch(() => {});
+  }
+
   const paid = tael({
     price: capability.price,
     payTo: capability.payTo,
@@ -78,5 +112,5 @@ export async function handleGatewayRequest(
     },
   });
 
-  return paid(request);
+  return paid(servedRequest);
 }

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -15,7 +15,23 @@ import {
   type CapabilityRepository,
   type ServableCapability,
 } from "../capabilities/capability.repository";
+import { KeyPaymentService, type AuthorizedKey, type KeyAuthorizer } from "../keys/key.service";
 import { createServer } from "../../server";
+
+// The only novel-to-#55 dependency we can't run in a unit test is the on-chain
+// signer. Mock it so the API-key → auto-pay → proxy chain runs deterministically;
+// the real signer is the same one run-capability already exercises in prod.
+vi.mock("@tael/stellar", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, buildSignedPayment: vi.fn(async () => "SIGNED-XDR-FROM-CARD") };
+});
+
+// The Card's secret is decrypted just before signing; decryption is proven
+// elsewhere and needs ENCRYPTION_KEY, so stub it (the mocked signer ignores it).
+vi.mock("@tael/database", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, decryptSecret: vi.fn(() => "TEST-CARD-SECRET") };
+});
 
 const ADDRESS = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
@@ -37,9 +53,25 @@ function fakeCapabilities(capability: ServableCapability | null): CapabilityRepo
   };
 }
 
+/** A KeyPaymentService over a fake authorizer — for exercising the API-key path. */
+function fakeKeys(authorizer: Partial<KeyAuthorizer> = {}): KeyPaymentService {
+  const repo: KeyAuthorizer = {
+    authorize: authorizer.authorize ?? (() => Promise.resolve(null)),
+    touch: authorizer.touch ?? (() => Promise.resolve()),
+    spentSince: authorizer.spentSince ?? (() => Promise.resolve("0")),
+  };
+  return new KeyPaymentService(repo, {
+    network: "testnet",
+    x402Network: "stellar-testnet",
+    horizonUrl: "https://horizon-testnet.stellar.org",
+    usdcIssuer: ADDRESS,
+  });
+}
+
 function buildContainer(
   capability: ServableCapability | null,
   fee?: { feeAddress: string; feeBps: number },
+  keys: KeyPaymentService = fakeKeys(),
 ): {
   container: Container;
   payments: PaymentService;
@@ -49,6 +81,7 @@ function buildContainer(
     wallets: new WalletService(new InMemoryWalletRepository()),
     payments,
     capabilities: fakeCapabilities(capability),
+    keys,
     verifier: createMockVerifier(),
     gateway: {
       issuer: ADDRESS,
@@ -202,5 +235,93 @@ describe("capability gateway", () => {
     expect(res.status).toBe(502);
     expect(upstream).not.toHaveBeenCalled();
     expect(await payments.list()).toHaveLength(0);
+  });
+
+  it("401s when an API key is unknown or revoked", async () => {
+    const { container } = buildContainer(CAPABILITY); // default authorizer → null
+    const app = createServer(container);
+
+    const res = await app.request("/c/predict-age", {
+      headers: { authorization: "Bearer tael_live_deadbeef" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("402s when the API key has no linked Card", async () => {
+    const keys = fakeKeys({
+      authorize: (): Promise<AuthorizedKey | null> => Promise.resolve({ id: "k1", card: null }),
+    });
+    const { container } = buildContainer(CAPABILITY, undefined, keys);
+    const app = createServer(container);
+
+    const res = await app.request("/c/predict-age", {
+      headers: { authorization: "Bearer tael_live_abc123" },
+    });
+    expect(res.status).toBe(402);
+  });
+
+  it("403s when the call exceeds the Card's per-call cap (before signing)", async () => {
+    const keys = fakeKeys({
+      authorize: (): Promise<AuthorizedKey | null> =>
+        Promise.resolve({
+          id: "k1",
+          card: {
+            agentId: "a1",
+            address: ADDRESS,
+            secretEnc: "unused",
+            policy: { maxPerCall: "0.01", dailyLimit: "5", blockedPublishers: [] },
+          },
+        }),
+    });
+    // Capability price 0.02 > the Card's 0.01 per-call cap.
+    const { container, payments } = buildContainer(CAPABILITY, undefined, keys);
+    const app = createServer(container);
+
+    const res = await app.request("/c/predict-age", {
+      headers: { authorization: "Bearer tael_live_abc123" },
+    });
+    expect(res.status).toBe(403);
+    expect(await payments.list()).toHaveLength(0);
+  });
+
+  it("auto-pays from the linked Card and proxies when the API key is valid", async () => {
+    const upstream = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ age: 41 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", upstream);
+
+    const keys = fakeKeys({
+      authorize: (): Promise<AuthorizedKey | null> =>
+        Promise.resolve({
+          id: "k1",
+          card: {
+            agentId: "a1",
+            address: ADDRESS,
+            secretEnc: "unused",
+            policy: { maxPerCall: "1", dailyLimit: "10", blockedPublishers: [] },
+          },
+        }),
+    });
+    const { container, payments } = buildContainer(CAPABILITY, undefined, keys);
+    const app = createServer(container);
+
+    const res = await app.request("/c/predict-age", {
+      headers: { authorization: "Bearer tael_live_valid" },
+    });
+
+    // The call succeeded without the caller ever attaching a payment header…
+    expect(res.status).toBe(200);
+    expect(res.headers.get(PAYMENT_RESPONSE_HEADER)).toBeTruthy();
+    expect(await res.json()).toEqual({ age: 41 });
+
+    // …the upstream ran, and the settlement was recorded against the Card.
+    expect(upstream).toHaveBeenCalledOnce();
+    const ledger = await payments.list();
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0]).toMatchObject({ amount: "0.02", fee: "0", status: "settled" });
   });
 });

--- a/apps/api/src/modules/keys/key.repository.ts
+++ b/apps/api/src/modules/keys/key.repository.ts
@@ -1,0 +1,74 @@
+import { createHash } from "node:crypto";
+import {
+  agents,
+  and,
+  apiKeys,
+  eq,
+  gte,
+  payments,
+  sql,
+  wallets,
+  type Database,
+} from "@tael/database";
+import { type AuthorizedKey, type KeyAuthorizer } from "./key.service";
+
+/**
+ * Postgres adapter for {@link KeyAuthorizer}. Looks up a key by the SHA-256 hash
+ * of the raw token (the raw key is never stored), joins to its linked Card's
+ * wallet, and answers the daily-spend question from the payments ledger.
+ *
+ * With no database configured (tests) every method is a safe no-op, so the
+ * key path simply doesn't authenticate — the wallet/x402 path is unaffected.
+ */
+export class DbApiKeyRepository implements KeyAuthorizer {
+  constructor(private readonly db: Database | undefined) {}
+
+  async authorize(rawKey: string): Promise<AuthorizedKey | null> {
+    if (!this.db) return null;
+    const keyHash = createHash("sha256").update(rawKey).digest("hex");
+
+    const [row] = await this.db
+      .select({
+        id: apiKeys.id,
+        revokedAt: apiKeys.revokedAt,
+        agentId: apiKeys.agentId,
+        address: wallets.address,
+        secretEnc: wallets.secretEnc,
+        policy: agents.policy,
+      })
+      .from(apiKeys)
+      .leftJoin(agents, eq(apiKeys.agentId, agents.id))
+      .leftJoin(wallets, eq(agents.walletId, wallets.id))
+      .where(eq(apiKeys.keyHash, keyHash))
+      .limit(1);
+
+    if (!row || row.revokedAt) return null;
+
+    const card =
+      row.agentId && row.address && row.secretEnc
+        ? {
+            agentId: row.agentId,
+            address: row.address,
+            secretEnc: row.secretEnc,
+            policy: row.policy,
+          }
+        : null;
+    return { id: row.id, card };
+  }
+
+  async touch(keyId: string): Promise<void> {
+    if (!this.db) return;
+    await this.db.update(apiKeys).set({ lastUsedAt: new Date() }).where(eq(apiKeys.id, keyId));
+  }
+
+  async spentSince(payer: string, since: Date): Promise<string> {
+    if (!this.db) return "0";
+    const [row] = await this.db
+      .select({
+        total: sql<string>`coalesce(sum(${payments.amount} + ${payments.fee}), 0)`,
+      })
+      .from(payments)
+      .where(and(eq(payments.payer, payer), gte(payments.createdAt, since)));
+    return row?.total ?? "0";
+  }
+}

--- a/apps/api/src/modules/keys/key.service.ts
+++ b/apps/api/src/modules/keys/key.service.ts
@@ -1,0 +1,125 @@
+import { decryptSecret } from "@tael/database";
+import { Money, type SpendingPolicy } from "@tael/types";
+import { buildSignedPayment, TAEL_MEMO, type PaymentLeg, type StellarNetwork } from "@tael/stellar";
+import { encodePaymentPayload, X402_VERSION, type PaymentNetwork } from "@tael/payments";
+
+/** The Card an API key spends from, with the (server-only) signing secret. */
+export interface AuthorizedCard {
+  agentId: string;
+  address: string;
+  /** Encrypted hot-wallet secret — decrypted only here, never leaves the server. */
+  secretEnc: string;
+  policy: SpendingPolicy | null;
+}
+
+/** A resolved API key: its id, plus the linked Card (null = nothing to spend from). */
+export interface AuthorizedKey {
+  id: string;
+  card: AuthorizedCard | null;
+}
+
+/**
+ * Port: reads API keys and the payer's recent spend. Kept narrow so the gateway
+ * depends on an abstraction (real Postgres in prod, a fake in tests).
+ */
+export interface KeyAuthorizer {
+  /** Resolve a raw `tael_live_…` key to its Card, or null if unknown/revoked. */
+  authorize(rawKey: string): Promise<AuthorizedKey | null>;
+  /** Best-effort: mark the key as just used. */
+  touch(keyId: string): Promise<void>;
+  /** Total (amount + fee) this payer settled since `since` — for the daily cap. */
+  spentSince(payer: string, since: Date): Promise<string>;
+}
+
+/** Stellar signing settings the service needs to build a payment from a Card. */
+export interface KeySigningConfig {
+  network: StellarNetwork;
+  x402Network: PaymentNetwork;
+  horizonUrl: string;
+  usdcIssuer: string;
+}
+
+export type PayResult =
+  { ok: true; xPayment: string } | { ok: false; status: number; error: string };
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Turns a Tael API key into a paid request: authenticates the key, enforces the
+ * linked Card's spending policy (per-call + rolling 24h), and signs an x402
+ * payment from the Card's hot wallet. This is the server-side mirror of the
+ * dashboard's `runCapability` — the caps are enforced BEFORE anything is signed,
+ * so a key (or a runaway agent holding one) can never exceed what the owner set.
+ */
+export class KeyPaymentService {
+  constructor(
+    private readonly repo: KeyAuthorizer,
+    private readonly config: KeySigningConfig,
+  ) {}
+
+  authorize(rawKey: string): Promise<AuthorizedKey | null> {
+    return this.repo.authorize(rawKey);
+  }
+
+  touch(keyId: string): Promise<void> {
+    return this.repo.touch(keyId);
+  }
+
+  async payForCall(input: {
+    card: AuthorizedCard;
+    /** Full price the Card pays (builder net + fee), decimal USDC. */
+    total: string;
+    /** Payment legs: builder net, plus the marketplace fee when set. */
+    legs: PaymentLeg[];
+  }): Promise<PayResult> {
+    const { card, legs } = input;
+    const total = Money.parse(input.total);
+
+    if (card.policy) {
+      const maxPerCall = Money.parse(card.policy.maxPerCall);
+      if (total.isGreaterThan(maxPerCall)) {
+        return {
+          ok: false,
+          status: 403,
+          error: `Over this Card's per-call cap ($${total.toDecimalString()} > $${card.policy.maxPerCall}).`,
+        };
+      }
+      const dailyLimit = Money.parse(card.policy.dailyLimit);
+      const spent = Money.parse(
+        await this.repo.spentSince(card.address, new Date(Date.now() - DAY_MS)),
+      );
+      if (spent.add(total).isGreaterThan(dailyLimit)) {
+        return {
+          ok: false,
+          status: 403,
+          error: `Would exceed this Card's daily limit of $${card.policy.dailyLimit}.`,
+        };
+      }
+    }
+
+    try {
+      const xdr = await buildSignedPayment({
+        secret: decryptSecret(card.secretEnc),
+        network: this.config.network,
+        horizonUrl: this.config.horizonUrl,
+        usdcIssuer: this.config.usdcIssuer,
+        legs,
+        memo: TAEL_MEMO,
+      });
+      const xPayment = encodePaymentPayload({
+        x402Version: X402_VERSION,
+        scheme: "exact",
+        network: this.config.x402Network,
+        payload: { transaction: xdr },
+      });
+      return { ok: true, xPayment };
+    } catch (error) {
+      console.error("[gateway] card auto-pay signing failed:", error);
+      return {
+        ok: false,
+        status: 402,
+        error: "This Card can't pay for the call — check its USDC balance and trustline.",
+      };
+    }
+  }
+}

--- a/apps/api/src/scripts/testnet-mint.ts
+++ b/apps/api/src/scripts/testnet-mint.ts
@@ -1,0 +1,63 @@
+/**
+ * TESTNET: mint test-USDC to any address (e.g. a Card) from the test issuer.
+ *
+ * Requires ISSUER_SECRET — the secret for the account in USDC_ISSUER, printed by
+ * `testnet:setup` (it said "Save these"). The destination must already hold a
+ * USDC trustline (a Card does once it shows "Ready").
+ *
+ * Run: pnpm --filter @tael/api testnet:mint <destinationAddress> [amount]
+ *   e.g. pnpm --filter @tael/api testnet:mint GDAK...KTE6I 25
+ *
+ * Testnet only — no mainnet, no real funds.
+ */
+import {
+  Asset,
+  BASE_FEE,
+  Horizon,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { networkPassphrase } from "@tael/stellar";
+
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+
+async function main(): Promise<void> {
+  const [dest, amountArg] = process.argv.slice(2);
+  const amount = amountArg ?? "25";
+  if (!dest) {
+    throw new Error("Usage: testnet:mint <destinationAddress> [amount]");
+  }
+  const issuerSecret = process.env.ISSUER_SECRET;
+  if (!issuerSecret) {
+    throw new Error("Set ISSUER_SECRET (the secret for USDC_ISSUER, printed by testnet:setup).");
+  }
+
+  const issuer = Keypair.fromSecret(issuerSecret);
+  if (process.env.USDC_ISSUER && issuer.publicKey() !== process.env.USDC_ISSUER) {
+    throw new Error(
+      `ISSUER_SECRET is for ${issuer.publicKey()}, but USDC_ISSUER is ${process.env.USDC_ISSUER}. They must match.`,
+    );
+  }
+
+  const usdc = new Asset("USDC", issuer.publicKey());
+  const server = new Horizon.Server(HORIZON_URL);
+  const account = await server.loadAccount(issuer.publicKey());
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: networkPassphrase("testnet"),
+  })
+    .addOperation(Operation.payment({ destination: dest, asset: usdc, amount }))
+    .setTimeout(60)
+    .build();
+  tx.sign(issuer);
+
+  const res = await server.submitTransaction(tx);
+  console.log(`Minted ${amount} test-USDC → ${dest}`);
+  console.log(`  tx: ${res.hash}`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/apps/dashboard/app/(dashboard)/agents/[id]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/agents/[id]/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, Bot } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { getAgentDetail } from "../../../../features/agents/queries";
+import { CardVisual } from "../../../../features/agents/card-visual";
 import { AgentManage } from "../../../../features/agents/agent-manage";
 
 export const dynamic = "force-dynamic";
@@ -12,38 +13,42 @@ export default async function AgentDetailPage({ params }: { params: Promise<{ id
   if (!agent) notFound();
 
   return (
-    <div className="mx-auto max-w-2xl space-y-8">
+    <div className="mx-auto max-w-4xl space-y-8">
       <Link
         href="/agents"
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
       >
-        <ArrowLeft className="h-4 w-4" /> My Agents
+        <ArrowLeft className="h-4 w-4" /> Cards
       </Link>
 
-      <div className="flex items-start gap-4">
-        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-muted">
-          <Bot className="h-6 w-6" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <h1 className="text-2xl font-semibold tracking-tight">{agent.name}</h1>
-          <p className="mt-1 text-sm tabular-nums text-muted-foreground">
-            Balance: ${Number(agent.usdc).toFixed(2)} USDC
-            {agent.policy ? (
-              <>
-                {" · "}max ${agent.policy.maxPerCall}/call{" · "}${agent.policy.dailyLimit}/day
-              </>
-            ) : null}
+      <div className="grid items-center gap-6 md:grid-cols-2">
+        <CardVisual
+          name={agent.name}
+          address={agent.address}
+          usdc={agent.usdc}
+          policy={agent.policy}
+          ready={agent.ready}
+          className="w-full max-w-sm"
+        />
+        <div className="space-y-3">
+          <div>
+            <p className="text-sm text-muted-foreground">Card</p>
+            <h1 className="text-2xl font-semibold tracking-tight">{agent.name}</h1>
+          </div>
+          {agent.ready ? (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-700">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Ready to spend
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-700">
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" /> Needs provisioning
+            </span>
+          )}
+          <p className="text-sm text-muted-foreground">
+            Fund this card and set its limits below. Your agents pay from it per call, and nothing
+            exceeds the caps you set.
           </p>
         </div>
-        {agent.ready ? (
-          <span className="rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-600">
-            Ready
-          </span>
-        ) : (
-          <span className="rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-600">
-            Not ready
-          </span>
-        )}
       </div>
 
       <AgentManage agent={agent} />

--- a/apps/dashboard/app/(dashboard)/agents/page.tsx
+++ b/apps/dashboard/app/(dashboard)/agents/page.tsx
@@ -1,4 +1,4 @@
-import { Bot } from "lucide-react";
+import { CreditCard } from "lucide-react";
 import { EmptyState } from "../../../components/empty-state";
 import { PageHeader } from "../../../components/page-header";
 import { listAgentWallets } from "../../../features/agents/queries";
@@ -13,15 +13,15 @@ export default async function AgentsPage() {
   return (
     <>
       <PageHeader
-        title="My Agents"
-        description="Create agents, fund them, and scope their spending."
+        title="Cards"
+        description="Funded, capped spending cards your agents pay from. Fund one and set its limits."
         action={<CreateAgentDialog />}
       />
       {agents.length === 0 ? (
         <EmptyState
-          icon={Bot}
-          title="No agents yet"
-          description="Create an agent wallet, set a spending policy, and let it purchase capabilities autonomously."
+          icon={CreditCard}
+          title="No cards yet"
+          description="Create a card, fund it with USDC, and set spending limits. Your agents pay per call within them."
         />
       ) : (
         <AgentsList agents={agents} />

--- a/apps/dashboard/app/(dashboard)/analytics/page.tsx
+++ b/apps/dashboard/app/(dashboard)/analytics/page.tsx
@@ -44,7 +44,7 @@ export default async function AnalyticsPage() {
           <ChartCard title="Earnings" subtitle="USDC received per day">
             <BarChart data={a.series} metric="earned" color="#059669" />
           </ChartCard>
-          <ChartCard title="Spend" subtitle="USDC paid by your agents">
+          <ChartCard title="Spend" subtitle="USDC paid by your cards">
             <BarChart data={a.series} metric="spent" color="#6b7280" />
           </ChartCard>
           <ChartCard title="Call volume" subtitle="Paid calls per day" className="lg:col-span-2">

--- a/apps/dashboard/app/(dashboard)/api-keys/page.tsx
+++ b/apps/dashboard/app/(dashboard)/api-keys/page.tsx
@@ -2,28 +2,29 @@ import { KeyRound } from "lucide-react";
 import { EmptyState } from "../../../components/empty-state";
 import { PageHeader } from "../../../components/page-header";
 import { listApiKeys } from "../../../features/api-keys/queries";
+import { listCardsForPicker } from "../../../features/agents/queries";
 import { ApiKeyItem, CreateKeyButton } from "../../../features/api-keys/api-keys-manager";
 
 export const dynamic = "force-dynamic";
 
 export default async function ApiKeysPage() {
-  const keys = await listApiKeys();
+  const [keys, cards] = await Promise.all([listApiKeys(), listCardsForPicker()]);
 
   return (
     <>
       <PageHeader
         title="API Keys"
-        description="Programmatic access to the Tael API for your agents and services."
-        action={<CreateKeyButton />}
+        description="Keys authenticate your app or agent to the Tael API. Each key spends from a Card, within that Card's limits."
+        action={<CreateKeyButton cards={cards} />}
       />
       {keys.length === 0 ? (
         <EmptyState
           icon={KeyRound}
           title="No API keys yet"
-          description="Create a key to authenticate SDK and API requests from your own infrastructure."
+          description="Create a key, link it to a Card, and use it to call any capability from your own code."
         />
       ) : (
-        <div className="divide-y rounded-xl border">
+        <div className="space-y-3">
           {keys.map((row) => (
             <ApiKeyItem key={row.id} row={row} />
           ))}

--- a/apps/dashboard/app/(dashboard)/api-keys/page.tsx
+++ b/apps/dashboard/app/(dashboard)/api-keys/page.tsx
@@ -3,7 +3,7 @@ import { EmptyState } from "../../../components/empty-state";
 import { PageHeader } from "../../../components/page-header";
 import { listApiKeys } from "../../../features/api-keys/queries";
 import { listCardsForPicker } from "../../../features/agents/queries";
-import { ApiKeyItem, CreateKeyButton } from "../../../features/api-keys/api-keys-manager";
+import { ApiKeysTable, CreateKeyButton } from "../../../features/api-keys/api-keys-manager";
 
 export const dynamic = "force-dynamic";
 
@@ -24,11 +24,7 @@ export default async function ApiKeysPage() {
           description="Create a key, link it to a Card, and use it to call any capability from your own code."
         />
       ) : (
-        <div className="space-y-3">
-          {keys.map((row) => (
-            <ApiKeyItem key={row.id} row={row} />
-          ))}
-        </div>
+        <ApiKeysTable rows={keys} />
       )}
     </>
   );

--- a/apps/dashboard/app/(dashboard)/page.tsx
+++ b/apps/dashboard/app/(dashboard)/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowDownLeft, ArrowUpRight, Bot, Boxes, Store, Wallet } from "lucide-react";
+import { ArrowDownLeft, ArrowUpRight, Boxes, CreditCard, Store, Wallet } from "lucide-react";
 import { PageHeader } from "../../components/page-header";
 import { getPaymentsData } from "../../features/payments/queries";
 import { getOverviewCounts } from "../../features/overview/queries";
@@ -49,15 +49,15 @@ export default async function OverviewPage() {
       cta: "Open",
     },
     {
-      label: "Create an agent",
-      hint: "A funded hot wallet that pays per call, within limits you set.",
+      label: "Create a card",
+      hint: "A funded hot wallet your agents pay from, within limits you set.",
       done: hasAgents,
       href: "/agents",
-      cta: "Create agent",
+      cta: "Create card",
     },
     {
       label: "Run your first capability",
-      hint: "Pay for an API from your agent and settle it on-chain.",
+      hint: "Pay for an API from a card and settle it on-chain.",
       done: hasSpent,
       href: "/marketplace",
       cta: "Browse",
@@ -81,11 +81,11 @@ export default async function OverviewPage() {
     },
     {
       href: "/agents",
-      icon: Bot,
-      title: "My Agents",
+      icon: CreditCard,
+      title: "Cards",
       subtitle: hasAgents
-        ? `Manage ${plural(counts.agents, "agent", "agents")}`
-        : "Create a funded agent",
+        ? `Manage ${plural(counts.agents, "card", "cards")}`
+        : "Create a funded card",
     },
     {
       href: "/capabilities",
@@ -99,7 +99,7 @@ export default async function OverviewPage() {
       href: "/wallet",
       icon: Wallet,
       title: "Wallet",
-      subtitle: "Fund agents and set limits",
+      subtitle: "Fund cards and set limits",
     },
   ];
 

--- a/apps/dashboard/app/(dashboard)/payments/page.tsx
+++ b/apps/dashboard/app/(dashboard)/payments/page.tsx
@@ -29,7 +29,7 @@ export default async function PaymentsPage() {
         <StatCard
           label="Spent"
           value={spent}
-          hint="By your agents"
+          hint="By your cards"
           icon={<ArrowUpRight className="h-4 w-4 text-muted-foreground" />}
         />
       </div>
@@ -39,7 +39,7 @@ export default async function PaymentsPage() {
         <EmptyState
           icon={Receipt}
           title="No payments yet"
-          description="Once an agent pays for one of your capabilities, or one of your agents pays for a call, it shows up here."
+          description="Once an agent pays for one of your capabilities, or one of your cards pays for a call, it shows up here."
         />
       ) : (
         <section className="space-y-3">

--- a/apps/dashboard/app/(dashboard)/wallet/page.tsx
+++ b/apps/dashboard/app/(dashboard)/wallet/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Bot, Wallet as WalletIcon } from "lucide-react";
+import { CreditCard, Wallet as WalletIcon } from "lucide-react";
 import { PageHeader } from "../../../components/page-header";
 import { getWalletOverview } from "../../../features/wallet/queries";
 import { WalletAddress } from "../../../features/wallet/wallet-address";
@@ -17,7 +17,7 @@ export default async function WalletPage() {
     <>
       <PageHeader
         title="Wallet"
-        description="Your connected wallet and the funds across your agents."
+        description="Your connected wallet and the funds across your cards."
       />
 
       <div className="grid gap-4 lg:grid-cols-2">
@@ -45,26 +45,25 @@ export default async function WalletPage() {
           className="group flex flex-col rounded-xl border p-5 transition-[border-color,box-shadow,transform] duration-150 ease-out hover:border-foreground/20 hover:shadow-sm active:scale-[0.99]"
         >
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Bot className="h-4 w-4" /> Across your agents
+            <CreditCard className="h-4 w-4" /> Across your cards
           </div>
           <p className="mt-2 text-3xl font-semibold tabular-nums">
             ${usd(w.agentsUsdc)}{" "}
             <span className="text-base font-normal text-muted-foreground">USDC</span>
           </p>
           <p className="mt-1 text-xs text-muted-foreground">
-            {w.agentCount} {w.agentCount === 1 ? "agent" : "agents"} · manage funding
+            {w.agentCount} {w.agentCount === 1 ? "card" : "cards"} · manage funding
           </p>
         </Link>
       </div>
 
       <div className="rounded-xl border border-dashed p-5 text-sm text-muted-foreground">
-        Tael is non-custodial: funds stay in your wallet and your agents&apos; wallets. Fund an
-        agent from{" "}
+        Tael is non-custodial: funds stay in your wallet and your cards. Fund a card from{" "}
         <Link href="/agents" className="font-medium text-foreground hover:underline">
-          My Agents
+          Cards
         </Link>{" "}
-        to let it pay per call. On testnet, add the USDC trustline in your wallet to receive
-        earnings.
+        to let your agents pay per call. On testnet, add the USDC trustline in your wallet to
+        receive earnings.
       </div>
     </>
   );

--- a/apps/dashboard/features/agents/agent-manage.tsx
+++ b/apps/dashboard/features/agents/agent-manage.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Check, Copy, Trash2 } from "lucide-react";
+import { Check, Copy, TriangleAlert, Trash2 } from "lucide-react";
 import {
   Button,
   Dialog,
@@ -86,8 +86,16 @@ export function AgentManage({ agent }: { agent: AgentWallet }) {
         {agent.ready ? (
           <>
             <p className="text-sm text-muted-foreground">
-              Send USDC on Stellar to this address. The agent pays from it, up to its cap.
+              Send <span className="font-medium text-foreground">USDC</span> on Stellar to this
+              address, and your agents pay from it up to the caps below.
             </p>
+            <div className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/[0.05] px-3 py-2 text-xs text-amber-700">
+              <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>
+                Send <span className="font-semibold">USDC</span>, not XLM. XLM only covers the
+                account reserve and fees, so it won&apos;t add spendable balance.
+              </span>
+            </div>
             <div className="flex items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2.5">
               <span className="min-w-0 flex-1 break-all font-mono text-sm">{agent.address}</span>
               <button
@@ -152,9 +160,9 @@ export function AgentManage({ agent }: { agent: AgentWallet }) {
         </h2>
         <div className="flex items-center justify-between rounded-xl border border-destructive/20 p-4">
           <div>
-            <p className="text-sm font-medium">Delete this agent</p>
+            <p className="text-sm font-medium">Delete this card</p>
             <p className="text-sm text-muted-foreground">
-              Removes the agent. Any on-chain funds stay recoverable.
+              Removes the card. Any on-chain funds stay recoverable.
             </p>
           </div>
           <Button variant="outline" onClick={() => setConfirmOpen(true)}>
@@ -172,7 +180,7 @@ export function AgentManage({ agent }: { agent: AgentWallet }) {
       >
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>Delete agent</DialogTitle>
+            <DialogTitle>Delete card</DialogTitle>
             <DialogDescription>
               This removes <span className="font-medium text-foreground">{agent.name}</span>. Type{" "}
               <span className="font-mono font-semibold text-foreground">delete</span> to confirm.
@@ -199,7 +207,7 @@ export function AgentManage({ agent }: { agent: AgentWallet }) {
               onClick={remove}
               disabled={pending || confirmText.trim().toLowerCase() !== "delete"}
             >
-              {pending ? "Deleting…" : "Delete agent"}
+              {pending ? "Deleting…" : "Delete card"}
             </Button>
           </div>
         </DialogContent>

--- a/apps/dashboard/features/agents/agents-list.tsx
+++ b/apps/dashboard/features/agents/agents-list.tsx
@@ -1,64 +1,24 @@
 import Link from "next/link";
-import { Bot, ChevronRight } from "lucide-react";
 import type { AgentWallet } from "./queries";
-
-function truncate(addr: string): string {
-  return `${addr.slice(0, 6)}…${addr.slice(-6)}`;
-}
+import { CardVisual } from "./card-visual";
 
 export function AgentsList({ agents }: { agents: AgentWallet[] }) {
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
+    <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
       {agents.map((a) => (
         <Link
           key={a.agentId}
           href={`/agents/${a.agentId}`}
-          className="group rounded-xl border p-5 transition-[border-color,background-color,box-shadow,transform] duration-150 ease-out hover:border-foreground/20 hover:bg-muted/30 hover:shadow-sm active:scale-[0.99]"
+          aria-label={a.name}
+          className="block rounded-2xl outline-none transition-transform duration-150 ease-out hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:scale-[0.99]"
         >
-          <div className="flex items-start justify-between gap-3">
-            <div className="flex items-center gap-2.5">
-              <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted">
-                <Bot className="h-[18px] w-[18px]" />
-              </span>
-              <div>
-                <p className="font-medium leading-tight">{a.name}</p>
-                <p className="font-mono text-xs text-muted-foreground">{truncate(a.address)}</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              {a.ready ? (
-                <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
-                  Ready
-                </span>
-              ) : (
-                <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
-                  Not ready
-                </span>
-              )}
-              <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-            </div>
-          </div>
-
-          <div className="mt-5 flex items-end justify-between">
-            <div>
-              <p className="text-xs uppercase tracking-wide text-muted-foreground">Balance</p>
-              <p className="mt-0.5 text-xl font-semibold tabular-nums">
-                ${Number(a.usdc).toFixed(2)}{" "}
-                <span className="text-sm font-normal text-muted-foreground">USDC</span>
-              </p>
-            </div>
-            {a.policy ? (
-              <div className="text-right text-xs text-muted-foreground">
-                <p>
-                  max <span className="tabular-nums text-foreground">${a.policy.maxPerCall}</span>
-                  /call
-                </p>
-                <p>
-                  <span className="tabular-nums text-foreground">${a.policy.dailyLimit}</span>/day
-                </p>
-              </div>
-            ) : null}
-          </div>
+          <CardVisual
+            name={a.name}
+            address={a.address}
+            usdc={a.usdc}
+            policy={a.policy}
+            ready={a.ready}
+          />
         </Link>
       ))}
     </div>

--- a/apps/dashboard/features/agents/card-visual.tsx
+++ b/apps/dashboard/features/agents/card-visual.tsx
@@ -1,0 +1,142 @@
+import { cn } from "@tael/ui";
+import { formatUsdc } from "../../lib/format";
+
+// A small, curated set of premium dark gradients (black + blue-led). Each card
+// keeps a stable one, so they vary but always look good.
+const CARD_GRADIENTS = [
+  "linear-gradient(135deg, #1e3a8a 0%, #0b1220 100%)", // navy blue
+  "linear-gradient(135deg, #18181b 0%, #050506 100%)", // black
+  "linear-gradient(135deg, #1d4ed8 0%, #0a1633 100%)", // royal blue
+  "linear-gradient(135deg, #1f2937 0%, #030712 100%)", // graphite
+  "linear-gradient(135deg, #0b2540 0%, #05101f 100%)", // deep ocean
+] as const;
+
+/** Deterministically pick a premium gradient; navy when there's no seed (preview). */
+function cardGradient(seed?: string | null): string {
+  if (!seed) return CARD_GRADIENTS[0];
+  let hash = 0;
+  for (let i = 0; i < seed.length; i += 1) hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  return CARD_GRADIENTS[hash % CARD_GRADIENTS.length]!;
+}
+
+/** Mask a Stellar address into a card-number look: GDYQ •••• •••• NM55P. */
+function cardNumber(address?: string | null): string {
+  if (!address) return "•••• •••• •••• ••••";
+  return `${address.slice(0, 4)} •••• •••• ${address.slice(-5)}`;
+}
+
+/**
+ * A Card rendered as a real payment card: gradient body, balance, the wallet
+ * address styled like a card number, and the spending limits. Presentational.
+ * With `preview`, it's a live template (no address yet) that fills in as a form
+ * is typed — used in the create dialog.
+ */
+export function CardVisual({
+  name,
+  address,
+  usdc = "0",
+  policy,
+  ready = false,
+  preview = false,
+  compact = false,
+  className,
+}: {
+  name: string;
+  address?: string | null;
+  usdc?: string;
+  policy: { maxPerCall: string; dailyLimit: string } | null;
+  ready?: boolean;
+  preview?: boolean;
+  /** A small, balance-free variant — the card's identity, for inline use. */
+  compact?: boolean;
+  className?: string;
+}) {
+  if (compact) {
+    return (
+      <div
+        className={cn(
+          "relative flex aspect-[1.62/1] w-44 shrink-0 flex-col justify-between overflow-hidden rounded-xl p-3 text-white shadow-sm",
+          className,
+        )}
+        style={{ background: cardGradient(address) }}
+      >
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-black/25" />
+        <span className="relative flex items-center gap-1 text-xs font-semibold tracking-wide">
+          <span className="text-sm leading-none" style={{ fontFamily: "var(--font-display)" }}>
+            t
+          </span>
+          tael
+        </span>
+        <div className="relative">
+          <p className="font-mono text-[10px] tracking-widest text-white/80">
+            {cardNumber(address)}
+          </p>
+          <p className="mt-0.5 truncate text-[11px] font-medium uppercase tracking-wide">
+            {name || "Card"}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative flex aspect-[1.62/1] w-full flex-col justify-between overflow-hidden rounded-2xl p-5 text-white shadow-md transition-[background] duration-300",
+        className,
+      )}
+      style={{ background: cardGradient(preview ? null : address) }}
+    >
+      {/* Depth + sheen */}
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-black/25" />
+      <div
+        className="pointer-events-none absolute -right-16 -top-16 h-48 w-48 rounded-full opacity-20"
+        style={{ background: "radial-gradient(circle, #fff 0%, transparent 70%)" }}
+      />
+
+      <div className="relative flex items-start justify-between">
+        <span className="flex items-center gap-1 text-sm font-semibold tracking-wide">
+          <span className="text-lg leading-none" style={{ fontFamily: "var(--font-display)" }}>
+            t
+          </span>
+          tael
+        </span>
+        {preview ? (
+          <span className="rounded-full bg-white/15 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide backdrop-blur">
+            New
+          </span>
+        ) : (
+          <span
+            className={cn(
+              "rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide backdrop-blur",
+              ready ? "bg-white/20" : "bg-amber-400/25 text-amber-50",
+            )}
+          >
+            {ready ? "Ready" : "Not ready"}
+          </span>
+        )}
+      </div>
+
+      <div className="relative">
+        <p className="text-2xl font-semibold tabular-nums">
+          ${formatUsdc(usdc)} <span className="text-sm font-normal text-white/70">USDC</span>
+        </p>
+        <p className="mt-1 font-mono text-xs tracking-widest text-white/85">
+          {cardNumber(address)}
+        </p>
+      </div>
+
+      <div className="relative flex items-end justify-between gap-3">
+        <span className="min-w-0 truncate text-sm font-medium uppercase tracking-wide">
+          {name || <span className="text-white/50">Card name</span>}
+        </span>
+        {policy && (policy.maxPerCall || policy.dailyLimit) ? (
+          <span className="shrink-0 text-right text-[11px] leading-tight text-white/80">
+            max ${policy.maxPerCall || "0"}/call
+            <br />${policy.dailyLimit || "0"}/day
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/features/agents/card-visual.tsx
+++ b/apps/dashboard/features/agents/card-visual.tsx
@@ -26,6 +26,29 @@ function cardNumber(address?: string | null): string {
 }
 
 /**
+ * A tiny card-shaped swatch in the Card's gradient — the card's identity at a
+ * glance, for inline use in dense rows/chips where a full CardVisual is too big.
+ */
+export function CardSwatch({
+  address,
+  className,
+}: {
+  address?: string | null;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "inline-block h-5 w-8 shrink-0 rounded-[5px] shadow-sm ring-1 ring-inset ring-white/10",
+        className,
+      )}
+      style={{ background: cardGradient(address) }}
+    />
+  );
+}
+
+/**
  * A Card rendered as a real payment card: gradient body, balance, the wallet
  * address styled like a card number, and the spending limits. Presentational.
  * With `preview`, it's a live template (no address yet) that fills in as a form

--- a/apps/dashboard/features/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/features/agents/create-agent-dialog.tsx
@@ -13,6 +13,7 @@ import {
   Input,
 } from "@tael/ui";
 import { createAgent } from "./actions";
+import { CardVisual } from "./card-visual";
 
 /**
  * Create an agent with a fresh hot wallet. Two steps: (1) name + spending caps,
@@ -59,7 +60,7 @@ export function CreateAgentDialog() {
 
   return (
     <>
-      <Button onClick={() => setOpen(true)}>New agent</Button>
+      <Button onClick={() => setOpen(true)}>New card</Button>
       <Dialog
         open={open}
         onOpenChange={(o) => {
@@ -78,19 +79,21 @@ export function CreateAgentDialog() {
           ) : (
             <>
               <DialogHeader className="min-w-0">
-                <DialogTitle>New agent</DialogTitle>
+                <DialogTitle>New card</DialogTitle>
                 <DialogDescription>
-                  Tael creates a wallet the agent pays from. You fund it and set a spending cap it
-                  cannot exceed.
+                  A card is a hot wallet your agents pay from, within limits you set.
                 </DialogDescription>
               </DialogHeader>
+
+              {/* Live preview: fills in as you type below. */}
+              <CardVisual name={name} policy={{ maxPerCall, dailyLimit }} preview />
 
               <div className="min-w-0 space-y-4">
                 <Field label="Name">
                   <Input
                     value={name}
                     onChange={(e) => setName(e.target.value)}
-                    placeholder="Research agent"
+                    placeholder="Production card"
                     autoFocus
                   />
                 </Field>
@@ -106,7 +109,7 @@ export function CreateAgentDialog() {
                 {error ? <p className="text-sm text-destructive">{error}</p> : null}
 
                 <Button className="w-full" onClick={submit} disabled={pending || !name.trim()}>
-                  {pending ? "Creating…" : "Create agent wallet"}
+                  {pending ? "Creating…" : "Create card"}
                 </Button>
               </div>
             </>
@@ -146,11 +149,11 @@ function FundStep({
         <div className="flex h-11 w-11 items-center justify-center rounded-full bg-emerald-500/10">
           <Wallet className="h-5 w-5 text-emerald-600" />
         </div>
-        <DialogTitle className="pt-2">Agent created</DialogTitle>
+        <DialogTitle className="pt-2">Card created</DialogTitle>
         <DialogDescription>
           {ready
-            ? "The wallet is ready. Send it USDC (testnet for now) and the agent pays from it, up to your cap."
-            : "The agent is created, but its wallet still needs provisioning before it can receive USDC. Retry it from the agent card."}
+            ? "The card is ready. Send it USDC (testnet for now) and your agents pay from it, up to your cap."
+            : "The card is created, but it still needs provisioning before it can receive USDC. Retry it from the card."}
         </DialogDescription>
       </DialogHeader>
 

--- a/apps/dashboard/features/agents/queries.ts
+++ b/apps/dashboard/features/agents/queries.ts
@@ -57,6 +57,26 @@ export async function listAgentWallets(): Promise<AgentWallet[]> {
   );
 }
 
+export interface CardPickerOption {
+  id: string;
+  name: string;
+  policy: SpendingPolicy | null;
+}
+
+/**
+ * The user's Cards for a picker (e.g. linking an API key), DB-only — no Horizon
+ * balance calls, so it's fast to render inline in a dialog.
+ */
+export async function listCardsForPicker(): Promise<CardPickerOption[]> {
+  const user = await getCurrentUser();
+  if (!user) return [];
+  return db
+    .select({ id: agents.id, name: agents.name, policy: agents.policy })
+    .from(agents)
+    .where(eq(agents.ownerId, user.id))
+    .orderBy(desc(agents.createdAt));
+}
+
 export interface AgentOption {
   agentId: string;
   name: string;

--- a/apps/dashboard/features/agents/run-capability-dialog.tsx
+++ b/apps/dashboard/features/agents/run-capability-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
-import { Bot, Check, Play, Search, Sparkles, TriangleAlert } from "lucide-react";
+import { Check, CreditCard, Play, Search, Sparkles, TriangleAlert } from "lucide-react";
 import {
   Button,
   Dialog,
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   Input,
 } from "@tael/ui";
+import { formatUsdc } from "../../lib/format";
 import { runCapability, type RunResult } from "./run-capability";
 import type { AgentOption } from "./queries";
 
@@ -73,7 +74,7 @@ export function RunCapabilityDialog({
         onClick={() => setOpen(true)}
         className="transition-transform duration-100 ease-out active:scale-[0.97]"
       >
-        <Play className="h-4 w-4" /> Run with agent
+        <Play className="h-4 w-4" /> Run with card
       </Button>
 
       <Dialog
@@ -85,10 +86,10 @@ export function RunCapabilityDialog({
       >
         <DialogContent className="max-w-md overflow-hidden">
           <DialogHeader className="min-w-0">
-            <DialogTitle>Run with an agent</DialogTitle>
+            <DialogTitle>Run with a card</DialogTitle>
             <DialogDescription>
-              Your agent pays ${price} in USDC from its wallet and returns the result. Nothing
-              exceeds the caps you set.
+              Your card pays ${price} in USDC and returns the result. Nothing exceeds the caps you
+              set.
             </DialogDescription>
           </DialogHeader>
 
@@ -100,13 +101,13 @@ export function RunCapabilityDialog({
             />
           ) : eligible.length === 0 ? (
             <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-              No agent can pay ${price} for this call.
+              No card can pay ${price} for this call.
               <br />
               <a
                 href="/agents"
                 className="mt-1 inline-block font-medium text-foreground hover:underline"
               >
-                Fund an agent or raise its cap
+                Fund a card or raise its cap
               </a>
             </div>
           ) : (
@@ -118,7 +119,7 @@ export function RunCapabilityDialog({
                   <Input
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
-                    placeholder="Search agents…"
+                    placeholder="Search cards…"
                     className="pl-9"
                   />
                 </div>
@@ -138,7 +139,7 @@ export function RunCapabilityDialog({
                       }`}
                     >
                       <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted">
-                        <Bot className="h-4 w-4" />
+                        <CreditCard className="h-4 w-4" />
                       </span>
                       <span className="min-w-0 flex-1">
                         <span className="block truncate text-sm font-medium">{a.name}</span>
@@ -149,7 +150,7 @@ export function RunCapabilityDialog({
                         ) : null}
                       </span>
                       <span className="shrink-0 text-right text-xs tabular-nums text-muted-foreground">
-                        ${Number(a.usdc).toFixed(2)}
+                        ${formatUsdc(a.usdc)}
                       </span>
                       {active ? <Check className="h-4 w-4 shrink-0 text-foreground" /> : null}
                     </button>

--- a/apps/dashboard/features/api-keys/actions.ts
+++ b/apps/dashboard/features/api-keys/actions.ts
@@ -3,7 +3,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { and, apiKeys, eq, isNull } from "@tael/database";
+import { agents, and, apiKeys, eq, isNull } from "@tael/database";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "../capabilities/current-user";
 
@@ -21,7 +21,7 @@ export interface CreateKeyResult {
  * short prefix for identification, and return the raw key exactly once. The raw
  * key is never persisted and cannot be recovered later.
  */
-export async function createApiKey(name: string): Promise<CreateKeyResult> {
+export async function createApiKey(name: string, cardId?: string | null): Promise<CreateKeyResult> {
   const user = await getCurrentUser();
   if (!user) return { ok: false, error: "Not signed in." };
 
@@ -30,12 +30,27 @@ export async function createApiKey(name: string): Promise<CreateKeyResult> {
     return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid name." };
   }
 
+  // A key optionally funds from one of the user's Cards (agent hot wallets).
+  // Verify ownership before linking so a key can't point at someone else's Card.
+  let agentId: string | null = null;
+  if (cardId) {
+    const [card] = await db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.id, cardId), eq(agents.ownerId, user.id)))
+      .limit(1);
+    if (!card) return { ok: false, error: "That Card was not found." };
+    agentId = card.id;
+  }
+
   const raw = `tael_live_${randomBytes(24).toString("hex")}`;
   const keyHash = createHash("sha256").update(raw).digest("hex");
   const prefix = raw.slice(0, 16); // "tael_live_" + 6 chars
 
   try {
-    await db.insert(apiKeys).values({ ownerId: user.id, name: parsed.data, prefix, keyHash });
+    await db
+      .insert(apiKeys)
+      .values({ ownerId: user.id, name: parsed.data, prefix, keyHash, agentId });
   } catch (error) {
     console.error("[api-keys] create failed:", error);
     return { ok: false, error: "Could not create the key. Try again." };

--- a/apps/dashboard/features/api-keys/api-keys-manager.tsx
+++ b/apps/dashboard/features/api-keys/api-keys-manager.tsx
@@ -3,7 +3,17 @@
 import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Check, Copy, CreditCard, KeyRound, TriangleAlert } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  CreditCard,
+  KeyRound,
+  MoreHorizontal,
+  Trash2,
+  TriangleAlert,
+} from "lucide-react";
 import {
   Button,
   cn,
@@ -12,15 +22,25 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@tael/ui";
-import { CardVisual } from "../agents/card-visual";
+import { CardSwatch } from "../agents/card-visual";
 import type { CardPickerOption } from "../agents/queries";
 import { createApiKey, revokeApiKey } from "./actions";
 import type { ApiKeyRow } from "./queries";
 
 function timeAgo(d: Date | null): string {
-  if (!d) return "never";
+  if (!d) return "Never";
   const s = Math.floor((Date.now() - new Date(d).getTime()) / 1000);
   for (const [sec, label] of [
     [86400, "d"],
@@ -29,7 +49,7 @@ function timeAgo(d: Date | null): string {
   ] as const) {
     if (s >= sec) return `${Math.floor(s / sec)}${label} ago`;
   }
-  return "just now";
+  return "Just now";
 }
 
 function cardLimits(policy: { maxPerCall: string; dailyLimit: string } | null): string {
@@ -196,8 +216,91 @@ function KeyRevealed({ keyValue, onDone }: { keyValue: string; onDone: () => voi
   );
 }
 
-export function ApiKeyItem({ row }: { row: ApiKeyRow }) {
+/** The linked Card, rendered as a compact single-line chip (swatch + name + cap). */
+function CardChip({ card }: { card: NonNullable<ApiKeyRow["card"]> }) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-2">
+      <CardSwatch address={card.address} />
+      <span className="truncate text-sm font-medium">{card.name}</span>
+      {card.policy ? (
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+          · ${card.policy.maxPerCall}/call
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/** The "Funds from" cell: the linked card, or a quiet state when none is set. */
+function FundsCell({ card, revoked }: { card: ApiKeyRow["card"]; revoked: boolean }) {
+  if (card) return <CardChip card={card} />;
+  if (revoked) return <span className="text-sm text-muted-foreground">—</span>;
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-amber-600">
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+      Not linked
+    </span>
+  );
+}
+
+export function ApiKeysTable({ rows }: { rows: ApiKeyRow[] }) {
+  const active = rows.filter((r) => r.revokedAt === null);
+  const revoked = rows.filter((r) => r.revokedAt !== null);
+  const [showRevoked, setShowRevoked] = useState(false);
+  const visible = showRevoked ? [...active, ...revoked] : active;
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-hidden rounded-xl border">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="h-11 pl-4 text-xs uppercase tracking-wide">Name</TableHead>
+              <TableHead className="text-xs uppercase tracking-wide">Key</TableHead>
+              <TableHead className="text-xs uppercase tracking-wide">Funds from</TableHead>
+              <TableHead className="text-xs uppercase tracking-wide">Last used</TableHead>
+              <TableHead className="w-12 pr-4" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {visible.map((row) => (
+              <KeyRow key={row.id} row={row} />
+            ))}
+            {visible.length === 0 ? (
+              <TableRow className="hover:bg-transparent">
+                <TableCell colSpan={5} className="py-10 text-center text-sm text-muted-foreground">
+                  No active keys — all of yours are revoked.
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </div>
+
+      {revoked.length > 0 ? (
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={() => setShowRevoked((s) => !s)}
+            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {showRevoked ? (
+              <ChevronUp className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" />
+            )}
+            {showRevoked ? "Hide" : "Show"} {revoked.length} revoked{" "}
+            {revoked.length === 1 ? "key" : "keys"}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function KeyRow({ row }: { row: ApiKeyRow }) {
   const router = useRouter();
+  const [menuOpen, setMenuOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -217,93 +320,91 @@ export function ApiKeyItem({ row }: { row: ApiKeyRow }) {
   }
 
   return (
-    <div className={cn("space-y-3 rounded-xl border p-4", revoked && "opacity-70")}>
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-3">
-          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted">
+    <TableRow className={cn(revoked && "opacity-60")}>
+      <TableCell className="py-3 pl-4">
+        <div className="flex items-center gap-2.5">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
             <KeyRound className="h-4 w-4 text-muted-foreground" />
           </span>
-          <div className="min-w-0">
-            <p className="flex items-center gap-2 text-sm font-medium">
-              <span className="truncate">{row.name}</span>
-              {revoked ? (
-                <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                  Revoked
-                </span>
-              ) : (
-                <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-700">
-                  <span className="h-1 w-1 rounded-full bg-emerald-500" /> Active
-                </span>
-              )}
-            </p>
-            <p className="truncate font-mono text-xs text-muted-foreground">{row.prefix}…</p>
-          </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-3">
-          <span className="hidden text-xs text-muted-foreground sm:inline">
-            used {timeAgo(row.lastUsedAt)}
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate font-medium">{row.name}</span>
+            {revoked ? (
+              <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                Revoked
+              </span>
+            ) : (
+              <span
+                className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
+                title="Active"
+                aria-label="Active"
+              />
+            )}
           </span>
-          {!revoked ? (
-            <Button variant="outline" size="sm" onClick={() => setConfirmOpen(true)}>
-              Revoke
-            </Button>
-          ) : null}
         </div>
-      </div>
+      </TableCell>
+      <TableCell className="py-3 font-mono text-xs text-muted-foreground">{row.prefix}…</TableCell>
+      <TableCell className="py-3">
+        <FundsCell card={row.card} revoked={revoked} />
+      </TableCell>
+      <TableCell className="py-3 text-sm tabular-nums text-muted-foreground">
+        {timeAgo(row.lastUsedAt)}
+      </TableCell>
+      <TableCell className="py-3 pr-4 text-right">
+        {!revoked ? (
+          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label={`Actions for ${row.name}`}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground data-[state=open]:bg-muted"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setMenuOpen(false);
+                  setTimeout(() => setConfirmOpen(true), 0);
+                }}
+              >
+                <Trash2 className="h-4 w-4" /> Revoke key
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
 
-      {row.card ? (
-        <div className="flex items-center gap-3.5 rounded-lg border bg-muted/20 p-3">
-          <CardVisual
-            name={row.card.name}
-            address={row.card.address}
-            policy={row.card.policy}
-            compact
-          />
-          <div className="min-w-0">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-              Funds from
-            </p>
-            <p className="truncate text-sm font-medium">{row.card.name}</p>
-            <p className="truncate text-xs tabular-nums text-muted-foreground">
-              {cardLimits(row.card.policy)}
-            </p>
-          </div>
-        </div>
-      ) : (
-        <div className="flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-xs text-muted-foreground">
-          <CreditCard className="h-4 w-4 shrink-0 text-amber-500" />
-          No Card linked — calls made with this key can&apos;t be billed yet.
-        </div>
-      )}
-
-      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-destructive/10">
-              <TriangleAlert className="h-5 w-5 text-destructive" />
+        <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <div className="flex h-11 w-11 items-center justify-center rounded-full bg-destructive/10">
+                <TriangleAlert className="h-5 w-5 text-destructive" />
+              </div>
+              <DialogTitle className="pt-2">Revoke key</DialogTitle>
+              <DialogDescription>
+                Revoking <span className="font-medium text-foreground">{row.name}</span> immediately
+                stops it from working. This can&apos;t be undone.
+              </DialogDescription>
+            </DialogHeader>
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => setConfirmOpen(false)}
+                disabled={pending}
+              >
+                Cancel
+              </Button>
+              <Button variant="destructive" className="flex-1" onClick={revoke} disabled={pending}>
+                {pending ? "Revoking…" : "Revoke key"}
+              </Button>
             </div>
-            <DialogTitle className="pt-2">Revoke key</DialogTitle>
-            <DialogDescription>
-              Revoking <span className="font-medium text-foreground">{row.name}</span> immediately
-              stops it from working. This can&apos;t be undone.
-            </DialogDescription>
-          </DialogHeader>
-          {error ? <p className="text-sm text-destructive">{error}</p> : null}
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              className="flex-1"
-              onClick={() => setConfirmOpen(false)}
-              disabled={pending}
-            >
-              Cancel
-            </Button>
-            <Button variant="destructive" className="flex-1" onClick={revoke} disabled={pending}>
-              {pending ? "Revoking…" : "Revoke key"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-    </div>
+          </DialogContent>
+        </Dialog>
+      </TableCell>
+    </TableRow>
   );
 }

--- a/apps/dashboard/features/api-keys/api-keys-manager.tsx
+++ b/apps/dashboard/features/api-keys/api-keys-manager.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Check, Copy, KeyRound, TriangleAlert } from "lucide-react";
+import { Check, Copy, CreditCard, KeyRound, TriangleAlert } from "lucide-react";
 import {
   Button,
+  cn,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -12,6 +14,8 @@ import {
   DialogTitle,
   Input,
 } from "@tael/ui";
+import { CardVisual } from "../agents/card-visual";
+import type { CardPickerOption } from "../agents/queries";
 import { createApiKey, revokeApiKey } from "./actions";
 import type { ApiKeyRow } from "./queries";
 
@@ -28,16 +32,22 @@ function timeAgo(d: Date | null): string {
   return "just now";
 }
 
-export function CreateKeyButton() {
+function cardLimits(policy: { maxPerCall: string; dailyLimit: string } | null): string {
+  return policy ? `max $${policy.maxPerCall}/call · $${policy.dailyLimit}/day` : "no limits set";
+}
+
+export function CreateKeyButton({ cards }: { cards: CardPickerOption[] }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
+  const [cardId, setCardId] = useState<string>(cards[0]?.id ?? "");
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [createdKey, setCreatedKey] = useState<string | null>(null);
 
   function reset() {
     setName("");
+    setCardId(cards[0]?.id ?? "");
     setError(null);
     setCreatedKey(null);
   }
@@ -45,7 +55,7 @@ export function CreateKeyButton() {
   function submit() {
     setError(null);
     startTransition(async () => {
-      const res = await createApiKey(name);
+      const res = await createApiKey(name, cardId || null);
       if (res.ok && res.key) {
         setCreatedKey(res.key);
         router.refresh();
@@ -73,8 +83,7 @@ export function CreateKeyButton() {
               <DialogHeader className="min-w-0">
                 <DialogTitle>Create API key</DialogTitle>
                 <DialogDescription>
-                  Name it so you can recognize it later. You&apos;ll see the key once, right after
-                  it&apos;s created.
+                  Name it, choose the Card it spends from, and you&apos;ll see the key once.
                 </DialogDescription>
               </DialogHeader>
               <div className="min-w-0 space-y-4">
@@ -90,6 +99,39 @@ export function CreateKeyButton() {
                     }}
                   />
                 </label>
+
+                <div className="space-y-1.5">
+                  <span className="text-sm font-medium">Funds from</span>
+                  <p className="text-xs text-muted-foreground">
+                    Which Card pays for calls made with this key.
+                  </p>
+                  {cards.length === 0 ? (
+                    <p className="rounded-lg border border-dashed px-3 py-2.5 text-xs text-muted-foreground">
+                      No Cards yet.{" "}
+                      <Link href="/agents" className="font-medium text-foreground underline">
+                        Create a Card
+                      </Link>{" "}
+                      to fund this key. You can also make the key now and link one later.
+                    </p>
+                  ) : (
+                    <div className="relative">
+                      <CreditCard className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                      <select
+                        value={cardId}
+                        onChange={(e) => setCardId(e.target.value)}
+                        className="h-9 w-full rounded-md border border-input bg-transparent pl-9 pr-3 text-sm"
+                      >
+                        {cards.map((c) => (
+                          <option key={c.id} value={c.id}>
+                            {c.name} — {cardLimits(c.policy)}
+                          </option>
+                        ))}
+                        <option value="">No Card (link one later)</option>
+                      </select>
+                    </div>
+                  )}
+                </div>
+
                 {error ? <p className="text-sm text-destructive">{error}</p> : null}
                 <Button
                   className="w-full transition-transform duration-100 ease-out active:scale-[0.99]"
@@ -175,34 +217,64 @@ export function ApiKeyItem({ row }: { row: ApiKeyRow }) {
   }
 
   return (
-    <div className="flex items-center gap-3 px-4 py-3">
-      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
-        <KeyRound className="h-4 w-4 text-muted-foreground" />
-      </span>
-      <div className="min-w-0 flex-1">
-        <p className="flex items-center gap-2 text-sm font-medium">
-          {row.name}
-          {revoked ? (
-            <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-              Revoked
-            </span>
+    <div className={cn("space-y-3 rounded-xl border p-4", revoked && "opacity-70")}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted">
+            <KeyRound className="h-4 w-4 text-muted-foreground" />
+          </span>
+          <div className="min-w-0">
+            <p className="flex items-center gap-2 text-sm font-medium">
+              <span className="truncate">{row.name}</span>
+              {revoked ? (
+                <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Revoked
+                </span>
+              ) : (
+                <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-700">
+                  <span className="h-1 w-1 rounded-full bg-emerald-500" /> Active
+                </span>
+              )}
+            </p>
+            <p className="truncate font-mono text-xs text-muted-foreground">{row.prefix}…</p>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          <span className="hidden text-xs text-muted-foreground sm:inline">
+            used {timeAgo(row.lastUsedAt)}
+          </span>
+          {!revoked ? (
+            <Button variant="outline" size="sm" onClick={() => setConfirmOpen(true)}>
+              Revoke
+            </Button>
           ) : null}
-        </p>
-        <p className="truncate font-mono text-xs text-muted-foreground">{row.prefix}…</p>
+        </div>
       </div>
-      <p className="shrink-0 text-right text-xs text-muted-foreground">
-        used {timeAgo(row.lastUsedAt)}
-      </p>
-      {!revoked ? (
-        <Button
-          variant="outline"
-          size="sm"
-          className="shrink-0"
-          onClick={() => setConfirmOpen(true)}
-        >
-          Revoke
-        </Button>
-      ) : null}
+
+      {row.card ? (
+        <div className="flex items-center gap-3.5 rounded-lg border bg-muted/20 p-3">
+          <CardVisual
+            name={row.card.name}
+            address={row.card.address}
+            policy={row.card.policy}
+            compact
+          />
+          <div className="min-w-0">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Funds from
+            </p>
+            <p className="truncate text-sm font-medium">{row.card.name}</p>
+            <p className="truncate text-xs tabular-nums text-muted-foreground">
+              {cardLimits(row.card.policy)}
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-xs text-muted-foreground">
+          <CreditCard className="h-4 w-4 shrink-0 text-amber-500" />
+          No Card linked — calls made with this key can&apos;t be billed yet.
+        </div>
+      )}
 
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent className="max-w-md">

--- a/apps/dashboard/features/api-keys/queries.ts
+++ b/apps/dashboard/features/api-keys/queries.ts
@@ -1,5 +1,6 @@
 import "server-only";
-import { apiKeys, desc, eq } from "@tael/database";
+import { agents, apiKeys, desc, eq, wallets } from "@tael/database";
+import type { SpendingPolicy } from "@tael/types";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "../capabilities/current-user";
 
@@ -10,13 +11,20 @@ export interface ApiKeyRow {
   lastUsedAt: Date | null;
   revokedAt: Date | null;
   createdAt: Date;
+  /** The Card this key spends from, if linked. */
+  card: {
+    id: string;
+    name: string;
+    address: string | null;
+    policy: SpendingPolicy | null;
+  } | null;
 }
 
-/** List the signed-in user's API keys. Never selects the hash. */
+/** List the signed-in user's API keys with their linked Card. Never selects the hash. */
 export async function listApiKeys(): Promise<ApiKeyRow[]> {
   const user = await getCurrentUser();
   if (!user) return [];
-  return db
+  const rows = await db
     .select({
       id: apiKeys.id,
       name: apiKeys.name,
@@ -24,8 +32,26 @@ export async function listApiKeys(): Promise<ApiKeyRow[]> {
       lastUsedAt: apiKeys.lastUsedAt,
       revokedAt: apiKeys.revokedAt,
       createdAt: apiKeys.createdAt,
+      cardId: agents.id,
+      cardName: agents.name,
+      cardPolicy: agents.policy,
+      cardAddress: wallets.address,
     })
     .from(apiKeys)
+    .leftJoin(agents, eq(apiKeys.agentId, agents.id))
+    .leftJoin(wallets, eq(agents.walletId, wallets.id))
     .where(eq(apiKeys.ownerId, user.id))
     .orderBy(desc(apiKeys.createdAt));
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    prefix: r.prefix,
+    lastUsedAt: r.lastUsedAt,
+    revokedAt: r.revokedAt,
+    createdAt: r.createdAt,
+    card: r.cardId
+      ? { id: r.cardId, name: r.cardName ?? "Card", address: r.cardAddress, policy: r.cardPolicy }
+      : null,
+  }));
 }

--- a/apps/dashboard/features/navigation/nav.config.ts
+++ b/apps/dashboard/features/navigation/nav.config.ts
@@ -1,8 +1,8 @@
 import {
   BarChart3,
-  Bot,
   Boxes,
   Building2,
+  CreditCard,
   KeyRound,
   LayoutDashboard,
   ArrowLeftRight,
@@ -41,7 +41,7 @@ export const navGroups: NavGroup[] = [
     label: "Build",
     items: [
       { label: "My Capabilities", href: "/capabilities", icon: Boxes },
-      { label: "My Agents", href: "/agents", icon: Bot },
+      { label: "Cards", href: "/agents", icon: CreditCard },
     ],
   },
   {

--- a/apps/dashboard/features/overview/getting-started.tsx
+++ b/apps/dashboard/features/overview/getting-started.tsx
@@ -26,7 +26,7 @@ export function GettingStarted({ steps }: { steps: SetupStep[] }) {
       <CardHeader className="flex-row items-center justify-between gap-4 space-y-0">
         <div className="space-y-1">
           <CardTitle className="text-base">Get started</CardTitle>
-          <CardDescription>A few steps to your first agent payment.</CardDescription>
+          <CardDescription>A few steps to your first card payment.</CardDescription>
         </div>
         <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
           {done} of {steps.length}

--- a/apps/dashboard/lib/format.ts
+++ b/apps/dashboard/lib/format.ts
@@ -1,0 +1,10 @@
+/**
+ * Format a USDC amount for display. Keeps precision for micro-amounts (< $1),
+ * since Tael runs on fractions-of-a-cent payments — rounding those to 2 decimals
+ * would show a funded card as "$0.00".
+ */
+export function formatUsdc(value: string | number): string {
+  const n = Number(value) || 0;
+  const max = n !== 0 && Math.abs(n) < 1 ? 7 : 2;
+  return n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: max });
+}

--- a/packages/database/drizzle/0009_hard_annihilus.sql
+++ b/packages/database/drizzle/0009_hard_annihilus.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "api_keys" ADD COLUMN "agent_id" uuid;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/database/drizzle/meta/0009_snapshot.json
+++ b/packages/database/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,989 @@
+{
+  "id": "b4271a22-1835-4275-96df-31ab2f31a790",
+  "prevId": "c8628af8-a103-4538-ad6e-cf342fe3c310",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_wallet_address_idx": {
+          "name": "users_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Main'"
+        },
+        "secret_enc": {
+          "name": "secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_cached": {
+          "name": "balance_cached",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallets_owner_id_idx": {
+          "name": "wallets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallets_owner_id_users_id_fk": {
+          "name": "wallets_owner_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_address_unique": {
+          "name": "wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "capability_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "capability_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "capability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "faqs": {
+          "name": "faqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pay_to": {
+          "name": "pay_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_secret_enc": {
+          "name": "upstream_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capabilities_publisher_id_idx": {
+          "name": "capabilities_publisher_id_idx",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_kind_idx": {
+          "name": "capabilities_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_visibility_idx": {
+          "name": "capabilities_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capabilities_publisher_id_users_id_fk": {
+          "name": "capabilities_publisher_id_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capabilities_slug_unique": {
+          "name": "capabilities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_wallet_id_wallets_id_fk": {
+          "name": "agents_wallet_id_wallets_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer": {
+          "name": "payer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_capability_id_idx": {
+          "name": "payments_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_agent_id_idx": {
+          "name": "payments_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payer_idx": {
+          "name": "payments_payer_idx",
+          "columns": [
+            {
+              "expression": "payer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payee_idx": {
+          "name": "payments_payee_idx",
+          "columns": [
+            {
+              "expression": "payee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_status_idx": {
+          "name": "payments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_tx_hash_unique": {
+          "name": "payments_tx_hash_unique",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_capability_id_capabilities_id_fk": {
+          "name": "payments_capability_id_capabilities_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_agent_id_agents_id_fk": {
+          "name": "payments_agent_id_agents_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_owner_id_idx": {
+          "name": "api_keys_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_owner_id_users_id_fk": {
+          "name": "api_keys_owner_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_agent_id_agents_id_fk": {
+          "name": "api_keys_agent_id_agents_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_capability_id_idx": {
+          "name": "reviews_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_capability_id_capabilities_id_fk": {
+          "name": "reviews_capability_id_capabilities_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_reviewer_id_users_id_fk": {
+          "name": "reviews_reviewer_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_capability_reviewer_unique": {
+          "name": "reviews_capability_reviewer_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "capability_id",
+            "reviewer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.capability_kind": {
+      "name": "capability_kind",
+      "schema": "public",
+      "values": [
+        "api",
+        "mcp",
+        "agent",
+        "model",
+        "dataset"
+      ]
+    },
+    "public.capability_status": {
+      "name": "capability_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "verified"
+      ]
+    },
+    "public.capability_visibility": {
+      "name": "capability_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "private"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "settled",
+        "failed",
+        "refunded"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1784178998035,
       "tag": "0008_massive_rictor",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1784183943146,
+      "tag": "0009_hard_annihilus",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/api-keys.ts
+++ b/packages/database/src/schema/api-keys.ts
@@ -1,6 +1,7 @@
 import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { primaryId, timestamps } from "./_shared";
 import { users } from "./users";
+import { agents } from "./agents";
 
 /**
  * Programmatic access tokens for a user's agents/services. Only a hash of the
@@ -13,6 +14,8 @@ export const apiKeys = pgTable(
     ownerId: uuid("owner_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
+    /** The Card (agent hot wallet) this key spends from; null = no funding source. */
+    agentId: uuid("agent_id").references(() => agents.id, { onDelete: "set null" }),
     name: text("name").notNull().default("Default"),
     /** First few chars of the key, e.g. "tael_live_abcd", shown in the dashboard. */
     prefix: text("prefix").notNull(),

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "catalog:",
+    "@radix-ui/react-dropdown-menu": "catalog:",
     "@radix-ui/react-slot": "catalog:",
     "@radix-ui/react-tooltip": "catalog:",
     "class-variance-authority": "catalog:",

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import { cn } from "../lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+function DropdownMenuShortcut({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />
+  );
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -37,6 +37,15 @@ export {
 } from "./components/sheet";
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "./components/tooltip";
 export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+} from "./components/dropdown-menu";
+export {
   Sidebar,
   SidebarContent,
   SidebarFooter,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@radix-ui/react-dialog':
       specifier: ^1.1.4
       version: 1.1.18
+    '@radix-ui/react-dropdown-menu':
+      specifier: ^2.1.6
+      version: 2.1.20
     '@radix-ui/react-slot':
       specifier: ^1.1.1
       version: 1.3.0
@@ -540,6 +543,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: 'catalog:'
         version: 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu':
+        specifier: 'catalog:'
+        version: 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot':
         specifier: 'catalog:'
         version: 1.3.0(@types/react@19.2.17)(react@19.2.7)
@@ -1842,6 +1848,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.12':
+    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.3':
     resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
     peerDependencies:
@@ -1882,6 +1901,15 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.14':
     resolution: {integrity: sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==}
     peerDependencies:
@@ -1897,6 +1925,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.15':
     resolution: {integrity: sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.20':
+    resolution: {integrity: sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1930,6 +1971,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-focus-scope@1.1.12':
+    resolution: {integrity: sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.2':
     resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
     peerDependencies:
@@ -1937,6 +1991,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.20':
+    resolution: {integrity: sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popper@1.3.3':
@@ -2004,6 +2071,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.15':
+    resolution: {integrity: sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.3.0':
     resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
     peerDependencies:
@@ -2046,6 +2126,15 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.3':
     resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -7126,6 +7215,18 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-collection@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -7166,6 +7267,12 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-direction@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-dismissable-layer@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -7192,6 +7299,21 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-dropdown-menu@2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -7209,12 +7331,49 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-focus-scope@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@radix-ui/react-menu@2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-popper@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -7271,6 +7430,25 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-roving-focus@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
@@ -7315,6 +7493,12 @@ snapshots:
   '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,6 +95,7 @@ catalog:
   next-themes: ^0.4.4
   "@radix-ui/react-slot": ^1.1.1
   "@radix-ui/react-dialog": ^1.1.4
+  "@radix-ui/react-dropdown-menu": ^2.1.6
   "@radix-ui/react-tooltip": ^1.1.6
 
   # --- Types ---


### PR DESCRIPTION
## Cards, API keys, and callable capabilities

Turns Tael from a marketplace you can *look at* into one you can `curl`. Four commits:

### Dashboard
- **Cards** — funded, capped spending wallets rendered as real payment cards (list, detail, live create preview). `formatUsdc` fixes micro-balances rounding to `$0.00`; USDC-not-XLM funding warning; `testnet:mint` script.
- **Link each API key to a funding Card** — pick the Card a key spends from; migration `0009` adds `api_keys.agent_id`.
- **API Keys as a columns table** — Name / Key / Funds from / Last used / actions, the way Stripe/OpenAI/Vercel do it. Linked Card shows as a small gradient swatch + cap; revoked keys hidden behind a quiet toggle. Adds a shared `DropdownMenu` to `@tael/ui`.

### API (#55)
- **Authenticate API keys in the gateway + auto-pay from their Card.** A capability can be called with just a Tael key:
  ```bash
  curl https://tael-protocol.onrender.com/c/<slug> -H "Authorization: Bearer tael_live_…"
  ```
  The gateway resolves the key's linked Card, enforces its policy (per-call + rolling 24h) **before** signing, signs an x402 payment from the Card's hot wallet, and proxies. Errors: `401` unknown/revoked, `402` no Card / can't pay, `403` over a cap. The wallet/x402 path is unchanged.

## Verification
- Typecheck 11/11, full lint (only the pre-existing `wallet-kit.ts` warning), all tests green.
- New gateway tests cover auth, policy caps, and the full **auto-pay → verify → proxy → settled** chain (signer/decrypt mocked; same signer `run-capability` already runs in prod).
- No new env vars. Migration `0009` already applied to the live DB.

## Notes / follow-ups
- Testnet only (mainnet is #57).
- Next: a copy-paste `curl` quickstart on each capability page.
- Unblocks the chat.tael epic (#42, sub-issues #43–#49).
