### PR TITLE
docs: capability model — become a capability + call a capability

### DIFF
--- a/apps/web/app/docs/_components/docs-sidebar.tsx
+++ b/apps/web/app/docs/_components/docs-sidebar.tsx
@@ -16,7 +16,12 @@ export const SECTIONS = [
     items: [
       { label: "Accept payments", href: "/docs/accept-payments" },
       { label: "Wrap an API", href: "/docs/wrap-an-api" },
+      { label: "Call a capability", href: "/docs/call-a-capability" },
     ],
+  },
+  {
+    title: "Partners",
+    items: [{ label: "Become a capability", href: "/docs/become-a-capability" }],
   },
   {
     title: "SDKs",

--- a/apps/web/app/docs/become-a-capability/page.tsx
+++ b/apps/web/app/docs/become-a-capability/page.tsx
@@ -1,0 +1,169 @@
+import { A, Callout, Code, CodeBlock, DocPage, H2, P, Ul } from "../_components/doc-page";
+
+const TOC = [
+  { label: "The model", href: "#model" },
+  { label: "What you can list", href: "#kinds" },
+  { label: "What you need", href: "#requirements" },
+  { label: "Pricing & fees", href: "#pricing" },
+  { label: "Publish it", href: "#publish" },
+  { label: "Onboarding prompt", href: "#prompt" },
+];
+
+/** The prompt a partner pastes into their own LLM to map their product onto
+ *  Tael's capability model and produce a manifest to hand back to us. */
+const PARTNER_PROMPT = `You are helping me put my product on Tael, the payment layer for AI agents.
+I want to list my product as one or more capabilities on Tael, so that anyone can use it
+with a single Tael API key and pay me per call in USDC on Stellar. Your job is to map my
+product onto Tael's capability model and produce a concrete capability manifest that I can
+hand to the Tael team.
+
+## How Tael works
+- A capability is any service reached through a paid URL of the form https://<tael-gateway>/c/<slug>.
+- A buyer calls that URL with a Tael API key. Tael verifies the USDC payment on Stellar, then
+  proxies the call to my real endpoint and returns my response. I get paid per call automatically,
+  and I never touch the buyer's wallet.
+- The requirement is simple: I expose a normal HTTP endpoint (GET or POST) that Tael calls on each
+  request. Tael injects my upstream credentials on the server, so buyers never see my key.
+- A capability can be any of these kinds: api, mcp, agent, model, or dataset.
+- I set a price per call in USDC. Tael takes a marketplace fee of about 1% in the same transaction,
+  and I keep the rest, settled to a Stellar address I choose.
+
+## What I want from you
+1. If I have not told you already, ask me what my product does and how it is accessed (its endpoints,
+   tools, and authentication).
+2. Find the largest surface I can reasonably offer. List every endpoint, tool, dataset, or model I
+   could expose as a capability, because each one is another way for people to pay me.
+3. For each capability, produce one row of a manifest with these fields:
+   - name, kind (api, mcp, agent, model, or dataset), and a one-line description
+   - the endpoint URL and its HTTP method
+   - how Tael should authenticate to my upstream (Bearer, x-api-key, a custom header, or none)
+   - the request shape (its parameters or body) and a sample response
+   - a suggested price per call in USDC, with a short reason
+4. Flag anything that does not fit a plain paid HTTP endpoint, such as streaming, stateful sessions,
+   MCP over HTTP, or on-chain signing, and suggest how to adapt it.
+5. Ask me for my Stellar payout address, which is where the USDC will settle.
+
+## Output
+Return the completed manifest as a table, followed by a short note on anything that needs a custom
+adapter. Optimize for the most value: list everything worth exposing, not just a single endpoint.`;
+
+export default function BecomeACapabilityPage() {
+  return (
+    <DocPage
+      eyebrow="Partners"
+      title="List your product as a capability"
+      lead="Bring your API, MCP server, agent, model, or dataset to Tael. Anyone can reach it with a single key and pay for it by the call in USDC, and your earnings settle to you automatically."
+      toc={TOC}
+    >
+      <H2 id="model">The model</H2>
+      <P>
+        A <strong>capability</strong> is any service reached through a single paid URL. You keep
+        running your product exactly as it is today, and Tael sits in front of it as a metered
+        gateway that handles payment on every request.
+      </P>
+      <Ul>
+        <li>A buyer calls your capability with one Tael API key.</li>
+        <li>
+          Tael verifies the USDC payment on Stellar, then <strong>proxies the call</strong> to your
+          real endpoint and returns your response unchanged.
+        </li>
+        <li>
+          You are paid per call, in USDC, automatically. You never see the buyer&apos;s wallet, and
+          the buyer never sees your upstream key.
+        </li>
+      </Ul>
+      <P>On the buyer&apos;s side, the entire integration is a single line of code:</P>
+      <CodeBlock
+        title="the buyer's code"
+        code={`import { Tael } from "@tael/sdk";
+const tael = new Tael({ apiKey: process.env.TAEL_KEY });
+
+// your product, called and paid for with one key:
+const result = await tael.post("your-product", { ...input });`}
+      />
+      <Callout>
+        The only real requirement is a normal, callable HTTP endpoint. If your users can already
+        reach it with a request today, Tael can put a price on it.
+      </Callout>
+
+      <H2 id="kinds">What you can list</H2>
+      <P>A capability can take any of the following forms. Choose whatever fits your product.</P>
+      <Ul>
+        <li>
+          <strong>API.</strong> Any REST or HTTP endpoint, such as a weather service or an OCR
+          engine.
+        </li>
+        <li>
+          <strong>MCP.</strong> A Model Context Protocol server or a single tool from one.
+        </li>
+        <li>
+          <strong>Agent.</strong> A hosted agent that accepts a task and returns a result.
+        </li>
+        <li>
+          <strong>Model.</strong> An inference endpoint, for example a language or image model.
+        </li>
+        <li>
+          <strong>Dataset.</strong> A paid data feed or query endpoint.
+        </li>
+      </Ul>
+
+      <H2 id="requirements">What you need</H2>
+      <Ul>
+        <li>
+          <strong>A paid HTTP endpoint</strong> that Tael can call on each request, using{" "}
+          <Code>GET</Code> or <Code>POST</Code>.
+        </li>
+        <li>
+          <strong>Upstream authentication, if any.</strong> If your endpoint needs a key, you hand
+          it to Tael once, and Tael injects it on the server for every call. Buyers never see it.
+        </li>
+        <li>
+          <strong>A price per call</strong> in USDC, where fractions of a cent are perfectly fine.
+        </li>
+        <li>
+          <strong>A Stellar payout address</strong> where your earnings land.
+        </li>
+      </Ul>
+      <Callout>
+        Streaming, stateful sessions, and on-chain signing do not fit the plain request and response
+        model out of the box, but they are supported through a custom adapter. Note them in your
+        manifest and we will map them with you.
+      </Callout>
+
+      <H2 id="pricing">Pricing &amp; fees</H2>
+      <P>
+        <strong>You set the price per call.</strong> Whatever you choose becomes the amount a buyer
+        pays in the <Code>402</Code> challenge for your capability.
+      </P>
+      <P>
+        Tael charges a <strong>marketplace fee of 1%</strong> on each call, taken in the very same
+        USDC transaction. Because settlement is non-custodial, your share lands directly at your
+        payout address. On a <Code>$0.010</Code> call, for instance, you keep <Code>$0.0099</Code>{" "}
+        and Tael takes <Code>$0.0001</Code>. There are no monthly fees and no minimums.
+      </P>
+
+      <H2 id="publish">Publish it</H2>
+      <P>
+        Sign in to the dashboard with your Stellar wallet, open <strong>My Capabilities</strong>,
+        and add one. You paste your endpoint, set a price, run a live test against it, and answer a
+        short set of verification questions. Once it is verified, it appears in the marketplace and
+        becomes callable by any Tael key. The <A href="/docs/quickstart">Quickstart</A> walks
+        through the whole flow.
+      </P>
+
+      <H2 id="prompt">Onboarding prompt</H2>
+      <P>
+        The quickest way to map your product onto Tael is to paste the prompt below into your own
+        LLM, whether that is Claude, ChatGPT, or anything else. It interviews you, uncovers every
+        part of your product worth exposing, and produces a <strong>capability manifest</strong> you
+        can hand straight back to us, so we can list you with the widest surface and the least back
+        and forth.
+      </P>
+      <CodeBlock title="paste into your LLM" lang="bash" code={PARTNER_PROMPT} />
+      <P>
+        Send the finished manifest to the team and we will get your capabilities live. The more you
+        expose, the more ways people have to pay you.
+      </P>
+    </DocPage>
+  );
+}

--- a/apps/web/app/docs/call-a-capability/page.tsx
+++ b/apps/web/app/docs/call-a-capability/page.tsx
@@ -1,0 +1,107 @@
+import { A, Callout, Code, CodeBlock, DocPage, H2, P, Ul } from "../_components/doc-page";
+
+const TOC = [
+  { label: "Setup", href: "#setup" },
+  { label: "Call a capability", href: "#call" },
+  { label: "Discover capabilities", href: "#discover" },
+  { label: "Receipts", href: "#receipts" },
+  { label: "Errors", href: "#errors" },
+];
+
+export default function CallACapabilityPage() {
+  return (
+    <DocPage
+      eyebrow="Guides"
+      title="Call a capability"
+      lead="Reach any capability on Tael from your own code with a single API key. Payment happens automatically from the Card your key is linked to, so you never sign a transaction yourself."
+      toc={TOC}
+    >
+      <H2 id="setup">Setup</H2>
+      <P>
+        Create a key in the dashboard under <strong>API Keys</strong> and link it to a funded{" "}
+        <strong>Card</strong>. That Card&apos;s caps, both per call and per day, bound everything
+        the key is allowed to spend.
+      </P>
+      <CodeBlock title="terminal" code={`pnpm add @tael/sdk`} />
+      <CodeBlock
+        title="setup.ts"
+        code={`import { Tael } from "@tael/sdk";
+
+const tael = new Tael({ apiKey: process.env.TAEL_KEY! });`}
+      />
+
+      <H2 id="call">Call a capability</H2>
+      <P>
+        Reference a capability by its slug. Both <Code>get</Code> and <Code>post</Code> return the
+        response data directly, so there is nothing else to unwrap.
+      </P>
+      <CodeBlock
+        title="call.ts"
+        code={`const facts = await tael.get("cat-facts");
+const reply = await tael.post("claude", { prompt: "Summarize this." });
+
+// works for any capability, any method, with one key.`}
+      />
+      <Callout>
+        You do not sign anything. Tael pays from the Card your key is linked to, stays within its
+        caps, and hands you back the result.
+      </Callout>
+
+      <H2 id="discover">Discover capabilities</H2>
+      <P>List or search the marketplace to find slugs and prices at runtime.</P>
+      <CodeBlock
+        title="discover.ts"
+        code={`const all = await tael.list();               // every capability
+const found = await tael.search("weather");  // by name or description
+
+// each: { slug, name, description, kind, method, price, logoUrl, verified }`}
+      />
+
+      <H2 id="receipts">Receipts</H2>
+      <P>
+        Reach for <Code>call()</Code> when you want the full response: the data, the HTTP status,
+        and the on-chain settlement receipt.
+      </P>
+      <CodeBlock
+        title="receipt.ts"
+        code={`const res = await tael.call("cat-facts");
+res.data;            // the capability's response
+res.status;          // HTTP status
+res.receipt?.txHash; // proof the USDC payment settled on Stellar`}
+      />
+
+      <H2 id="errors">Errors</H2>
+      <P>
+        When a call fails, the client throws a <Code>TaelError</Code> that carries the
+        gateway&apos;s message and its status code.
+      </P>
+      <Ul>
+        <li>
+          <Code>401</Code> means the key is unknown or has been revoked.
+        </li>
+        <li>
+          <Code>402</Code> means the linked Card holds no USDC, or no Card is linked at all.
+        </li>
+        <li>
+          <Code>403</Code> means the call exceeds the Card&apos;s per-call or daily cap.
+        </li>
+      </Ul>
+      <CodeBlock
+        title="errors.ts"
+        code={`import { Tael, TaelError } from "@tael/sdk";
+
+try {
+  await tael.post("claude", { prompt: "hi" });
+} catch (err) {
+  if (err instanceof TaelError) {
+    console.error(err.status, err.message); // e.g. 403 "Over this Card's per-call cap."
+  }
+}`}
+      />
+      <P>
+        Would you rather publish your own capability? See{" "}
+        <A href="/docs/become-a-capability">List your product as a capability</A>.
+      </P>
+    </DocPage>
+  );
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -11,6 +11,8 @@ const paths = [
   "/docs/authentication",
   "/docs/accept-payments",
   "/docs/wrap-an-api",
+  "/docs/call-a-capability",
+  "/docs/become-a-capability",
   "/docs/sdk/node",
   "/docs/sdk/curl",
   ...posts.map((post) => `/blog/${post.slug}`),


### PR DESCRIPTION
Two new docs pages: **Become a capability** (the partner model, kinds, requirements, 1% pricing, publish flow, and a copy-paste onboarding prompt) and **Call a capability** (the buy-side @tael/sdk client). Wired into the docs sidebar and sitemap. Rich prose, no em dashes.