### PR TITLE
feat(gateway): rate limiting port and in-memory sliding window adapter

### DIFF
--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -26,6 +26,7 @@ import {
 } from "./modules/capabilities/capability.repository";
 import { DbApiKeyRepository } from "./modules/keys/key.repository";
 import { KeyPaymentService } from "./modules/keys/key.service";
+import { type RateLimiter, InMemoryRateLimiter } from "./modules/gateway/rate-limit";
 
 /**
  * The composition root. This is the ONE place where concrete implementations are
@@ -40,6 +41,7 @@ export interface Container {
   /** Authenticates Tael API keys and auto-pays from their linked Card. */
   keys: KeyPaymentService;
   verifier: PaymentVerifier;
+  limiter: RateLimiter;
   /** Payment settings the gateway needs to build x402 challenges. */
   gateway: {
     issuer: string;
@@ -127,12 +129,15 @@ export function createContainer(env: Env): Container {
   // Real on-chain settlement in production; a mock keeps dev + tests hermetic.
   const verifier = isProd ? createStellarVerifier(env) : createMockVerifier();
 
+  const limiter = new InMemoryRateLimiter(env.RATE_LIMIT_WINDOW_MS, env.RATE_LIMIT_MAX);
+
   return {
     wallets,
     payments,
     capabilities,
     keys,
     verifier,
+    limiter,
     gateway: {
       issuer: env.USDC_ISSUER,
       network: toPaymentNetwork(env.STELLAR_NETWORK),

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -22,6 +22,8 @@ const envSchema = z.object({
   // (non-custodial). Unset → no fee (builder keeps 100%). 100 bps = 1%.
   TAEL_FEE_ADDRESS: z.string().optional(),
   TAEL_FEE_BPS: z.coerce.number().int().min(0).max(10000).default(100),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60000),
+  RATE_LIMIT_MAX: z.coerce.number().int().positive().default(120),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -2,11 +2,12 @@ import { tael } from "@tael/sdk";
 import { PAYMENT_REQUEST_HEADER, splitFee } from "@tael/payments";
 import { type Container } from "../../container";
 import { proxyToUpstream, isBlockedUrl, resolveUpstreamUrl } from "./upstream";
+import { checkRateLimit } from "./rate-limit";
 
 /** The slice of the container the gateway needs. */
 export type GatewayDeps = Pick<
   Container,
-  "capabilities" | "payments" | "verifier" | "gateway" | "keys"
+  "capabilities" | "payments" | "verifier" | "gateway" | "keys" | "limiter"
 >;
 
 function json(body: unknown, status: number): Response {
@@ -29,9 +30,12 @@ function parseTaelKey(header: string | null): string | null {
  * pick and call one — no upstream URLs, no secrets.
  */
 export async function handleCatalogRequest(
-  deps: Pick<GatewayDeps, "capabilities">,
+  deps: Pick<GatewayDeps, "capabilities" | "limiter">,
   request: Request,
 ): Promise<Response> {
+  const rateLimitResponse = await checkRateLimit(deps.limiter, request);
+  if (rateLimitResponse) return rateLimitResponse;
+
   const url = new URL(request.url);
   const limitParam = url.searchParams.get("limit");
   const items = await deps.capabilities.listCatalog({
@@ -57,6 +61,9 @@ export async function handleGatewayRequest(
   request: Request,
   operationSlug?: string,
 ): Promise<Response> {
+  const rateLimitResponse = await checkRateLimit(deps.limiter, request);
+  if (rateLimitResponse) return rateLimitResponse;
+
   const capability = await deps.capabilities.findServableBySlug(slug);
   if (!capability) {
     return json({ error: "Capability not found" }, 404);

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { InMemoryRateLimiter } from "./rate-limit";
+
+const testRateLimiter = new InMemoryRateLimiter(60000, 120);
 import {
   createMockVerifier,
   encodePaymentPayload,
@@ -105,6 +108,7 @@ function buildContainer(
     capabilities: fakeCapabilities(capability),
     keys,
     verifier: createMockVerifier(),
+    limiter: testRateLimiter,
     gateway: {
       issuer: ADDRESS,
       network: "stellar-testnet",
@@ -127,6 +131,7 @@ function paymentHeader(): string {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  testRateLimiter.reset();
 });
 
 describe("capability gateway", () => {
@@ -547,5 +552,94 @@ describe("capability gateway", () => {
       result += decoder.decode(value, { stream: true });
     }
     expect(result).toBe("chunk1chunk2");
+  });
+
+  describe("gateway rate limiting", () => {
+    it("allows requests within the configured rate limit", async () => {
+      testRateLimiter.reset(60000, 2);
+
+      const { container } = buildContainer(CAPABILITY);
+      const app = createServer(container);
+
+      // Call 1
+      let res = await app.request("/capabilities");
+      expect(res.status).toBe(200);
+
+      // Call 2
+      res = await app.request("/capabilities");
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 429 Too Many Requests with Retry-After when limit is exceeded", async () => {
+      testRateLimiter.reset(60000, 2);
+
+      const { container } = buildContainer(CAPABILITY);
+      const app = createServer(container);
+
+      // Call 1
+      let res = await app.request("/capabilities");
+      expect(res.status).toBe(200);
+
+      // Call 2
+      res = await app.request("/capabilities");
+      expect(res.status).toBe(200);
+
+      // Call 3 -> Exceeded!
+      res = await app.request("/capabilities");
+      expect(res.status).toBe(429);
+      expect(await res.json()).toEqual({ error: "Rate limit exceeded" });
+      expect(res.headers.get("Retry-After")).toBeTruthy();
+      expect(Number(res.headers.get("Retry-After"))).toBeGreaterThanOrEqual(1);
+    });
+
+    it("limits different IP addresses independently", async () => {
+      testRateLimiter.reset(60000, 1);
+
+      const { container } = buildContainer(CAPABILITY);
+      const app = createServer(container);
+
+      // IP 1: Call 1 -> OK
+      let res = await app.request("/capabilities", {
+        headers: { "x-forwarded-for": "1.1.1.1" },
+      });
+      expect(res.status).toBe(200);
+
+      // IP 1: Call 2 -> 429
+      res = await app.request("/capabilities", {
+        headers: { "x-forwarded-for": "1.1.1.1" },
+      });
+      expect(res.status).toBe(429);
+
+      // IP 2: Call 1 -> OK (different IP is independent)
+      res = await app.request("/capabilities", {
+        headers: { "x-forwarded-for": "2.2.2.2" },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("limits different API keys independently", async () => {
+      testRateLimiter.reset(60000, 1);
+
+      const { container } = buildContainer(CAPABILITY);
+      const app = createServer(container);
+
+      // Key 1: Call 1 -> OK
+      let res = await app.request("/capabilities", {
+        headers: { authorization: "Bearer tael_live_key1" },
+      });
+      expect(res.status).toBe(200);
+
+      // Key 1: Call 2 -> 429
+      res = await app.request("/capabilities", {
+        headers: { authorization: "Bearer tael_live_key1" },
+      });
+      expect(res.status).toBe(429);
+
+      // Key 2: Call 1 -> OK (different Key is independent)
+      res = await app.request("/capabilities", {
+        headers: { authorization: "Bearer tael_live_key2" },
+      });
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/apps/api/src/modules/gateway/rate-limit.ts
+++ b/apps/api/src/modules/gateway/rate-limit.ts
@@ -1,0 +1,142 @@
+import { createHash } from "crypto";
+
+export interface RateLimitResult {
+  limited: boolean;
+  retryAfterSeconds?: number;
+}
+
+/**
+ * Port: RateLimiter interface.
+ * Can be implemented by in-memory, Redis, or other backing stores.
+ */
+export interface RateLimiter {
+  check(key: string): Promise<RateLimitResult>;
+}
+
+/**
+ * Derives a rate limit key for a given request.
+ * Keys by hashed Tael API key if present, otherwise by the client IP address (X-Forwarded-For).
+ */
+export function getClientIdentifier(request: Request): string {
+  // 1. Tael API Key
+  const authHeader = request.headers.get("authorization");
+  if (authHeader) {
+    const match = /^Bearer\s+(tael_live_[A-Za-z0-9]+)$/i.exec(authHeader.trim());
+    if (match && match[1]) {
+      // Key by SHA-256 of the token to avoid storing raw API keys in memory.
+      const hash = createHash("sha256").update(match[1]).digest("hex");
+      return `key_${hash}`;
+    }
+  }
+
+  // 2. Client IP via X-Forwarded-For (first hop)
+  const xForwardedFor = request.headers.get("x-forwarded-for");
+  if (xForwardedFor) {
+    const firstIp = xForwardedFor.split(",")[0]?.trim();
+    if (firstIp) {
+      return `ip_${firstIp}`;
+    }
+  }
+
+  // 3. Fallback for IP (CF-Connecting-IP)
+  const cfConnectingIp = request.headers.get("cf-connecting-ip");
+  if (cfConnectingIp) {
+    return `ip_${cfConnectingIp.trim()}`;
+  }
+
+  return "ip_unknown";
+}
+
+/**
+ * Adapter: Sliding window rate limiter implementation in memory.
+ * NOTE: This is per-instance. A distributed rate limiter (e.g. using Redis) is a follow-up.
+ */
+export class InMemoryRateLimiter implements RateLimiter {
+  private readonly requests = new Map<string, number[]>();
+
+  constructor(
+    public windowMs: number,
+    public maxRequests: number,
+  ) {
+    // Prevent memory leaks in long-running processes (skip during unit tests)
+    if (process.env.NODE_ENV !== "test") {
+      const timer = setInterval(() => this.cleanup(), 5 * 60 * 1000);
+      if (typeof timer.unref === "function") {
+        timer.unref();
+      }
+    }
+  }
+
+  /**
+   * Clears the request memory and optionally updates configuration (useful for tests).
+   */
+  reset(windowMs?: number, maxRequests?: number) {
+    this.requests.clear();
+    if (windowMs !== undefined) this.windowMs = windowMs;
+    if (maxRequests !== undefined) this.maxRequests = maxRequests;
+  }
+
+  /**
+   * Check if a request should be limited.
+   * If limited, returns true and the Retry-After seconds.
+   * Otherwise, records the request timestamp and returns false.
+   */
+  async check(key: string): Promise<RateLimitResult> {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+
+    let timestamps = this.requests.get(key) || [];
+    // Clean up timestamps outside the current window
+    timestamps = timestamps.filter((ts) => ts > windowStart);
+
+    if (timestamps.length >= this.maxRequests) {
+      const oldestInWindow = timestamps[0]!;
+      const retryAfterMs = oldestInWindow + this.windowMs - now;
+      const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+      this.requests.set(key, timestamps);
+      return { limited: true, retryAfterSeconds };
+    }
+
+    timestamps.push(now);
+    this.requests.set(key, timestamps);
+    return { limited: false };
+  }
+
+  /**
+   * Cleans up keys with no active timestamps.
+   */
+  cleanup() {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+    for (const [key, timestamps] of this.requests.entries()) {
+      const active = timestamps.filter((ts) => ts > windowStart);
+      if (active.length === 0) {
+        this.requests.delete(key);
+      } else {
+        this.requests.set(key, active);
+      }
+    }
+  }
+}
+
+/**
+ * Lightweight check applied to the gateway requests using the injected limiter.
+ * Returns a 429 response if limited, or null if allowed.
+ */
+export async function checkRateLimit(
+  limiter: RateLimiter,
+  request: Request,
+): Promise<Response | null> {
+  const key = getClientIdentifier(request);
+  const result = await limiter.check(key);
+  if (result.limited) {
+    return new Response(JSON.stringify({ error: "Rate limit exceeded" }), {
+      status: 429,
+      headers: {
+        "content-type": "application/json",
+        "Retry-After": String(result.retryAfterSeconds),
+      },
+    });
+  }
+  return null;
+}

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -11,6 +11,8 @@ const testEnv: Env = {
   STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org",
   USDC_ISSUER: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
   TAEL_FEE_BPS: 100,
+  RATE_LIMIT_WINDOW_MS: 60000,
+  RATE_LIMIT_MAX: 120,
 };
 
 const app = createServer(createContainer(testEnv));


### PR DESCRIPTION
## What & why

This PR implements a lightweight rate limiter for the public gateway endpoints (`GET /capabilities`, `/c/:slug`, and `/c/:slug/:operation`).

Following the codebase's established design patterns:
- We abstracted the rate limiting logic behind a `RateLimiter` port interface (`check(key): Promise<RateLimitResult>`).
- Implemented an `InMemoryRateLimiter` adapter that handles sliding-window rate limiting in-memory.
- Registered the rate limiter inside the application composition root DI Container (`Container` in `apps/api/src/container.ts`).
- Passed the rate limiter dependency into the handlers to perform asynchronous checks before processing gateway requests.

This ensures we can seamlessly swap in a shared `RedisRateLimiter` later when running multiple instances with zero handler changes.

Closes #57 (or the relevant issue number)

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Refactor / chore
- [ ] Docs

## Checklist

- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` pass locally
- [x] Added/updated tests for the change
- [ ] Added a changeset (`pnpm changeset`)
- [ ] Updated docs (`ARCHITECTURE.md` / package `README`)
