### PR TITLE
feat(gateway): substitute {payer} in a capability's upstream URL

### DIFF
--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -1,7 +1,7 @@
 import { tael } from "@tael/sdk";
 import { PAYMENT_REQUEST_HEADER, splitFee } from "@tael/payments";
 import { type Container } from "../../container";
-import { proxyToUpstream, isBlockedUrl, resolveUpstreamUrl } from "./upstream";
+import { applyPayerToken, proxyToUpstream, isBlockedUrl, resolveUpstreamUrl } from "./upstream";
 import { checkRateLimit } from "./rate-limit";
 
 /** The slice of the container the gateway needs. */
@@ -157,7 +157,11 @@ export async function handleGatewayRequest(
       }
 
       try {
-        return await proxyToUpstream(capability, paidRequest, targetUrl, receipt.payer);
+        // Substitute `{payer}` in the URL with the verified caller so per-caller
+        // capabilities (e.g. TrustLine's `/agent/{payer}/available-credit`) hit
+        // the right resource. No token → unchanged.
+        const upstreamUrl = applyPayerToken(targetUrl, receipt.payer);
+        return await proxyToUpstream(capability, paidRequest, upstreamUrl, receipt.payer);
       } catch (error) {
         console.error("[gateway] upstream call failed:", error);
         return json({ error: "Upstream call failed" }, 502);

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -212,6 +212,31 @@ describe("capability gateway", () => {
     expect(upstream.mock.calls[0]?.[0]).toBe("https://api.example.com/age/premium");
   });
 
+  it("substitutes the {payer} token in the upstream URL with the caller's address", async () => {
+    const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", upstream);
+
+    // A per-caller capability: its upstream references the paying agent.
+    const perCaller: ServableCapability = {
+      ...CAPABILITY,
+      upstreamUrl: "https://api.example.com/agent/{payer}/available-credit",
+      operations: [],
+    };
+    const { container } = buildContainer(perCaller);
+    const app = createServer(container);
+    await app.request("/c/predict-age", {
+      method: "POST",
+      headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+    });
+
+    // {payer} is replaced with the verified payer (never a literal token).
+    const calledUrl = String(upstream.mock.calls[0]?.[0]);
+    expect(calledUrl).not.toContain("{payer}");
+    expect(calledUrl).toMatch(
+      /^https:\/\/api\.example\.com\/agent\/mock_payer_.+\/available-credit$/,
+    );
+  });
+
   it("proxies to the upstream and records the payment when paid", async () => {
     const upstream = vi.fn<typeof fetch>(
       async () =>

--- a/apps/api/src/modules/gateway/upstream.ts
+++ b/apps/api/src/modules/gateway/upstream.ts
@@ -48,6 +48,19 @@ export function resolveUpstreamUrl(base: string, path: string): string {
 }
 
 /**
+ * Substitute the `{payer}` token in a resolved upstream URL with the caller's
+ * Stellar address, enabling per-caller capabilities (e.g. TrustLine's
+ * `…/agent/{payer}/available-credit`). No token → returned unchanged, so every
+ * existing capability behaves byte-for-byte as before. The address comes from
+ * the settled payment (`receipt.payer`), so it can't be spoofed by the caller;
+ * it's a base32 G-address (URL-safe), but we encode defensively.
+ */
+export function applyPayerToken(url: string, payer: string | undefined): string {
+  if (!url.includes("{payer}")) return url;
+  return url.replaceAll("{payer}", encodeURIComponent(payer ?? ""));
+}
+
+/**
  * Proxy the (already-paid) request to the capability's real upstream endpoint,
  * injecting the decrypted API key. Forwards the caller's method, body, and safe
  * headers; returns the upstream response verbatim. `targetUrl` is the resolved


### PR DESCRIPTION
Implements the TrustLine follow-up ask: let a capability's upstream URL reference the caller.

A publisher can put `{payer}` anywhere in the upstream URL (or an operation path), and the gateway substitutes the **paying agent's Stellar address** at call time. This makes **per-caller** capabilities possible:

```
https://<trustline-api>/agent/{payer}/available-credit
```
→ every caller gets *their own* credit read, from one capability.

## Why it's safe
- **Purely additive** — no `{payer}` token → byte-for-byte identical behavior. Every existing capability is unaffected.
- **Un-spoofable** — the address is `receipt.payer` (the settled tx's source), not user input.
- Applied only on the **paid** path (the free path has no payer).

## Complements #67
- `x-tael-agent` header (#67) → for upstreams that read a header (Nebula's MCP model).
- `{payer}` URL token (this) → for path-shaped REST endpoints (TrustLine's credit read).

## Verified
typecheck clean, api tests **32/32** (new: `{payer}` substitution), eslint + prettier clean. No env vars, no migration.