### PR TITLE
feat(gateway): stream upstream response body and adjust timeout

### DIFF
--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -505,4 +505,47 @@ describe("capability gateway", () => {
     expect(headers.has("authorization")).toBe(false);
     expect(headers.get("x-static-only")).toBe("yes");
   });
+
+  it("proxies a streaming response without buffering it", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("chunk1"));
+        controller.enqueue(encoder.encode("chunk2"));
+        controller.close();
+      },
+    });
+
+    const upstream = vi.fn<typeof fetch>(
+      async () =>
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+    );
+    vi.stubGlobal("fetch", upstream);
+
+    const { container } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+
+    const res = await app.request("/c/predict-age", {
+      method: "POST",
+      headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+    const reader = res.body?.getReader();
+    expect(reader).toBeTruthy();
+
+    const decoder = new TextDecoder();
+    let result = "";
+    while (true) {
+      const { done, value } = await reader!.read();
+      if (done) break;
+      result += decoder.decode(value, { stream: true });
+    }
+    expect(result).toBe("chunk1chunk2");
+  });
 });

--- a/apps/api/src/modules/gateway/upstream.ts
+++ b/apps/api/src/modules/gateway/upstream.ts
@@ -91,16 +91,19 @@ export async function proxyToUpstream(
       body: hasBody ? await request.arrayBuffer() : undefined,
       signal: controller.signal,
     });
+    clearTimeout(timer);
+
     // Re-emit as a fresh Response so the body is consumable by the SDK wrapper.
     const responseHeaders = new Headers(upstream.headers);
     responseHeaders.delete("content-encoding");
     responseHeaders.delete("content-length");
-    return new Response(await upstream.arrayBuffer(), {
+    return new Response(upstream.body, {
       status: upstream.status,
       statusText: upstream.statusText,
       headers: responseHeaders,
     });
-  } finally {
+  } catch (error) {
     clearTimeout(timer);
+    throw error;
   }
 }


### PR DESCRIPTION
## What & why

This PR enables real-time pass-through streaming of the HTTP body response for capabilities (such as token streaming over SSE / Chunked responses in Claude, Grok, etc.). 

Key changes:
- In `proxyToUpstream`, we return the `upstream.body` stream directly instead of buffering it using `arrayBuffer()`.
- We clear the 30-second abort timeout as soon as the fetch headers resolve. This prevents connection terminations on long-lived streaming requests.
- Verified that `packages/sdk/src/tael.ts` forwards `response.body` without reading or consuming it, preserving the stream pipeline.
- Added a mock streaming test case to `gateway.test.ts`.

Closes #58 (or the relevant streaming issue number)

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Refactor / chore
- [ ] Docs

## Checklist

- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` pass locally
- [x] Added/updated tests for the change
- [ ] Added a changeset (`pnpm changeset`)
- [ ] Updated docs (`ARCHITECTURE.md` / package `README`)
