### PR TITLE
docs(capabilities): tell publishers their payout wallet needs a USDC trustline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,6 @@ WAITLIST_FROM_EMAIL="Tael <hello@taelprotocol.xyz>"
 NEXT_PUBLIC_DASHBOARD_URL=http://localhost:3002
 # Network the wallet connects to (client-exposed). "testnet" | "mainnet".
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
+# USDC issuer Tael settles in (client-exposed) — shown to publishers so they add
+# the matching trustline on their payout wallet. Must equal the API's USDC_ISSUER.
+NEXT_PUBLIC_USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5

--- a/apps/dashboard/features/capabilities/publish-wizard.tsx
+++ b/apps/dashboard/features/capabilities/publish-wizard.tsx
@@ -30,6 +30,12 @@ type Kind = (typeof KINDS)[number];
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
+// The USDC issuer Tael settles in. A payout wallet MUST hold a trustline for
+// this issuer, or Stellar rejects the payment (op_no_trust). Shown to publishers
+// so they set it up before listing.
+const USDC_ISSUER =
+  process.env.NEXT_PUBLIC_USDC_ISSUER ?? "GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+
 type Step = "describe" | "test" | "verify" | "done";
 type Answer = { question: string; answer: string };
 type Operation = {
@@ -508,6 +514,17 @@ export function PublishWizard() {
                 required
               />
             </Field>
+
+            <div className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/[0.05] px-3 py-2.5 text-xs text-amber-700">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span className="min-w-0">
+                Your pay-to wallet must hold a <span className="font-semibold">USDC trustline</span>{" "}
+                for Tael&apos;s issuer, or payments will be rejected on-chain. Add a trustline to:
+                <span className="mt-1 block break-all font-mono text-[11px] text-amber-800">
+                  {USDC_ISSUER}
+                </span>
+              </span>
+            </div>
 
             {error ? <p className="text-sm text-destructive">{error}</p> : null}
 

--- a/apps/web/app/docs/become-a-capability/page.tsx
+++ b/apps/web/app/docs/become-a-capability/page.tsx
@@ -41,7 +41,8 @@ hand to the Tael team.
    - a suggested price per call in USDC, with a short reason
 4. Flag anything that does not fit a plain paid HTTP endpoint, such as streaming, stateful sessions,
    MCP over HTTP, or on-chain signing, and suggest how to adapt it.
-5. Ask me for my Stellar payout address, which is where the USDC will settle.
+5. Ask me for my Stellar payout address, and remind me it must hold a USDC trustline for Tael's
+   issuer (shown on the publish form) or payments will be rejected on-chain.
 
 ## Output
 Return the completed manifest as a table, followed by a short note on anything that needs a custom
@@ -121,9 +122,18 @@ const result = await tael.post("your-product", { ...input });`}
           <strong>A price per call</strong> in USDC, where fractions of a cent are perfectly fine.
         </li>
         <li>
-          <strong>A Stellar payout address</strong> where your earnings land.
+          <strong>A Stellar payout address</strong> where your earnings land. It must hold a{" "}
+          <strong>USDC trustline for Tael&apos;s issuer</strong> (see below), or payments are
+          rejected on-chain.
         </li>
       </Ul>
+      <Callout>
+        <strong>Set up the USDC trustline first.</strong> Tael settles in USDC from a specific
+        issuer, and Stellar will reject a payment to an account that doesn&apos;t trust that asset (
+        <Code>op_no_trust</Code>). Before you publish, add a USDC trustline to your payout wallet
+        for Tael&apos;s issuer &mdash; the exact issuer address is shown on the publish form, next
+        to the pay-to field. This is a one-time transaction on your side.
+      </Callout>
       <Callout>
         Streaming, stateful sessions, and on-chain signing do not fit the plain request and response
         model out of the box, but they are supported through a custom adapter. Note them in your


### PR DESCRIPTION
**Prevents the silent "unpayable capability" trap** that just bit the Nebula listing.

A capability's `payTo` wallet must hold a **USDC trustline for Tael's issuer**, or the gateway's payment is rejected on-chain (`op_no_trust` → the call 500s at settlement, before any charge). This wasn't surfaced anywhere, so a publisher could list a *verified* capability that's silently unpayable.

## Changes
- **Publish form:** an amber notice under the pay-to field with the **exact USDC issuer address** to add a trustline for (from `NEXT_PUBLIC_USDC_ISSUER`).
- **Docs (become a capability):** a requirement bullet + a callout explaining the trustline (`op_no_trust`), and the onboarding prompt reminds partners of it.
- **.env.example:** add `NEXT_PUBLIC_USDC_ISSUER`.

## Deploy note
Set `NEXT_PUBLIC_USDC_ISSUER` on Vercel (dashboard) to match the API's `USDC_ISSUER` (currently `GBCDXWBEN…`), so the form shows the correct issuer. Falls back to that value if unset.

Verified: typecheck (dashboard + web) clean, eslint clean. No em dashes, no migration.