### PR TITLE
feat: discovery catalog (GET /capabilities) + Tael buy-side SDK + clean slugs

### DIFF
--- a/apps/api/src/modules/capabilities/capability.repository.ts
+++ b/apps/api/src/modules/capabilities/capability.repository.ts
@@ -1,4 +1,4 @@
-import { and, capabilities, eq, ne, type Database } from "@tael/database";
+import { and, capabilities, desc, eq, ilike, ne, or, type Database } from "@tael/database";
 import { TaelError } from "@tael/types";
 
 /**
@@ -19,6 +19,31 @@ export interface ServableCapability {
   upstreamSecretEnc: string | null;
 }
 
+/** A capability as a buyer discovers it in the public catalog. No secrets. */
+export interface CatalogCapability {
+  slug: string;
+  name: string;
+  description: string;
+  kind: string;
+  /** HTTP method the capability expects, from its spec (e.g. "GET" | "POST"). */
+  method: string | null;
+  /** Headline price per call, decimal USDC string. */
+  price: string;
+  logoUrl: string | null;
+  /** True when the capability has passed Tael's verify flow (trust badge). */
+  verified: boolean;
+}
+
+/** Filters for the public catalog. */
+export interface CatalogQuery {
+  /** Free-text match against name + description. */
+  q?: string;
+  /** Restrict to one kind (api | mcp | agent | model | dataset). */
+  kind?: string;
+  /** Page size (default 50, max 100). */
+  limit?: number;
+}
+
 /** Port: read capabilities that are eligible to be called through the gateway. */
 export interface CapabilityRepository {
   /**
@@ -26,6 +51,13 @@ export interface CapabilityRepository {
    * be `verified`, and not be `private`. Returns null otherwise.
    */
   findServableBySlug(slug: string): Promise<ServableCapability | null>;
+
+  /**
+   * List public, verified capabilities for the discovery catalog, newest first.
+   * Never returns secrets or the upstream URL — only what a buyer needs to pick
+   * and call one.
+   */
+  listCatalog(query?: CatalogQuery): Promise<CatalogCapability[]>;
 }
 
 /** Postgres-backed adapter over @tael/database. */
@@ -61,5 +93,53 @@ export class DbCapabilityRepository implements CapabilityRepository {
       .limit(1);
 
     return row ?? null;
+  }
+
+  async listCatalog(query: CatalogQuery = {}): Promise<CatalogCapability[]> {
+    if (!this.db) {
+      throw new TaelError(
+        "INTERNAL",
+        "DATABASE_URL is not configured — the gateway cannot read capabilities.",
+      );
+    }
+
+    const limit = Math.min(Math.max(query.limit ?? 50, 1), 100);
+    const filters = [eq(capabilities.status, "verified"), eq(capabilities.visibility, "public")];
+    if (query.kind)
+      filters.push(
+        eq(capabilities.kind, query.kind as (typeof capabilities.kind.enumValues)[number]),
+      );
+    if (query.q) {
+      const like = `%${query.q}%`;
+      const match = or(ilike(capabilities.name, like), ilike(capabilities.description, like));
+      if (match) filters.push(match);
+    }
+
+    const rows = await this.db
+      .select({
+        slug: capabilities.slug,
+        name: capabilities.name,
+        description: capabilities.description,
+        kind: capabilities.kind,
+        spec: capabilities.spec,
+        price: capabilities.price,
+        logoUrl: capabilities.logoUrl,
+        status: capabilities.status,
+      })
+      .from(capabilities)
+      .where(and(...filters))
+      .orderBy(desc(capabilities.createdAt))
+      .limit(limit);
+
+    return rows.map((r) => ({
+      slug: r.slug,
+      name: r.name,
+      description: r.description,
+      kind: r.kind,
+      method: (r.spec as { method?: string } | null)?.method ?? null,
+      price: r.price,
+      logoUrl: r.logoUrl,
+      verified: r.status === "verified",
+    }));
   }
 }

