### PR TITLE
chore: sync pnpm-lock.yaml after @tael/sdk repackage (fixes CI)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,16 +468,19 @@ importers:
 
   packages/sdk:
     dependencies:
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+    devDependencies:
+      '@tael/config':
+        specifier: workspace:*
+        version: link:../config
       '@tael/payments':
         specifier: workspace:*
         version: link:../payments
       '@tael/types':
         specifier: workspace:*
         version: link:../types
-    devDependencies:
-      '@tael/config':
-        specifier: workspace:*
-        version: link:../config
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.0


### PR DESCRIPTION
**Unbreaks main.** PR #62 changed `packages/sdk/package.json` (added `zod`, moved workspace deps to devDependencies) but the matching `pnpm-lock.yaml` was not committed. CI runs a frozen install, so the mismatch failed the build.

This commits the lockfile only — no code changes. Verified locally: `pnpm install --frozen-lockfile`, lint, test (6/6), and build (8/8) all pass.