### PR TITLE
feat: capabilities expose many priced operations (/c/<slug>/<op>)

### DIFF
--- a/apps/api/src/modules/capabilities/capability.repository.ts
+++ b/apps/api/src/modules/capabilities/capability.repository.ts
@@ -1,6 +1,16 @@
 import { and, capabilities, desc, eq, ilike, ne, or, type Database } from "@tael/database";
 import { TaelError } from "@tael/types";
 
+/** One callable operation of a capability, resolved for the gateway. */
+export interface ServableOperation {
+  /** URL-safe handle, addressed at `/c/<slug>/<opSlug>`. */
+  slug: string;
+  /** Path appended to the capability's upstreamUrl (empty = the base URL). */
+  path: string;
+  /** Price per call for this operation, decimal USDC string. */
+  price: string;
+}
+
 /**
  * The subset of a capability the gateway needs to serve and charge for a call.
  * Deliberately narrow — the gateway never needs the publisher, FAQs, or spec.
@@ -9,7 +19,7 @@ export interface ServableCapability {
   id: string;
   slug: string;
   name: string;
-  /** Headline price per call, decimal USDC string. */
+  /** Headline price per call, decimal USDC string (used for `/c/<slug>`). */
   price: string;
   /** Stellar address that receives settlement. */
   payTo: string;
@@ -17,6 +27,18 @@ export interface ServableCapability {
   upstreamUrl: string;
   /** Encrypted upstream API key (AES-256-GCM), or null if the upstream is open. */
   upstreamSecretEnc: string | null;
+  /** Priced operations, for `/c/<slug>/<op>`. Empty when the capability is flat. */
+  operations: ServableOperation[];
+}
+
+/** Lowercase, URL-safe slug from a name (mirrors the dashboard's slugify). */
+function opSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
 }
 
 /** A capability as a buyer discovers it in the public catalog. No secrets. */