--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -24,6 +24,25 @@ function parseTaelKey(header: string | null): string | null {
 }
 
 /**
+ * Serve the public discovery catalog: `GET /capabilities?q=&kind=&limit=`.
+ * Lists public, verified capabilities with only the fields a buyer needs to
+ * pick and call one — no upstream URLs, no secrets.
+ */
+export async function handleCatalogRequest(
+  deps: Pick<GatewayDeps, "capabilities">,
+  request: Request,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const limitParam = url.searchParams.get("limit");
+  const items = await deps.capabilities.listCatalog({
+    q: url.searchParams.get("q") ?? undefined,
+    kind: url.searchParams.get("kind") ?? undefined,
+    limit: limitParam ? Number(limitParam) : undefined,
+  });
+  return json({ capabilities: items }, 200);
+}
+
+/**
  * Serve a capability over x402. Loads the capability, then hands the request to
  * the SDK's `tael()` wrapper: no payment → `402` challenge; valid payment →
  * verify, proxy to the real upstream, record the settled payment, and return the

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -50,6 +50,23 @@ function fakeCapabilities(capability: ServableCapability | null): CapabilityRepo
   return {
     findServableBySlug: (slug) =>
       Promise.resolve(capability && slug === capability.slug ? capability : null),
+    listCatalog: () =>
+      Promise.resolve(
+        capability
+          ? [
+              {
+                slug: capability.slug,
+                name: capability.name,
+                description: "",
+                kind: "api",
+                method: "GET",
+                price: capability.price,
+                logoUrl: null,
+                verified: true,
+              },
+            ]
+          : [],
+      ),
   };
 }
 
@@ -282,6 +299,25 @@ describe("capability gateway", () => {
     });
     expect(res.status).toBe(403);
     expect(await payments.list()).toHaveLength(0);
+  });
+
+  it("lists the public catalog at GET /capabilities", async () => {
+    const { container } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+
+    const res = await app.request("/capabilities");
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      capabilities: { slug: string; name: string; price: string; verified: boolean }[];
+    };
+    expect(body.capabilities).toHaveLength(1);
+    expect(body.capabilities[0]).toMatchObject({
+      slug: "predict-age",
+      name: "Age Prediction API",
+      price: "0.02",
+      verified: true,
+    });
   });
 
   it("auto-pays from the linked Card and proxies when the API key is valid", async () => {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,7 +2,7 @@ import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { type Container } from "./container";
-import { handleGatewayRequest } from "./modules/gateway/gateway.handler";
+import { handleCatalogRequest, handleGatewayRequest } from "./modules/gateway/gateway.handler";
 import { createContextFactory } from "./trpc/context";
 import { appRouter } from "./trpc/router";
 
@@ -17,6 +17,10 @@ export function createServer(container: Container) {
   app.use("*", cors());
 
   app.get("/health", (c) => c.json({ status: "ok", service: "tael-api" }));
+
+  // Public discovery catalog: list/search verified capabilities (no secrets).
+  // Lets the SDK do `tael.list()` / `tael.search(...)` and buyers browse.
+  app.get("/capabilities", (c) => handleCatalogRequest(container, c.req.raw));
 
   // The capability gateway: agents call `/c/:slug` and pay per call over x402.
   // Public + unauthenticated by design — the payment *is* the authentication.

--- a/apps/dashboard/features/capabilities/actions.ts
+++ b/apps/dashboard/features/capabilities/actions.ts
@@ -1,12 +1,12 @@
 "use server";
 
-import { randomBytes } from "node:crypto";
 import { revalidatePath } from "next/cache";
 import {
   and,
   capabilities,
   encryptSecret,
   eq,
+  ilike,
   type CapabilityFaq,
   type CapabilitySpec,
 } from "@tael/database";
@@ -71,6 +71,24 @@ export async function generateQuestions(input: {
 }
 
 /**
+ * Turn a base slug into a unique one, keeping the clean name the publisher chose.
+ * Returns `cat-facts` when free; only falls back to `cat-facts-2`, `-3`, … when
+ * the name is already taken. Keeps public URLs human — no random suffix.
+ */
+async function uniqueSlug(base: string): Promise<string> {
+  const rows = await db
+    .select({ slug: capabilities.slug })
+    .from(capabilities)
+    .where(ilike(capabilities.slug, `${base}%`));
+  const taken = new Set(rows.map((r) => r.slug));
+  if (!taken.has(base)) return base;
+  for (let i = 2; ; i += 1) {
+    const candidate = `${base}-${i}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/**
  * Step 3 (final): publish with the tested responses + FAQ answers. Each request
  * stores its real captured response as the public sample. Headline price is the
  * cheapest operation.
@@ -100,7 +118,7 @@ export async function publishCapability(
       price: op.price,
     })),
   };
-  const slug = `${slugify(input.name)}-${randomBytes(3).toString("hex")}`;
+  const slug = await uniqueSlug(slugify(input.name));
 
   try {
     await db.insert(capabilities).values({

--- a/apps/dashboard/features/capabilities/schema.ts
+++ b/apps/dashboard/features/capabilities/schema.ts
@@ -59,7 +59,7 @@ export function minPrice(operations: OperationInput[]): string {
   );
 }
 
-/** Build a URL-safe slug from a name (unique suffix appended in the action). */
+/** Build a URL-safe slug from a name (the action makes it unique on collision). */
 export function slugify(name: string): string {
   return name
     .toLowerCase()

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -18,6 +18,7 @@ export {
   desc,
   asc,
   sql,
+  ilike,
   inArray,
   isNull,
   isNotNull,

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { PAYMENT_RESPONSE_HEADER } from "@tael/payments";
+import { Tael, TaelError } from "./client";
+
+const KEY = "tael_live_test123";
+
+/** A fetch stub that captures the last request and returns a canned response. */
+function stubFetch(response: Response) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    return response;
+  }) as unknown as typeof fetch;
+  return { fn, calls };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function receiptHeader(): string {
+  const receipt = { txHash: "abc", network: "stellar-testnet", settledAt: "now", payer: "G..." };
+  return Buffer.from(JSON.stringify(receipt), "utf8").toString("base64");
+}
+
+describe("Tael client", () => {
+  it("requires an apiKey", () => {
+    expect(() => new Tael({ apiKey: "" })).toThrow(/apiKey/);
+  });
+
+  it("GETs a capability with the key attached and returns data directly", async () => {
+    const { fn, calls } = stubFetch(jsonResponse({ fact: "cats purr" }));
+    const tael = new Tael({ apiKey: KEY, baseUrl: "https://gw.test", fetch: fn });
+
+    const data = await tael.get<{ fact: string }>("cat-facts");
+
+    expect(data).toEqual({ fact: "cats purr" });
+    expect(calls[0]?.url).toBe("https://gw.test/c/cat-facts");
+    expect(calls[0]?.init?.method).toBe("GET");
+    const headers = new Headers(calls[0]?.init?.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${KEY}`);
+  });
+
+  it("POSTs a JSON body and decodes the settlement receipt", async () => {
+    const { fn, calls } = stubFetch(
+      jsonResponse(
+        { ok: true },
+        {
+          headers: {
+            "content-type": "application/json",
+            [PAYMENT_RESPONSE_HEADER]: receiptHeader(),
+          },
+        },
+      ),
+    );
+    const tael = new Tael({ apiKey: KEY, baseUrl: "https://gw.test", fetch: fn });
+
+    const res = await tael.call("claude", { method: "POST", body: { prompt: "hi" } });
+
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ ok: true });
+    expect(res.receipt?.txHash).toBe("abc");
+    expect(calls[0]?.init?.body).toBe(JSON.stringify({ prompt: "hi" }));
+    const headers = new Headers(calls[0]?.init?.headers);
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  it("throws TaelError with the gateway's message on a non-2xx", async () => {
+    const { fn } = stubFetch(
+      jsonResponse({ error: "Over this Card's per-call cap." }, { status: 403 }),
+    );
+    const tael = new Tael({ apiKey: KEY, baseUrl: "https://gw.test", fetch: fn });
+
+    await expect(tael.get("expensive")).rejects.toMatchObject({
+      name: "TaelError",
+      status: 403,
+      message: "Over this Card's per-call cap.",
+    });
+    await expect(tael.get("expensive")).rejects.toBeInstanceOf(TaelError);
+  });
+
+  it("lists and searches the catalog", async () => {
+    const { fn, calls } = stubFetch(
+      jsonResponse({ capabilities: [{ slug: "weather-now", name: "Weather Now" }] }),
+    );
+    const tael = new Tael({ apiKey: KEY, baseUrl: "https://gw.test", fetch: fn });
+
+    const results = await tael.search("weather", { limit: 10 });
+
+    expect(results[0]?.slug).toBe("weather-now");
+    const url = new URL(calls[0]!.url);
+    expect(url.pathname).toBe("/capabilities");
+    expect(url.searchParams.get("q")).toBe("weather");
+    expect(url.searchParams.get("limit")).toBe("10");
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,0 +1,189 @@
+// The buy-side SDK: call any Tael capability with one API key.
+//
+// Where `tael()` (see ./tael) is what a builder wraps their service in to *sell*
+// a capability, `Tael` is what a developer uses to *buy* — it points at the
+// gateway, attaches your key, and returns the result. Payment happens server
+// side from the Card your key is linked to, within that Card's caps; you never
+// sign a transaction here.
+//
+//   import { Tael } from "@tael/sdk";
+//   const tael = new Tael({ apiKey: process.env.TAEL_KEY! });
+//   const joke = await tael.get("cat-facts");
+//   const reply = await tael.post("claude", { prompt: "hi" });
+import { PAYMENT_RESPONSE_HEADER, type SettlementReceipt } from "@tael/payments";
+
+/** Where the gateway lives. Override for local dev or a self-hosted deployment. */
+const DEFAULT_BASE_URL = "https://tael-protocol.onrender.com";
+
+export interface TaelClientOptions {
+  /** Your `tael_live_…` key. Get one in the dashboard under API Keys. */
+  apiKey: string;
+  /** Gateway base URL. Defaults to the hosted gateway. */
+  baseUrl?: string;
+  /** Inject a `fetch` implementation (tests, non-standard runtimes). */
+  fetch?: typeof fetch;
+}
+
+/** A capability as returned by the discovery catalog. No secrets. */
+export interface CatalogCapability {
+  slug: string;
+  name: string;
+  description: string;
+  kind: string;
+  method: string | null;
+  price: string;
+  logoUrl: string | null;
+  verified: boolean;
+}
+
+export interface ListOptions {
+  /** Free-text search over name + description. */
+  q?: string;
+  /** Restrict to one kind (api | mcp | agent | model | dataset). */
+  kind?: string;
+  /** Page size (max 100). */
+  limit?: number;
+}
+
+export interface CallOptions {
+  method?: string;
+  /** Request body. Objects are JSON-encoded; strings are sent as-is. */
+  body?: unknown;
+  /** Extra headers to forward to the capability. */
+  headers?: Record<string, string>;
+  /** Query string appended to the capability URL. */
+  query?: Record<string, string | number>;
+}
+
+/** The full result of a paid call: the data, the HTTP status, and the receipt. */
+export interface TaelResponse<T = unknown> {
+  data: T;
+  status: number;
+  /** Decoded `X-PAYMENT-RESPONSE`: proof the payment settled on-chain. */
+  receipt: SettlementReceipt | null;
+}
+
+/** Thrown when a capability call fails (non-2xx). Carries status + body. */
+export class TaelError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: unknown,
+  ) {
+    super(message);
+    this.name = "TaelError";
+  }
+}
+
+function decodeReceipt(header: string | null): SettlementReceipt | null {
+  if (!header) return null;
+  try {
+    const json =
+      typeof atob === "function" ? atob(header) : Buffer.from(header, "base64").toString("utf8");
+    return JSON.parse(json) as SettlementReceipt;
+  } catch {
+    return null;
+  }
+}
+
+export class Tael {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: TaelClientOptions) {
+    if (!options.apiKey) throw new Error("Tael: `apiKey` is required.");
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    const f = options.fetch ?? globalThis.fetch;
+    if (!f) throw new Error("Tael: no `fetch` available — pass one via options.fetch.");
+    this.fetchImpl = f;
+  }
+
+  /** Call a capability and return the full response (data + status + receipt). */
+  async call<T = unknown>(slug: string, options: CallOptions = {}): Promise<TaelResponse<T>> {
+    const url = new URL(`${this.baseUrl}/c/${encodeURIComponent(slug)}`);
+    for (const [k, v] of Object.entries(options.query ?? {})) url.searchParams.set(k, String(v));
+
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${this.apiKey}`,
+      ...options.headers,
+    };
+
+    let body: string | undefined;
+    if (options.body !== undefined && options.body !== null) {
+      if (typeof options.body === "string") {
+        body = options.body;
+      } else {
+        body = JSON.stringify(options.body);
+        headers["content-type"] ??= "application/json";
+      }
+    }
+
+    const res = await this.fetchImpl(url.toString(), {
+      method: options.method ?? (body ? "POST" : "GET"),
+      headers,
+      body,
+    });
+
+    const data = (await parseBody(res)) as T;
+    if (!res.ok) {
+      const message =
+        (data as { error?: string })?.error ?? `Tael call to "${slug}" failed (${res.status}).`;
+      throw new TaelError(message, res.status, data);
+    }
+    return {
+      data,
+      status: res.status,
+      receipt: decodeReceipt(res.headers.get(PAYMENT_RESPONSE_HEADER)),
+    };
+  }
+
+  /** GET a capability and return its data directly. */
+  async get<T = unknown>(
+    slug: string,
+    options: Omit<CallOptions, "method" | "body"> = {},
+  ): Promise<T> {
+    return (await this.call<T>(slug, { ...options, method: "GET" })).data;
+  }
+
+  /** POST to a capability and return its data directly. */
+  async post<T = unknown>(
+    slug: string,
+    body?: unknown,
+    options: Omit<CallOptions, "method" | "body"> = {},
+  ): Promise<T> {
+    return (await this.call<T>(slug, { ...options, method: "POST", body })).data;
+  }
+
+  /** List public, verified capabilities from the discovery catalog. */
+  async list(options: ListOptions = {}): Promise<CatalogCapability[]> {
+    const url = new URL(`${this.baseUrl}/capabilities`);
+    if (options.q) url.searchParams.set("q", options.q);
+    if (options.kind) url.searchParams.set("kind", options.kind);
+    if (options.limit) url.searchParams.set("limit", String(options.limit));
+
+    const res = await this.fetchImpl(url.toString());
+    const data = (await parseBody(res)) as { capabilities?: CatalogCapability[] };
+    if (!res.ok) throw new TaelError("Failed to list capabilities.", res.status, data);
+    return data.capabilities ?? [];
+  }
+
+  /** Search the catalog by free text — shorthand for `list({ q })`. */
+  search(query: string, options: Omit<ListOptions, "q"> = {}): Promise<CatalogCapability[]> {
+    return this.list({ ...options, q: query });
+  }
+}
+
+/** Parse a response as JSON when it says so, else as text. */
+async function parseBody(res: Response): Promise<unknown> {
+  const type = res.headers.get("content-type") ?? "";
+  if (type.includes("application/json")) {
+    try {
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+  return res.text();
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,9 +1,23 @@
 // @tael/sdk — the developer-facing SDK.
-// Wrap any Fetch-style handler with x402 payments in one call. Framework
-// agnostic (Hono, Next.js route handlers, Bun, Deno, Workers) because it speaks
-// the Web `Request`/`Response` standard. Composes @tael/payments; the settlement
-// verifier is injected so the SDK stays chain-agnostic.
+//
+// Two sides:
+//  - `tael()` (sell): wrap any Fetch-style handler with x402 payments in one
+//    call. Framework agnostic (Hono, Next.js, Bun, Deno, Workers) because it
+//    speaks the Web `Request`/`Response` standard.
+//  - `Tael` (buy): call any capability on the marketplace with one API key —
+//    the gateway pays from the Card your key is linked to, within its caps.
 export * from "./tael";
+
+// The buy-side client: call any capability with one API key.
+export {
+  Tael,
+  TaelError,
+  type TaelClientOptions,
+  type TaelResponse,
+  type CallOptions,
+  type ListOptions,
+  type CatalogCapability,
+} from "./client";
 
 // Re-export the payment primitives SDK users commonly need at the call site.
 export {


### PR DESCRIPTION
## Discovery + the buy-side SDK

Makes capabilities **discoverable and callable from code** — the natural follow-up to API-key gateway auth (#50). Three commits:

### `GET /capabilities` — discovery catalog (api)
A read-only endpoint so buyers/the SDK can find capabilities without knowing slugs:
```
GET /capabilities            → all public, verified capabilities
GET /capabilities?q=weather  → search name + description
GET /capabilities?kind=model → filter by kind
```
Returns only buyer-facing fields — never upstream URLs or secrets.

### `Tael` — buy-side SDK client (sdk)
One key, any capability:
```ts
import { Tael } from "@tael/sdk";
const tael = new Tael({ apiKey: process.env.TAEL_KEY });
const facts = await tael.get("cat-facts");
const reply = await tael.post("claude", { prompt: "hi" });
const found = await tael.search("weather");
```
Attaches the key, picks GET/POST, decodes the on-chain receipt, throws a typed `TaelError` on failure. Sits alongside the existing sell-side `tael()` wrapper.

### Clean capability slugs (dashboard)
Publishing now keeps the human name — `/cat-facts`, not `/cat-facts-ee8103`. Uniqueness kept by only appending `-2`, `-3`… on collision.

## Verification
- format clean, typecheck 11/11, lint clean (only the pre-existing `wallet-kit.ts` warning), all 6 test packages pass.
- New tests: catalog endpoint + every SDK method (mocked fetch).

## Notes / next
- Existing capabilities keep their old suffixed slugs (only new publishes are clean); we can backfill later if wanted.
- Next phase: **upstream auth mapping** (so Claude/Grok/partners like Nebula can be added as capabilities) + **streaming**.
