### PR TITLE
fix(marketplace): run a specific operation of a multi-op capability

### DIFF
--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -15,6 +15,17 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
 export const dynamic = "force-dynamic";
 
+/** URL-safe operation handle for `/c/<slug>/<op>` (mirrors the publish action). */
+function opSlug(name: string | undefined, i: number): string {
+  const base = (name ?? "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  return base || `op-${i + 1}`;
+}
+
 export default async function CapabilityDetailPage({
   params,
 }: {
@@ -29,6 +40,13 @@ export default async function CapabilityDetailPage({
   const meta = kindMeta(capability.kind);
   const Icon = meta.icon;
   const operations = capability.spec.operations ?? [];
+  const runOp = (op: (typeof operations)[number], i: number) => ({
+    slug: op.slug || opSlug(op.name, i),
+    name: op.name || `Request ${i + 1}`,
+    price: formatPrice(op.price),
+    method: op.method || "GET",
+    body: op.sampleRequest ?? "",
+  });
   const contact = capability.contact;
   const contactHref = contact
     ? contact.startsWith("http")
@@ -68,6 +86,7 @@ export default async function CapabilityDetailPage({
             slug={capability.slug}
             price={formatPrice(capability.price)}
             agents={agentOptions}
+            operation={operations.length > 0 ? runOp(operations[0]!, 0) : undefined}
           />
           <UseCapabilityDialog
             endpoint={`${API_URL}/c/${capability.slug}`}
@@ -162,12 +181,27 @@ export default async function CapabilityDetailPage({
                   ) : null}
                   <span className="font-medium">{op.name || `Request ${i + 1}`}</span>
                   <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
-                    /{capability.slug}
+                    /{capability.slug}/{op.slug || opSlug(op.name, i)}
                   </code>
-                  <span className="ml-auto text-sm font-semibold">
-                    ${formatPrice(op.price)}
-                    <span className="text-xs font-normal text-muted-foreground">USDC/call</span>
+                  <span className="ml-auto text-sm font-semibold tabular-nums">
+                    {Number(op.price) > 0 ? (
+                      <>
+                        ${formatPrice(op.price)}
+                        <span className="text-xs font-normal text-muted-foreground">USDC/call</span>
+                      </>
+                    ) : (
+                      <span className="rounded-md bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+                        Free
+                      </span>
+                    )}
                   </span>
+                  <RunCapabilityDialog
+                    slug={capability.slug}
+                    price={formatPrice(op.price)}
+                    agents={agentOptions}
+                    operation={runOp(op, i)}
+                    trigger="compact"
+                  />
                 </div>
                 {op.sampleRequest || op.sampleResponse ? (
                   <div className="grid gap-4 md:grid-cols-2">

--- a/apps/dashboard/features/agents/run-capability-dialog.tsx
+++ b/apps/dashboard/features/agents/run-capability-dialog.tsx
@@ -20,21 +20,38 @@ import type { AgentOption } from "./queries";
  * actually pay (enough balance, within their per-call cap) are offered. Motion
  * follows the design rules: ease-out entrances, press feedback, a fast loader.
  */
+/** A specific priced operation to run (e.g. one MCP tool), when a capability
+ *  exposes several. Omit to run the base capability. */
+export interface RunOperation {
+  slug: string;
+  name: string;
+  price: string;
+  method?: string;
+  body?: string;
+}
+
 export function RunCapabilityDialog({
   slug,
   price,
   agents,
+  operation,
+  trigger = "default",
 }: {
   slug: string;
   price: string;
   agents: AgentOption[];
+  operation?: RunOperation;
+  /** "default" = the header "Run with card" button; "compact" = a small per-row Run. */
+  trigger?: "default" | "compact";
 }) {
   const [open, setOpen] = useState(false);
   const [pending, startTransition] = useTransition();
   const [result, setResult] = useState<RunResult | null>(null);
   const [query, setQuery] = useState("");
 
-  const priceNum = Number(price);
+  const runPrice = operation ? operation.price : price;
+  const runLabel = operation?.name;
+  const priceNum = Number(runPrice);
 
   // Only agents that can actually pay for this call.
   const eligible = useMemo(
@@ -63,19 +80,38 @@ export function RunCapabilityDialog({
   function run() {
     setResult(null);
     startTransition(async () => {
-      setResult(await runCapability({ agentId: selectedId, slug }));
+      setResult(
+        await runCapability({
+          agentId: selectedId,
+          slug,
+          operation: operation?.slug,
+          method: operation?.method,
+          body: operation?.body,
+        }),
+      );
     });
   }
 
   return (
     <>
-      <Button
-        variant="outline"
-        onClick={() => setOpen(true)}
-        className="transition-transform duration-100 ease-out active:scale-[0.97]"
-      >
-        <Play className="h-4 w-4" /> Run with card
-      </Button>
+      {trigger === "compact" ? (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setOpen(true)}
+          className="transition-transform duration-100 ease-out active:scale-[0.97]"
+        >
+          <Play className="h-3.5 w-3.5" /> Run
+        </Button>
+      ) : (
+        <Button
+          variant="outline"
+          onClick={() => setOpen(true)}
+          className="transition-transform duration-100 ease-out active:scale-[0.97]"
+        >
+          <Play className="h-4 w-4" /> Run with card
+        </Button>
+      )}
 
       <Dialog
         open={open}
@@ -86,10 +122,10 @@ export function RunCapabilityDialog({
       >
         <DialogContent className="max-w-md overflow-hidden">
           <DialogHeader className="min-w-0">
-            <DialogTitle>Run with a card</DialogTitle>
+            <DialogTitle>{runLabel ? `Run ${runLabel}` : "Run with a card"}</DialogTitle>
             <DialogDescription>
-              Your card pays ${price} in USDC and returns the result. Nothing exceeds the caps you
-              set.
+              Your card pays ${runPrice} in USDC and returns the result. Nothing exceeds the caps
+              you set.
             </DialogDescription>
           </DialogHeader>
 
@@ -101,7 +137,7 @@ export function RunCapabilityDialog({
             />
           ) : eligible.length === 0 ? (
             <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-              No card can pay ${price} for this call.
+              No card can pay ${runPrice} for this call.
               <br />
               <a
                 href="/agents"
@@ -163,7 +199,7 @@ export function RunCapabilityDialog({
 
               <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-3 py-2.5 text-sm">
                 <span className="text-muted-foreground">This call costs</span>
-                <span className="font-semibold tabular-nums">${price} USDC</span>
+                <span className="font-semibold tabular-nums">${runPrice} USDC</span>
               </div>
 
               {result?.error ? (

--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -57,7 +57,16 @@ async function spentLast24h(payer: string): Promise<Money> {
  * a runaway agent can never exceed the caps the owner set. The signing key is
  * decrypted only here, on the server, and never leaves it.
  */
-export async function runCapability(input: { agentId: string; slug: string }): Promise<RunResult> {
+export async function runCapability(input: {
+  agentId: string;
+  slug: string;
+  /** Optional operation slug: calls `/c/<slug>/<operation>` and pays its price. */
+  operation?: string;
+  /** HTTP method for the call (defaults to GET). */
+  method?: string;
+  /** Request body to forward to the capability (e.g. the tool selector for MCP). */
+  body?: string;
+}): Promise<RunResult> {
   const user = await getCurrentUser();
   if (!user) return { ok: false, error: "Not signed in." };
 
@@ -74,12 +83,35 @@ export async function runCapability(input: { agentId: string; slug: string }): P
 
   if (!agent?.secretEnc) return { ok: false, error: "Agent wallet not found." };
 
+  const url = input.operation
+    ? `${API_URL}/c/${input.slug}/${input.operation}`
+    : `${API_URL}/c/${input.slug}`;
+  const method = (input.method || "GET").toUpperCase();
+  const hasBody = method !== "GET" && method !== "HEAD" && Boolean(input.body?.trim());
+  const bodyInit = hasBody
+    ? {
+        body: input.body,
+        headers: { "content-type": "application/json" } as Record<string, string>,
+      }
+    : { headers: {} as Record<string, string> };
+
   // 1. Ask the gateway what this call costs (the 402 challenge).
   let req: Requirement;
   try {
-    const res = await fetch(`${API_URL}/c/${input.slug}`, { cache: "no-store" });
+    const res = await fetch(url, { cache: "no-store" });
+    // Free operation (price 0): the gateway proxies instead of returning 402.
+    // Nothing to sign — just make the real call with the intended method + body.
     if (res.status !== 402) {
-      return { ok: false, error: `Capability is not payable (got ${res.status}).` };
+      const direct = await fetch(url, {
+        method,
+        cache: "no-store",
+        ...(hasBody ? { body: input.body, headers: bodyInit.headers } : {}),
+      });
+      const body = await direct.text();
+      if (!direct.ok) {
+        return { ok: false, status: direct.status, body, error: friendlyError(direct.status) };
+      }
+      return { ok: true, status: direct.status, body, paid: "0" };
     }
     const body = (await res.json()) as { accepts: Requirement[] };
     if (!body.accepts?.[0]) return { ok: false, error: "Invalid payment challenge." };
@@ -145,11 +177,13 @@ export async function runCapability(input: { agentId: string; slug: string }): P
     return { ok: false, error: "Could not sign the payment (is the wallet funded?)." };
   }
 
-  // 5. Retry the call with the payment proof.
+  // 5. Retry the call with the payment proof (forwarding the method + body).
   try {
-    const res = await fetch(`${API_URL}/c/${input.slug}`, {
-      headers: { "X-PAYMENT": xPayment },
+    const res = await fetch(url, {
+      method,
+      headers: { "X-PAYMENT": xPayment, ...bodyInit.headers },
       cache: "no-store",
+      ...(hasBody ? { body: input.body } : {}),
     });
     const body = await res.text();
     if (!res.ok) {


### PR DESCRIPTION
The Run dialog only knew the capability, so it always used the base price ($0 for MCP-style capabilities) and a bare GET — which failed with 405 on a POST-only upstream (e.g. Nebula's tools).

Now each request row has its own Run button that calls /c/<slug>/<operation>, charges that operation's price, and forwards its method + sample request body (so the MCP tool selector reaches the upstream). Free operations (price 0) skip payment and just proxy. The header "Run with card" defaults to the first operation instead of the ambiguous base call.

<!--
Thanks for contributing to Tael! Keep PRs focused and small where possible.
See CONTRIBUTING.md for coding standards and the local workflow.
-->

## What & why

<!-- What does this change and why? Link the issue: Closes #123 -->

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor / chore
- [ ] Docs

## Checklist

- [ ] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` pass locally
- [ ] Added/updated tests for the change
- [ ] Added a changeset (`pnpm changeset`) if a published `@tael/*` package changed
- [ ] Updated docs (`ARCHITECTURE.md` / package `README`) if boundaries or public APIs changed
