### PR TITLE
feat(gateway): forward paying agent identity via x-tael-agent header

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -24,6 +24,7 @@ const envSchema = z.object({
   TAEL_FEE_BPS: z.coerce.number().int().min(0).max(10000).default(100),
   RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60000),
   RATE_LIMIT_MAX: z.coerce.number().int().positive().default(120),
+  PARTNER_HMAC_SECRET: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -157,7 +157,7 @@ export async function handleGatewayRequest(
       }
 
       try {
-        return await proxyToUpstream(capability, paidRequest, targetUrl);
+        return await proxyToUpstream(capability, paidRequest, targetUrl, receipt.payer);
       } catch (error) {
         console.error("[gateway] upstream call failed:", error);
         return json({ error: "Upstream call failed" }, 502);

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -1,4 +1,6 @@
+import { createHmac } from "crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { env } from "../../env";
 import { InMemoryRateLimiter } from "./rate-limit";
 
 const testRateLimiter = new InMemoryRateLimiter(60000, 120);
@@ -552,6 +554,103 @@ describe("capability gateway", () => {
       result += decoder.decode(value, { stream: true });
     }
     expect(result).toBe("chunk1chunk2");
+  });
+
+  describe("paying agent identity forwarding", () => {
+    afterEach(() => {
+      env.PARTNER_HMAC_SECRET = undefined;
+    });
+
+    it("sends x-tael-agent with the payer address to the upstream on a paid call", async () => {
+      const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", upstream);
+
+      const { container } = buildContainer(CAPABILITY);
+      const app = createServer(container);
+
+      await app.request("/c/predict-age", {
+        method: "POST",
+        headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+      });
+
+      expect(upstream).toHaveBeenCalledOnce();
+      const forwarded = upstream.mock.calls[0]?.[1] as RequestInit;
+      const headers = new Headers(forwarded.headers);
+
+      expect(headers.has("x-tael-agent")).toBe(true);
+      expect(headers.get("x-tael-agent")).toBeTruthy();
+    });
+
+    it("does not send x-tael-agent on a free operation call", async () => {
+      const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", upstream);
+
+      const { container } = buildContainer(CAPABILITY);
+      const app = createServer(container);
+
+      await app.request("/c/predict-age/ping");
+
+      expect(upstream).toHaveBeenCalledOnce();
+      const forwarded = upstream.mock.calls[0]?.[1] as RequestInit;
+      const headers = new Headers(forwarded.headers);
+      expect(headers.has("x-tael-agent")).toBe(false);
+    });
+
+    it("attaches signature and timestamp headers when PARTNER_HMAC_SECRET is configured", async () => {
+      const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", upstream);
+
+      const secret = "my-secret-key";
+      env.PARTNER_HMAC_SECRET = secret;
+
+      const { container } = buildContainer(CAPABILITY);
+      const app = createServer(container);
+
+      await app.request("/c/predict-age", {
+        method: "POST",
+        headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+      });
+
+      expect(upstream).toHaveBeenCalledOnce();
+      const forwarded = upstream.mock.calls[0]?.[1] as RequestInit;
+      const headers = new Headers(forwarded.headers);
+
+      const agent = headers.get("x-tael-agent");
+      const ts = headers.get("x-tael-timestamp");
+      const sig = headers.get("x-tael-agent-sig");
+
+      expect(agent).toBeTruthy();
+      expect(ts).toBeTruthy();
+      expect(sig).toBeTruthy();
+
+      const hmac = createHmac("sha256", secret);
+      hmac.update(`${ts}.${agent}`);
+      const expectedSig = hmac.digest("hex");
+      expect(sig).toBe(expectedSig);
+    });
+
+    it("does not attach signature and timestamp headers when PARTNER_HMAC_SECRET is unset", async () => {
+      const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", upstream);
+
+      env.PARTNER_HMAC_SECRET = undefined;
+
+      const { container } = buildContainer(CAPABILITY);
+      const app = createServer(container);
+
+      await app.request("/c/predict-age", {
+        method: "POST",
+        headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+      });
+
+      expect(upstream).toHaveBeenCalledOnce();
+      const forwarded = upstream.mock.calls[0]?.[1] as RequestInit;
+      const headers = new Headers(forwarded.headers);
+
+      expect(headers.get("x-tael-agent")).toBeTruthy();
+      expect(headers.has("x-tael-timestamp")).toBe(false);
+      expect(headers.has("x-tael-agent-sig")).toBe(false);
+    });
   });
 
   describe("gateway rate limiting", () => {

--- a/apps/api/src/modules/gateway/upstream.ts
+++ b/apps/api/src/modules/gateway/upstream.ts
@@ -1,5 +1,7 @@
+import { createHmac } from "crypto";
 import { decryptSecret } from "@tael/database";
 import { type ServableCapability } from "../capabilities/capability.repository";
+import { env } from "../../env";
 
 /** How long we wait on the upstream before giving up. */
 const UPSTREAM_TIMEOUT_MS = 30_000;
@@ -55,6 +57,7 @@ export async function proxyToUpstream(
   capability: ServableCapability,
   request: Request,
   targetUrl: string = capability.upstreamUrl,
+  agentAddress?: string,
 ): Promise<Response> {
   const headers = new Headers();
   request.headers.forEach((value, key) => {
@@ -76,6 +79,20 @@ export async function proxyToUpstream(
   if (auth.extraHeaders) {
     for (const [key, value] of Object.entries(auth.extraHeaders)) {
       headers.set(key, value);
+    }
+  }
+
+  if (agentAddress) {
+    headers.set("x-tael-agent", agentAddress);
+    const partnerSecret = env.PARTNER_HMAC_SECRET;
+    if (partnerSecret) {
+      const ts = Date.now();
+      const hmac = createHmac("sha256", partnerSecret);
+      hmac.update(`${ts}.${agentAddress}`);
+      const sig = hmac.digest("hex");
+
+      headers.set("x-tael-timestamp", String(ts));
+      headers.set("x-tael-agent-sig", sig);
     }
   }
 

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -13,6 +13,7 @@ const testEnv: Env = {
   TAEL_FEE_BPS: 100,
   RATE_LIMIT_WINDOW_MS: 60000,
   RATE_LIMIT_MAX: 120,
+  PARTNER_HMAC_SECRET: undefined,
 };
 
 const app = createServer(createContainer(testEnv));


### PR DESCRIPTION
## What & why

This PR forwards the verified identity (Stellar address) of the paying Card (`receipt.payer`) to upstream capabilities via an `x-tael-agent` header on paid requests. This enables partner backends (such as Nebula) to attribute and isolate state per agent Card.

Key changes:
- Updated `proxyToUpstream` to accept `agentAddress?: string`.
- Added the `x-tael-agent` header to the proxied requests when `agentAddress` is present.
- Support cryptographic anti-spoofing signature verification: if `PARTNER_HMAC_SECRET` is set in env, Tael will sign the header with a timestamp and attach `x-tael-timestamp` and `x-tael-agent-sig` (HMAC SHA-256) headers.
- Pass `receipt.payer` inside the paid path execution block in `gateway.handler.ts`.
- Mocked and added complete integration tests to `gateway.test.ts` to verify headers are present/absent correctly across paid vs free operation calls, and validated the cryptographic signature verification.

Closes #59 (or the relevant issue number)

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Refactor / chore
- [ ] Docs

## Checklist

- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` pass locally
- [x] Added/updated tests for the change
- [ ] Added a changeset (`pnpm changeset`)
- [ ] Updated docs (`ARCHITECTURE.md` / package `README`)
