### PR TITLE
feat(capabilities): choose the upstream auth scheme when publishing

### DIFF
--- a/apps/dashboard/features/capabilities/actions.ts
+++ b/apps/dashboard/features/capabilities/actions.ts
@@ -9,11 +9,30 @@ import {
   ilike,
   type CapabilityFaq,
   type CapabilitySpec,
+  type UpstreamAuth,
 } from "@tael/database";
 import { generateFaqQuestions } from "@tael/claude";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "./current-user";
-import { minPrice, publishCapabilitySchema, slugify } from "./schema";
+import { minPrice, parseHeaderLines, publishCapabilitySchema, slugify } from "./schema";
+
+/** Build the stored UpstreamAuth from the publisher's choices, or null for the
+ *  plain Bearer default (keeps existing behavior + a compact row). */
+function buildUpstreamAuth(input: {
+  authScheme: "bearer" | "header" | "none";
+  authHeader: string;
+  authExtraHeaders: string;
+}): UpstreamAuth | null {
+  const extra = parseHeaderLines(input.authExtraHeaders);
+  const hasExtra = Object.keys(extra).length > 0;
+  // Plain bearer with no static headers = the default → store null.
+  if (input.authScheme === "bearer" && !hasExtra) return null;
+  return {
+    scheme: input.authScheme,
+    header: input.authScheme === "header" ? input.authHeader || undefined : undefined,
+    extraHeaders: hasExtra ? extra : undefined,
+  };
+}
 
 /** Live result of calling a capability's endpoint during verification. */
 export interface TestResult {
@@ -40,6 +59,9 @@ export async function testRequest(input: {
   method: string;
   body: string;
   secret: string;
+  authScheme?: "bearer" | "header" | "none";
+  authHeader?: string;
+  authExtraHeaders?: string;
 }): Promise<{ ok: boolean; result?: TestResult; error?: string }> {
   const user = await getCurrentUser();
   if (!user) return { ok: false, error: "Not signed in." };
@@ -49,6 +71,9 @@ export async function testRequest(input: {
     method: input.method || "POST",
     body: input.body,
     secret: input.secret,
+    authScheme: input.authScheme ?? "bearer",
+    authHeader: input.authHeader ?? "",
+    authExtraHeaders: input.authExtraHeaders ?? "",
   });
   return { ok: true, result };
 }
@@ -147,6 +172,7 @@ export async function publishCapability(
       payTo: input.payTo,
       upstreamUrl: input.upstreamUrl,
       upstreamSecretEnc: input.upstreamSecret ? encryptSecret(input.upstreamSecret) : null,
+      upstreamAuth: buildUpstreamAuth(input),
       publisherId: user.id,
     });
   } catch (error) {
@@ -217,6 +243,9 @@ async function testUpstream(args: {
   method: string;
   body: string;
   secret: string;
+  authScheme: "bearer" | "header" | "none";
+  authHeader: string;
+  authExtraHeaders: string;
 }): Promise<TestResult> {
   if (isBlockedUrl(args.url)) {
     return {
@@ -230,8 +259,15 @@ async function testUpstream(args: {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 15000);
   try {
+    // Mirror the gateway's auth injection so the test hits the endpoint the same
+    // way a live call will (Bearer, a named header like x-api-key, or none).
     const headers: Record<string, string> = { accept: "application/json" };
-    if (args.secret) headers.authorization = `Bearer ${args.secret}`;
+    if (args.secret) {
+      if (args.authScheme === "bearer") headers.authorization = `Bearer ${args.secret}`;
+      else if (args.authScheme === "header" && args.authHeader)
+        headers[args.authHeader] = args.secret;
+    }
+    for (const [k, v] of Object.entries(parseHeaderLines(args.authExtraHeaders))) headers[k] = v;
     let reqBody: string | undefined;
     if (args.method !== "GET" && args.method !== "DELETE" && args.body.trim()) {
       headers["content-type"] = "application/json";
@@ -278,6 +314,9 @@ function readDescribe(formData: FormData): Record<string, unknown> {
     payTo: formData.get("payTo"),
     upstreamUrl: formData.get("upstreamUrl"),
     upstreamSecret: formData.get("upstreamSecret") ?? "",
+    authScheme: formData.get("authScheme") ?? "bearer",
+    authHeader: formData.get("authHeader") ?? "",
+    authExtraHeaders: formData.get("authExtraHeaders") ?? "",
     visibility: formData.get("visibility") ?? "public",
     operations: safeParseJson(formData.get("operations")),
   };

--- a/apps/dashboard/features/capabilities/publish-wizard.tsx
+++ b/apps/dashboard/features/capabilities/publish-wizard.tsx
@@ -173,6 +173,9 @@ export function PublishWizard() {
         method: op.method || "POST",
         body: op.sampleRequest,
         secret: describe.upstreamSecret ?? "",
+        authScheme: (describe.authScheme as "bearer" | "header" | "none") ?? "bearer",
+        authHeader: describe.authHeader ?? "",
+        authExtraHeaders: describe.authExtraHeaders ?? "",
       });
       setTestingIndex(null);
       if (!res.ok || !res.result) {
@@ -365,6 +368,44 @@ export function PublishWizard() {
                 onChange={(e) => setField("upstreamSecret", e.target.value)}
                 type="password"
                 placeholder="sk-…"
+              />
+            </Field>
+
+            <Field
+              label="Auth scheme"
+              hint="How Tael sends your secret to the endpoint. Use a header like x-api-key for Anthropic; Bearer for most APIs."
+            >
+              <select
+                value={describe.authScheme ?? "bearer"}
+                onChange={(e) => setField("authScheme", e.target.value)}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-2 text-sm"
+              >
+                <option value="bearer">Bearer (Authorization: Bearer …)</option>
+                <option value="header">Custom header (e.g. x-api-key)</option>
+                <option value="none">None (no secret sent)</option>
+              </select>
+            </Field>
+
+            {describe.authScheme === "header" ? (
+              <Field label="Header name" hint="The header the secret is sent in, e.g. x-api-key.">
+                <Input
+                  value={describe.authHeader ?? ""}
+                  onChange={(e) => setField("authHeader", e.target.value)}
+                  placeholder="x-api-key"
+                />
+              </Field>
+            ) : null}
+
+            <Field
+              label="Extra headers"
+              hint="Static headers sent on every call, one per line as Name: value. e.g. anthropic-version: 2023-06-01"
+            >
+              <textarea
+                rows={2}
+                value={describe.authExtraHeaders ?? ""}
+                onChange={(e) => setField("authExtraHeaders", e.target.value)}
+                placeholder={"anthropic-version: 2023-06-01"}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs"
               />
             </Field>
 

--- a/apps/dashboard/features/capabilities/schema.ts
+++ b/apps/dashboard/features/capabilities/schema.ts
@@ -47,9 +47,28 @@ export const describeCapabilitySchema = z.object({
   payTo: stellarAddressSchema,
   upstreamUrl: z.string().url("Enter a valid URL"),
   upstreamSecret: z.string().max(500).optional().default(""),
+  // How Tael sends the upstream secret: bearer (default), a named header
+  // (e.g. x-api-key for Anthropic), or none. `authExtraHeaders` are static
+  // headers always sent (e.g. "anthropic-version: 2023-06-01"), one per line.
+  authScheme: z.enum(["bearer", "header", "none"]).optional().default("bearer"),
+  authHeader: z.string().max(100).optional().default(""),
+  authExtraHeaders: z.string().max(1000).optional().default(""),
   visibility: z.enum(["public", "unlisted", "private"]).default("public"),
   operations: z.array(operationSchema).min(1, "Add at least one request"),
 });
+
+/** Parse "Header-Name: value" lines into a record; ignores blanks/malformed. */
+export function parseHeaderLines(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key && value) out[key] = value;
+  }
+  return out;
+}
 
 export type DescribeCapabilityInput = z.infer<typeof describeCapabilitySchema>;
 


### PR DESCRIPTION
**Piece 1 of listing first-party models (Claude, Grok, …).** The backend supported `upstreamAuth` since #57, but the publish form couldn't set it — so everything published as Bearer. This adds the picker.

## What's new
On the publish form, an **Auth scheme** selector:
- **Bearer** (default) → `Authorization: Bearer <secret>`
- **Custom header** (e.g. `x-api-key`) → for Anthropic and similar
- **None**

Plus an **Extra headers** field for static headers (one per line, `Name: value`), e.g. `anthropic-version: 2023-06-01`.

Wired through the form → `publishCapability` (stored as `upstreamAuth`) → and the live **Test** step, so testing hits the endpoint the same way a real call will. Plain Bearer + no extra headers still stores `null` (identical to before).

## Verified
dashboard typecheck + eslint clean, prettier clean. No migration (uses the `upstream_auth` column from #57).

## Next (this thread's plan)
2. Verified control (publish stops auto-verifying; Tael grants Verified)
3. Metered billing #56 (pass-through token pricing)
4. Model Run UI + token usage display