### PR TITLE
fix(capabilities): show the Credit kind tile in the publish wizard

### DIFF
--- a/apps/dashboard/features/capabilities/publish-wizard.tsx
+++ b/apps/dashboard/features/capabilities/publish-wizard.tsx
@@ -25,7 +25,7 @@ import { CapabilityLogo } from "./capability-logo";
 import { LogoField } from "./logo-field";
 import { HTTP_METHODS, kindFields } from "./kind-fields";
 
-const KINDS = ["api", "mcp", "agent", "model", "dataset"] as const;
+const KINDS = ["api", "mcp", "agent", "model", "dataset", "credit"] as const;
 type Kind = (typeof KINDS)[number];
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";


### PR DESCRIPTION
The `credit` kind (from #51) was added to the Zod schema, DB enum, and `kind-meta`/`kind-fields`, but the publish wizard's `KINDS` array — which renders the selectable kind tiles — still listed only the original five. So **Credit never appeared as an option** in the wizard.

One-line fix: add `"credit"` to `KINDS`. Typecheck + eslint clean.