### PR TITLE
chore(sdk): package @tael/sdk for npm (published 0.1.1)

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,66 @@
 # @tael/sdk
 
-Wrap any HTTP handler with x402 payments in **one call**.
+The official SDK for [Tael](https://taelprotocol.xyz), the payment layer for AI agents. Two sides in one package:
+
+- **Buy** any capability on the Tael marketplace with a single API key.
+- **Sell** your own service by wrapping any HTTP handler with x402 payments in one line.
+
+```bash
+pnpm add @tael/sdk   # or npm / yarn / bun
+```
+
+## Buy: call any capability with one key
+
+Create a key in the dashboard under **API Keys** and link it to a funded **Card**. Then call any capability, and payment happens automatically from that Card, within the caps you set. You never sign a transaction.
+
+```ts
+import { Tael } from "@tael/sdk";
+
+const tael = new Tael({ apiKey: process.env.TAEL_KEY! });
+
+const facts = await tael.get("cat-facts"); // GET a capability
+const reply = await tael.post("claude", { prompt: "Summarize this." }); // POST a capability
+```
+
+Capabilities can expose several priced operations. Address one with `capability/operation`:
+
+```ts
+await tael.post("nebula/swap", { amount: "5" });
+```
+
+**Discover** what is available at runtime:
+
+```ts
+const all = await tael.list(); // every capability
+const found = await tael.search("weather"); // by name or description
+```
+
+**Receipts.** Use `call()` when you want the full response, including the on-chain settlement receipt:
+
+```ts
+const res = await tael.call("cat-facts");
+res.data; // the capability's response
+res.status; // HTTP status
+res.receipt?.txHash; // proof the USDC payment settled on Stellar
+```
+
+**Errors.** A failed call throws a `TaelError` carrying the gateway's message and status:
+
+```ts
+import { Tael, TaelError } from "@tael/sdk";
+
+try {
+  await tael.post("claude", { prompt: "hi" });
+} catch (err) {
+  if (err instanceof TaelError) {
+    console.error(err.status, err.message); // e.g. 403 "Over this Card's per-call cap."
+  }
+}
+```
+
+## Sell: put a price on your own service
+
+The `tael()` wrapper turns any Fetch handler into a payment-gated one. `createTael()` binds your settlement details once and returns a `paid()` factory:
 
 ```ts
 import { createTael } from "@tael/sdk";
@@ -11,19 +71,20 @@ const paid = createTael({ payTo, issuer, network: "stellar-testnet", verifier })
 export default paid({ price: "0.02", handler: myApi });
 ```
 
-## How it works
+How it works. `tael()` returns a standard Fetch handler `(Request) => Promise<Response>`:
 
-`tael()` returns a standard Fetch handler `(Request) => Promise<Response>`:
+1. No `X-PAYMENT` header returns a `402` with the payment challenge.
+2. A valid payment is verified via the injected `PaymentVerifier`, your handler runs, and an `X-PAYMENT-RESPONSE` receipt is echoed back.
 
-1. No `X-PAYMENT` header → responds `402` with the payment challenge.
-2. Valid payment → verifies via the injected `PaymentVerifier`, runs your handler, and echoes an
-   `X-PAYMENT-RESPONSE` receipt.
+Because it speaks the Web `Request`/`Response` standard, it drops into Hono, Next.js route handlers, Bun, Deno, and Cloudflare Workers unchanged.
 
-Because it speaks the Web `Request`/`Response` standard, it drops into Hono, Next.js route handlers,
-Bun, Deno, and Cloudflare Workers unchanged.
+## Docs
+
+- [Call a capability](https://taelprotocol.xyz/docs/call-a-capability)
+- [Wrap an API](https://taelprotocol.xyz/docs/wrap-an-api)
+- [Node.js SDK reference](https://taelprotocol.xyz/docs/sdk/node)
 
 ## Boundaries
 
-- **Belongs here:** the developer-facing ergonomics of gating a handler behind a payment.
-- **Never here:** chain-specific settlement (injected via `verifier`, implemented by `@tael/stellar`)
-  or the protocol wire format (owned by `@tael/payments`).
+- **Belongs here:** the developer-facing ergonomics of buying a capability and of gating a handler behind a payment.
+- **Never here:** chain-specific settlement (injected via `verifier`, implemented by `@tael/stellar`) or the protocol wire format (owned by `@tael/payments`).

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@tael/sdk",
-  "version": "0.0.0",
+  "version": "0.1.1",
   "type": "module",
-  "description": "Wrap any HTTP handler with x402 payments in one call: tael({ price, handler }).",
+  "description": "The Tael SDK: call any capability with one API key, or wrap your own service with x402 payments in one line.",
   "license": "MIT",
   "keywords": [
     "tael",
@@ -12,6 +12,12 @@
     "stellar",
     "usdc"
   ],
+  "homepage": "https://taelprotocol.xyz",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rahulsainlll/tael-protocol.git",
+    "directory": "packages/sdk"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",
@@ -26,6 +32,7 @@
       }
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],
@@ -36,11 +43,12 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
-    "@tael/payments": "workspace:*",
-    "@tael/types": "workspace:*"
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@tael/config": "workspace:*",
+    "@tael/payments": "workspace:*",
+    "@tael/types": "workspace:*",
     "@types/node": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": "@tael/config/tsconfig/library.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@tael/payments": ["../payments/src/index.ts"],
+      "@tael/types": ["../types/src/index.ts"]
+    }
+  },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -3,8 +3,13 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
-  dts: true,
+  // Inline the workspace types into the .d.ts too, so consumers never resolve
+  // `@tael/*` (which they don't install).
+  dts: { resolve: true },
   clean: true,
   sourcemap: true,
   treeshake: true,
+  // Inline the workspace packages so the published SDK is self-contained — users
+  // install one package. `zod` stays external (a normal runtime dependency).
+  noExternal: [/^@tael\//],
 });


### PR DESCRIPTION
Makes `@tael/sdk` a self-contained, installable package. **Already published to npm as `@tael/sdk@0.1.1`** — this commits the source that matches it.

- **Bundled** the workspace deps (`@tael/payments`, `@tael/types`) into the dist (tsup `noExternal`), and inlined their types into the `.d.ts` (tsconfig `paths`), so consumers install **one** package with a single runtime dep (`zod`).
- **README** rewritten buy-side first: the `Tael` client (call any capability with one key) leads, then the `tael()` sell-side wrapper + docs links.
- Version `0.1.1`; added homepage / repository / sideEffects.

Build/packaging only — no runtime behavior change. `pnpm add @tael/sdk` now works for everyone. 🚀