@@ -81,6 +103,7 @@ export class DbCapabilityRepository implements CapabilityRepository {
         payTo: capabilities.payTo,
         upstreamUrl: capabilities.upstreamUrl,
         upstreamSecretEnc: capabilities.upstreamSecretEnc,
+        spec: capabilities.spec,
       })
       .from(capabilities)
       .where(
@@ -92,7 +115,13 @@ export class DbCapabilityRepository implements CapabilityRepository {
       )
       .limit(1);
 
-    return row ?? null;
+    if (!row) return null;
+    const operations: ServableOperation[] = (row.spec.operations ?? []).map((op) => ({
+      slug: op.slug ?? opSlug(op.name),
+      path: op.path ?? "",
+      price: op.price,
+    }));
+    return { ...row, operations };
   }
 
   async listCatalog(query: CatalogQuery = {}): Promise<CatalogCapability[]> {

--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -1,7 +1,7 @@
 import { tael } from "@tael/sdk";
 import { PAYMENT_REQUEST_HEADER, splitFee } from "@tael/payments";
 import { type Container } from "../../container";
-import { proxyToUpstream, isBlockedUrl } from "./upstream";
+import { proxyToUpstream, isBlockedUrl, resolveUpstreamUrl } from "./upstream";
 
 /** The slice of the container the gateway needs. */
 export type GatewayDeps = Pick<
@@ -55,15 +55,41 @@ export async function handleGatewayRequest(
   deps: GatewayDeps,
   slug: string,
   request: Request,
+  operationSlug?: string,
 ): Promise<Response> {
   const capability = await deps.capabilities.findServableBySlug(slug);
   if (!capability) {
     return json({ error: "Capability not found" }, 404);
   }
 
+  // Resolve the operation (if any): its own price and upstream path. A capability
+  // can expose many priced operations at `/c/<slug>/<op>`; `/c/<slug>` uses the
+  // headline price and the base URL, exactly as before.
+  let price = capability.price;
+  let targetUrl = capability.upstreamUrl;
+  if (operationSlug) {
+    const operation = capability.operations.find((o) => o.slug === operationSlug);
+    if (!operation) {
+      return json({ error: "Operation not found" }, 404);
+    }
+    price = operation.price;
+    targetUrl = resolveUpstreamUrl(capability.upstreamUrl, operation.path);
+  }
+
   // Never take payment for a call we won't be able to make.
-  if (isBlockedUrl(capability.upstreamUrl)) {
+  if (isBlockedUrl(targetUrl)) {
     return json({ error: "Capability upstream is unavailable" }, 502);
+  }
+
+  // Free operation (price 0): no payment gate at all — just proxy and return.
+  // Lets a capability mix free reads (balance, quote) with paid actions (swap).
+  if (Number(price) <= 0) {
+    try {
+      return await proxyToUpstream(capability, request, targetUrl);
+    } catch (error) {
+      console.error("[gateway] free upstream call failed:", error);
+      return json({ error: "Upstream call failed" }, 502);
+    }
   }
 
   // Take the marketplace fee out of the price (non-custodial: it's paid directly
@@ -72,7 +98,7 @@ export async function handleGatewayRequest(
     deps.gateway.feeAddress && deps.gateway.feeBps > 0
       ? { payTo: deps.gateway.feeAddress, bps: deps.gateway.feeBps }
       : undefined;
-  const split = splitFee(capability.price, fee ? deps.gateway.feeBps : 0);
+  const split = splitFee(price, fee ? deps.gateway.feeBps : 0);
 
   // API-key path: when the caller sends a Tael key (and hasn't already attached
   // a signed payment), authenticate it and auto-pay from its linked Card, within
@@ -89,7 +115,7 @@ export async function handleGatewayRequest(
     const legs = [{ to: capability.payTo, amount: split.net }];
     if (fee) legs.push({ to: fee.payTo, amount: split.fee });
 
-    const payment = await deps.keys.payForCall({ card: key.card, total: capability.price, legs });
+    const payment = await deps.keys.payForCall({ card: key.card, total: price, legs });
     if (!payment.ok) return json({ error: payment.error }, payment.status);
 
     const headers = new Headers(request.headers);
@@ -99,7 +125,7 @@ export async function handleGatewayRequest(
   }
 
   const paid = tael({
-    price: capability.price,
+    price,
     payTo: capability.payTo,
     issuer: deps.gateway.issuer,
     network: deps.gateway.network,
@@ -123,7 +149,7 @@ export async function handleGatewayRequest(
       }
 
       try {
-        return await proxyToUpstream(capability, paidRequest);
+        return await proxyToUpstream(capability, paidRequest, targetUrl);
       } catch (error) {
         console.error("[gateway] upstream call failed:", error);
         return json({ error: "Upstream call failed" }, 502);

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -43,6 +43,10 @@ const CAPABILITY: ServableCapability = {
   payTo: ADDRESS,
   upstreamUrl: "https://api.example.com/age",
   upstreamSecretEnc: null,
+  operations: [
+    { slug: "premium", path: "/premium", price: "0.05" },
+    { slug: "ping", path: "/ping", price: "0" },
+  ],
 };
 
 /** A capability repo that returns the fixture for its slug and null otherwise. */
@@ -140,6 +144,64 @@ describe("capability gateway", () => {
     expect(body.accepts[0]?.maxAmountRequired).toBe("0.02");
     expect(body.accepts[0]?.payTo).toBe(ADDRESS);
     expect(body.accepts[0]?.resource).toBe("/c/predict-age");
+  });
+
+  it("charges the operation's price at /c/:slug/:operation", async () => {
+    const { container } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+
+    // Base capability keeps its headline price…
+    const base = await app.request("/c/predict-age");
+    const baseBody = (await base.json()) as { accepts: { maxAmountRequired: string }[] };
+    expect(baseBody.accepts[0]?.maxAmountRequired).toBe("0.02");
+
+    // …the operation advertises its own.
+    const op = await app.request("/c/predict-age/premium");
+    expect(op.status).toBe(402);
+    const opBody = (await op.json()) as {
+      accepts: { maxAmountRequired: string; resource: string }[];
+    };
+    expect(opBody.accepts[0]?.maxAmountRequired).toBe("0.05");
+    expect(opBody.accepts[0]?.resource).toBe("/c/predict-age/premium");
+  });
+
+  it("serves a free operation (price 0) with no payment required", async () => {
+    const upstream = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ pong: true }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", upstream);
+
+    const { container, payments } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+
+    // No X-PAYMENT, no key — a free op just returns the result.
+    const res = await app.request("/c/predict-age/ping");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ pong: true });
+    expect(upstream.mock.calls[0]?.[0]).toBe("https://api.example.com/age/ping");
+    // Nothing charged, nothing recorded.
+    expect(await payments.list()).toHaveLength(0);
+  });
+
+  it("404s for an unknown operation on a real capability", async () => {
+    const { container } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+    const res = await app.request("/c/predict-age/does-not-exist");
+    expect(res.status).toBe(404);
+  });
+
+  it("routes an operation call to the base URL + the operation path", async () => {
+    const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", upstream);
+
+    const { container } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+    await app.request("/c/predict-age/premium", {
+      method: "POST",
+      headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+    });
+
+    expect(upstream.mock.calls[0]?.[0]).toBe("https://api.example.com/age/premium");
   });
 
   it("proxies to the upstream and records the payment when paid", async () => {

--- a/apps/api/src/modules/gateway/upstream.ts
+++ b/apps/api/src/modules/gateway/upstream.ts
@@ -39,14 +39,22 @@ const STRIPPED_REQUEST_HEADERS = new Set([
   "authorization",
 ]);
 
+/** Join a base upstream URL with an operation path (empty path = the base). */
+export function resolveUpstreamUrl(base: string, path: string): string {
+  if (!path) return base;
+  return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
 /**
  * Proxy the (already-paid) request to the capability's real upstream endpoint,
  * injecting the decrypted API key. Forwards the caller's method, body, and safe
- * headers; returns the upstream response verbatim.
+ * headers; returns the upstream response verbatim. `targetUrl` is the resolved
+ * endpoint (base URL, or base + the operation's path).
  */
 export async function proxyToUpstream(
   capability: ServableCapability,
   request: Request,
+  targetUrl: string = capability.upstreamUrl,
 ): Promise<Response> {
   const headers = new Headers();
   request.headers.forEach((value, key) => {
@@ -62,7 +70,7 @@ export async function proxyToUpstream(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
   try {
-    const upstream = await fetch(capability.upstreamUrl, {
+    const upstream = await fetch(targetUrl, {
       method,
       headers,
       body: hasBody ? await request.arrayBuffer() : undefined,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -24,7 +24,11 @@ export function createServer(container: Container) {
 
   // The capability gateway: agents call `/c/:slug` and pay per call over x402.
   // Public + unauthenticated by design — the payment *is* the authentication.
+  // `/c/:slug/:operation` picks a specific priced operation of the capability.
   app.all("/c/:slug", (c) => handleGatewayRequest(container, c.req.param("slug"), c.req.raw));
+  app.all("/c/:slug/:operation", (c) =>
+    handleGatewayRequest(container, c.req.param("slug"), c.req.raw, c.req.param("operation")),
+  );
 
   // Mount the tRPC router. The dashboard/SDK talk to this with full type safety.
   app.all("/trpc/*", (c) =>

--- a/apps/dashboard/features/capabilities/actions.ts
+++ b/apps/dashboard/features/capabilities/actions.ts
@@ -109,14 +109,25 @@ export async function publishCapability(
   const input = parsed.data;
 
   const faqs: CapabilityFaq[] = input.faqs.filter((f) => f.answer.trim().length > 0);
+  // Give each operation a URL-safe slug (from its name) so buyers can address it
+  // at /c/<slug>/<operation>; dedupe collisions with a numeric suffix.
+  const opSlugs = new Set<string>();
   const spec: CapabilitySpec = {
-    operations: input.operations.map((op) => ({
-      name: op.name || "Request",
-      method: op.method || undefined,
-      sampleRequest: op.sampleRequest || undefined,
-      sampleResponse: op.sampleResponse || undefined,
-      price: op.price,
-    })),
+    operations: input.operations.map((op, i) => {
+      const base = slugify(op.name || `op-${i + 1}`) || `op-${i + 1}`;
+      let opSlug = base;
+      for (let n = 2; opSlugs.has(opSlug); n += 1) opSlug = `${base}-${n}`;
+      opSlugs.add(opSlug);
+      return {
+        name: op.name || "Request",
+        slug: opSlug,
+        path: op.path || undefined,
+        method: op.method || undefined,
+        sampleRequest: op.sampleRequest || undefined,
+        sampleResponse: op.sampleResponse || undefined,
+        price: op.price,
+      };
+    }),
   };
   const slug = await uniqueSlug(slugify(input.name));
 

--- a/apps/dashboard/features/capabilities/publish-wizard.tsx
+++ b/apps/dashboard/features/capabilities/publish-wizard.tsx
@@ -8,6 +8,7 @@ import {
   ArrowLeft,
   Check,
   CheckCircle2,
+  ChevronDown,
   Copy,
   ExternalLink,
   FileText,
@@ -33,6 +34,7 @@ type Step = "describe" | "test" | "verify" | "done";
 type Answer = { question: string; answer: string };
 type Operation = {
   name: string;
+  path: string;
   method: string;
   sampleRequest: string;
   sampleResponse: string;
@@ -40,7 +42,51 @@ type Operation = {
 };
 
 function newOperation(): Operation {
-  return { name: "", method: "POST", sampleRequest: "", sampleResponse: "", price: "" };
+  return { name: "", path: "", method: "POST", sampleRequest: "", sampleResponse: "", price: "" };
+}
+
+/** Restrained HTTP-method tints (subtle, not the loud Swagger palette). */
+const METHOD_COLORS: Record<string, string> = {
+  GET: "bg-sky-500/10 text-sky-600 dark:text-sky-400",
+  POST: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  PUT: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  PATCH: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
+  DELETE: "bg-rose-500/10 text-rose-600 dark:text-rose-400",
+};
+
+/** A small colored method chip for a request row. */
+function MethodBadge({ method }: { method: string }) {
+  const m = (method || "POST").toUpperCase();
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 shrink-0 items-center rounded-md px-2 font-mono text-[11px] font-semibold tracking-wide",
+        METHOD_COLORS[m] ?? "bg-muted text-muted-foreground",
+      )}
+    >
+      {m}
+    </span>
+  );
+}
+
+/** Price summary on a request row: a "Free" pill for 0, else "$X/call". */
+function PriceTag({ price }: { price: string }) {
+  if (!price.trim()) {
+    return <span className="shrink-0 text-xs text-muted-foreground">Set price</span>;
+  }
+  if (Number(price) <= 0) {
+    return (
+      <span className="shrink-0 rounded-md bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+        Free
+      </span>
+    );
+  }
+  return (
+    <span className="shrink-0 text-xs font-medium tabular-nums">
+      ${price}
+      <span className="text-muted-foreground">/call</span>
+    </span>
+  );
 }
 
 export function PublishWizard() {
@@ -48,6 +94,18 @@ export function PublishWizard() {
   const [step, setStep] = useState<Step>("describe");
   const [kind, setKind] = useState<Kind>("api");
   const [operations, setOperations] = useState<Operation[]>([newOperation()]);
+  // Which request row is expanded for editing (accordion). -1 = all collapsed.
+  const [openOp, setOpenOp] = useState<number>(0);
+
+  function addOp() {
+    setOpenOp(operations.length); // open the row we're about to add
+    setOperations((prev) => [...prev, newOperation()]);
+  }
+
+  function removeOp(i: number) {
+    setOperations((prev) => prev.filter((_, j) => j !== i));
+    setOpenOp((cur) => (cur === i ? -1 : cur > i ? cur - 1 : cur));
+  }
   // Describe-step fields live in state (controlled) so they survive navigating
   // back and forth between steps instead of resetting.
   const [describe, setDescribe] = useState<Record<string, string>>({ visibility: "public" });
@@ -100,10 +158,12 @@ export function PublishWizard() {
     setError(null);
     setTestingIndex(i);
     const op = operations[i]!;
+    const base = describe.upstreamUrl ?? "";
+    const url = op.path ? `${base.replace(/\/+$/, "")}/${op.path.replace(/^\/+/, "")}` : base;
     startTransition(async () => {
       const res = await testRequest({
         name: op.name || `Request ${i + 1}`,
-        url: describe.upstreamUrl ?? "",
+        url,
         method: op.method || "POST",
         body: op.sampleRequest,
         secret: describe.upstreamSecret ?? "",
@@ -203,7 +263,7 @@ export function PublishWizard() {
             }}
             className="space-y-4"
           >
-            <Field label="Product name">
+            <Field label="Product name" required>
               <Input
                 value={describe.name ?? ""}
                 onChange={(e) => setField("name", e.target.value)}
@@ -212,7 +272,7 @@ export function PublishWizard() {
               />
             </Field>
 
-            <Field label="Logo (optional)">
+            <Field label="Logo">
               <LogoField
                 value={describe.logoUrl ?? ""}
                 kind={kind}
@@ -261,7 +321,7 @@ export function PublishWizard() {
               </select>
             </Field>
 
-            <Field label="Description">
+            <Field label="Description" required>
               <textarea
                 value={describe.description ?? ""}
                 onChange={(e) => setField("description", e.target.value)}
@@ -272,7 +332,7 @@ export function PublishWizard() {
               />
             </Field>
 
-            <Field label="Contact / support (optional)">
+            <Field label="Contact" hint="Where buyers can reach you about this capability.">
               <Input
                 value={describe.contact ?? ""}
                 onChange={(e) => setField("contact", e.target.value)}
@@ -280,7 +340,7 @@ export function PublishWizard() {
               />
             </Field>
 
-            <Field label={fields.urlLabel}>
+            <Field label={fields.urlLabel} required>
               <Input
                 value={describe.upstreamUrl ?? ""}
                 onChange={(e) => setField("upstreamUrl", e.target.value)}
@@ -290,12 +350,15 @@ export function PublishWizard() {
               />
             </Field>
 
-            <Field label="Upstream secret (encrypted at rest)">
+            <Field
+              label="Upstream secret"
+              hint="Your key for the endpoint above. We encrypt it and add it to every call, so buyers never see it."
+            >
               <Input
                 value={describe.upstreamSecret ?? ""}
                 onChange={(e) => setField("upstreamSecret", e.target.value)}
                 type="password"
-                placeholder="sk-… (optional)"
+                placeholder="sk-…"
               />
             </Field>
 
@@ -304,82 +367,140 @@ export function PublishWizard() {
                 <span className="text-sm font-medium">Requests</span>
                 <button
                   type="button"
-                  onClick={() => setOperations((prev) => [...prev, newOperation()])}
+                  onClick={addOp}
                   className="inline-flex items-center gap-1 text-sm font-medium text-foreground/80 hover:text-foreground"
                 >
                   <Plus className="h-4 w-4" /> Add request
                 </button>
               </div>
 
-              {operations.map((op, i) => (
-                <div key={i} className="space-y-3 rounded-xl border p-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      Request {i + 1}
-                    </span>
-                    {operations.length > 1 ? (
-                      <button
-                        type="button"
-                        onClick={() => setOperations((prev) => prev.filter((_, j) => j !== i))}
-                        className="text-muted-foreground hover:text-destructive"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    ) : null}
-                  </div>
-
-                  <div
-                    className={cn(
-                      "grid gap-3",
-                      fields.method ? "grid-cols-[6rem_1fr_7rem]" : "grid-cols-[1fr_7rem]",
-                    )}
-                  >
-                    {fields.method ? (
-                      <Field label="Method">
-                        <select
-                          value={op.method}
-                          onChange={(e) => updateOp(i, { method: e.target.value })}
-                          className="h-9 w-full rounded-md border border-input bg-transparent px-2 text-sm"
+              <div className="divide-y overflow-hidden rounded-xl border">
+                {operations.map((op, i) => {
+                  const open = openOp === i;
+                  return (
+                    <div key={i}>
+                      {/* Summary row — click to expand its editor. */}
+                      <div className="flex items-center">
+                        <button
+                          type="button"
+                          onClick={() => setOpenOp(open ? -1 : i)}
+                          className="flex min-w-0 flex-1 items-center gap-3 px-3.5 py-3 text-left transition-colors hover:bg-muted/40"
                         >
-                          {HTTP_METHODS.map((m) => (
-                            <option key={m} value={m}>
-                              {m}
-                            </option>
-                          ))}
-                        </select>
-                      </Field>
-                    ) : null}
-                    <Field label="Label">
-                      <Input
-                        value={op.name}
-                        onChange={(e) => updateOp(i, { name: e.target.value })}
-                        placeholder="Extract text"
-                      />
-                    </Field>
-                    <Field label="Price/call">
-                      <Input
-                        value={op.price}
-                        onChange={(e) => updateOp(i, { price: e.target.value })}
-                        placeholder="0.02"
-                        required
-                      />
-                    </Field>
-                  </div>
+                          {fields.method ? <MethodBadge method={op.method} /> : null}
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-sm font-medium">
+                              {op.name || (
+                                <span className="text-muted-foreground">Untitled request</span>
+                              )}
+                            </span>
+                            {op.path ? (
+                              <span className="block truncate font-mono text-xs text-muted-foreground">
+                                {op.path}
+                              </span>
+                            ) : null}
+                          </span>
+                          <PriceTag price={op.price} />
+                          <ChevronDown
+                            className={cn(
+                              "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+                              open && "rotate-180",
+                            )}
+                          />
+                        </button>
+                        {operations.length > 1 ? (
+                          <button
+                            type="button"
+                            onClick={() => removeOp(i)}
+                            aria-label="Remove request"
+                            className="px-3 text-muted-foreground transition-colors hover:text-destructive"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        ) : null}
+                      </div>
 
-                  <Field label={`${fields.requestLabel} (optional)`}>
-                    <textarea
-                      rows={4}
-                      value={op.sampleRequest}
-                      onChange={(e) => updateOp(i, { sampleRequest: e.target.value })}
-                      placeholder={fields.requestPlaceholder}
-                      className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs"
-                    />
-                  </Field>
-                </div>
-              ))}
+                      {/* Editor — revealed for the open row. */}
+                      {open ? (
+                        <div className="space-y-3 border-t bg-muted/20 px-3.5 py-4 duration-150 ease-out animate-in fade-in slide-in-from-top-1">
+                          <div
+                            className={cn(
+                              "grid gap-3",
+                              fields.method ? "grid-cols-[6rem_1fr_7rem]" : "grid-cols-[1fr_7rem]",
+                            )}
+                          >
+                            {fields.method ? (
+                              <Field label="Method">
+                                <select
+                                  value={op.method}
+                                  onChange={(e) => updateOp(i, { method: e.target.value })}
+                                  className="h-9 w-full rounded-md border border-input bg-transparent px-2 text-sm"
+                                >
+                                  {HTTP_METHODS.map((m) => (
+                                    <option key={m} value={m}>
+                                      {m}
+                                    </option>
+                                  ))}
+                                </select>
+                              </Field>
+                            ) : null}
+                            <Field label="Name">
+                              <Input
+                                value={op.name}
+                                onChange={(e) => updateOp(i, { name: e.target.value })}
+                                placeholder="Extract text"
+                              />
+                            </Field>
+                            <Field label="Price" required>
+                              <Input
+                                value={op.price}
+                                onChange={(e) => updateOp(i, { price: e.target.value })}
+                                placeholder="0.02"
+                                required
+                              />
+                            </Field>
+                          </div>
+
+                          <Field
+                            label="Path"
+                            hint="Added to the endpoint URL for this request. Leave empty to call the base URL."
+                          >
+                            <Input
+                              value={op.path}
+                              onChange={(e) => updateOp(i, { path: e.target.value })}
+                              placeholder="/swap"
+                            />
+                          </Field>
+
+                          <Field
+                            label={fields.requestLabel}
+                            hint="Shown on the listing and used to test this request."
+                          >
+                            <textarea
+                              rows={4}
+                              value={op.sampleRequest}
+                              onChange={(e) => updateOp(i, { sampleRequest: e.target.value })}
+                              placeholder={fields.requestPlaceholder}
+                              className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs"
+                            />
+                          </Field>
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+
+              <p className="text-xs text-muted-foreground">
+                Set a price of <span className="font-medium text-foreground">0</span> to make a
+                request free.
+              </p>
             </div>
 
-            <Field label="Pay to (Stellar address)">
+            <Field
+              label="Pay to"
+              required
+              hint="The Stellar address that receives your USDC earnings."
+            >
               <Input
                 value={describe.payTo ?? ""}
                 onChange={(e) => setField("payTo", e.target.value)}
@@ -666,10 +787,26 @@ function StepIndicator({ step }: { step: Step }) {
   );
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function Field({
+  label,
+  required,
+  hint,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  hint?: string;
+  children: React.ReactNode;
+}) {
   return (
     <label className="block space-y-1.5">
-      <span className="text-sm font-medium">{label}</span>
+      <span className="text-sm font-medium">
+        {label}
+        {required ? <span className="text-destructive"> *</span> : null}
+      </span>
+      {hint ? (
+        <span className="block text-xs leading-snug text-muted-foreground">{hint}</span>
+      ) : null}
       {children}
     </label>
   );

--- a/apps/dashboard/features/capabilities/schema.ts
+++ b/apps/dashboard/features/capabilities/schema.ts
@@ -1,9 +1,18 @@
 import { z } from "zod";
 import { capabilityKindSchema, moneyAmountSchema, stellarAddressSchema } from "@tael/types";
 
-/** One callable operation: sample request/response + its own price per call. */
+/** One callable operation: sample request/response + its own price per call.
+ *  `path` is an optional sub-path appended to the capability's upstream URL, so
+ *  one capability can expose many priced operations (a balance read, a swap…),
+ *  each addressed at `/c/<slug>/<operation>`. Empty path means the base URL. */
 export const operationSchema = z.object({
   name: z.string().max(80).optional().default(""),
+  path: z
+    .string()
+    .max(200)
+    .optional()
+    .default("")
+    .refine((v) => v === "" || !/^https?:\/\//.test(v), "Use a path like /swap, not a full URL"),
   method: z.string().max(10).optional().default(""),
   sampleRequest: z.string().max(4000).optional().default(""),
   sampleResponse: z.string().max(4000).optional().default(""),

--- a/packages/database/src/schema/capabilities.ts
+++ b/packages/database/src/schema/capabilities.ts
@@ -22,6 +22,18 @@ export interface CapabilityFaq {
 export interface CapabilityOperation {
   /** Human label, e.g. "Extract text" or "GET /prices". */
   name: string;
+  /**
+   * URL-safe handle for addressing this operation at `/c/<slug>/<op>`. When
+   * absent, it's derived from `name`. Lets one capability expose many priced
+   * operations (e.g. a Nebula MCP with balance / quote / swap / pay).
+   */
+  slug?: string;
+  /**
+   * Optional path appended to the capability's `upstreamUrl` for this operation,
+   * e.g. "/v1/swap". Empty means the base URL (the operation is selected by the
+   * request body, as with an MCP tool call).
+   */
+  path?: string;
   /** HTTP method for API/model kinds, e.g. "GET" | "POST". */
   method?: string;
   /** Example request payload (JSON string), shown publicly. */

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -100,9 +100,14 @@ export class Tael {
     this.fetchImpl = f;
   }
 
-  /** Call a capability and return the full response (data + status + receipt). */
+  /**
+   * Call a capability and return the full response (data + status + receipt).
+   * `slug` may address a specific operation as `"capability/operation"`
+   * (e.g. `"nebula/swap"`), which is priced per operation.
+   */
   async call<T = unknown>(slug: string, options: CallOptions = {}): Promise<TaelResponse<T>> {
-    const url = new URL(`${this.baseUrl}/c/${encodeURIComponent(slug)}`);
+    const path = slug.split("/").filter(Boolean).map(encodeURIComponent).join("/");
+    const url = new URL(`${this.baseUrl}/c/${path}`);
     for (const [k, v] of Object.entries(options.query ?? {})) url.searchParams.set(k, String(v));
 
     const headers: Record<string, string> = {


### PR DESCRIPTION
One capability now holds several callable **operations**, each with its own **price** and upstream **path**. A multi-tool product (an API with many endpoints, or an MCP with balance / quote / swap / pay) is published once and addressed at `/c/<slug>/<operation>` instead of as many separate capabilities.

## What's in it
- **Gateway:** `/c/:slug/:operation` resolves the operation, charges its price, routes to base URL + the operation's path. `/c/:slug` unchanged (backward compatible).
- **Free operations:** price `0` skips payment entirely and just proxies, so a capability can mix free reads with paid actions.
- **SDK:** `tael.post("nebula/swap", …)`.
- **Publish form:** collapsible request list (method badge, path, per-op price, a "Free" tag) with cleaner copy — required fields marked `*`, helper lines instead of "(optional)".
- Marketplace detail already lists each operation with its price.

## Verified
typecheck 11/11, api 19/19, sdk 7/7, lint clean. No new env vars; operations live in the existing capability `spec` (no migration).