### PR TITLE
feat(capabilities): Verified is Tael-granted; publishes start Pending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,6 @@ NEXT_PUBLIC_STELLAR_NETWORK=testnet
 # USDC issuer Tael settles in (client-exposed) — shown to publishers so they add
 # the matching trustline on their payout wallet. Must equal the API's USDC_ISSUER.
 NEXT_PUBLIC_USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+# Tael-team wallet addresses (comma-separated) allowed to grant the Verified
+# badge on capabilities. Server-only. Empty = no one can verify.
+ADMIN_WALLET_ADDRESSES=

--- a/apps/api/src/modules/capabilities/capability.repository.ts
+++ b/apps/api/src/modules/capabilities/capability.repository.ts
@@ -122,7 +122,9 @@ export class DbCapabilityRepository implements CapabilityRepository {
       .where(
         and(
           eq(capabilities.slug, slug),
-          eq(capabilities.status, "verified"),
+          // Serve anything published (pending OR verified), not drafts. Verified
+          // is a trust badge, not a gate on usability.
+          ne(capabilities.status, "draft"),
           ne(capabilities.visibility, "private"),
         ),
       )
@@ -156,7 +158,9 @@ export class DbCapabilityRepository implements CapabilityRepository {
     }
 
     const limit = Math.min(Math.max(query.limit ?? 50, 1), 100);
-    const filters = [eq(capabilities.status, "verified"), eq(capabilities.visibility, "public")];
+    // List anything published (pending + verified), public only. The `verified`
+    // field below reflects which ones carry the trust badge.
+    const filters = [ne(capabilities.status, "draft"), eq(capabilities.visibility, "public")];
     if (query.kind)
       filters.push(
         eq(capabilities.kind, query.kind as (typeof capabilities.kind.enumValues)[number]),

--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -3,9 +3,11 @@ import { notFound } from "next/navigation";
 import { ArrowLeft, BadgeCheck, ChevronDown, Code2 } from "lucide-react";
 import { cn } from "@tael/ui";
 import { getPublicCapabilityBySlug } from "../../../../features/capabilities/queries";
+import { isCurrentUserAdmin } from "../../../../features/capabilities/actions";
 import { CapabilityLogo } from "../../../../features/capabilities/capability-logo";
 import { formatPrice, kindMeta, timeAgo } from "../../../../features/capabilities/kind-meta";
 import { UseCapabilityDialog } from "../../../../features/capabilities/use-capability-dialog";
+import { VerifyToggle } from "../../../../features/capabilities/verify-toggle";
 import { RunCapabilityDialog } from "../../../../features/agents/run-capability-dialog";
 import { listAgentsForRun } from "../../../../features/agents/queries";
 import { ReviewsSection } from "../../../../features/reviews/reviews-section";
@@ -37,6 +39,7 @@ export default async function CapabilityDetailPage({
 
   const agentOptions = await listAgentsForRun();
   const verified = capability.status === "verified";
+  const isAdmin = await isCurrentUserAdmin();
   const meta = kindMeta(capability.kind);
   const Icon = meta.icon;
   const operations = capability.spec.operations ?? [];
@@ -103,8 +106,8 @@ export default async function CapabilityDetailPage({
               <BadgeCheck className="h-4 w-4" /> Verified
             </span>
           ) : (
-            <span className="inline-flex rounded-full bg-muted px-2.5 py-1 text-sm text-muted-foreground">
-              Draft
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-sm font-medium text-amber-700">
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" /> Pending review
             </span>
           )}
         </Meta>
@@ -127,6 +130,8 @@ export default async function CapabilityDetailPage({
           <span className="font-medium">{timeAgo(capability.createdAt.toISOString())}</span>
         </Meta>
       </div>
+
+      {isAdmin ? <VerifyToggle id={capability.id} verified={verified} /> : null}
 
       {contact ? (
         <p className="text-sm text-muted-foreground">

--- a/apps/dashboard/features/capabilities/actions.ts
+++ b/apps/dashboard/features/capabilities/actions.ts
@@ -165,7 +165,9 @@ export async function publishCapability(
       contact: input.contact || null,
       kind: input.kind,
       visibility: input.visibility,
-      status: "verified",
+      // Published capabilities are usable + listed immediately, but start
+      // `pending` — Tael grants `verified` (the trust badge) after review.
+      status: "pending",
       faqs,
       spec,
       price: minPrice(input.operations),
@@ -183,6 +185,45 @@ export async function publishCapability(
   revalidatePath("/capabilities");
   revalidatePath("/marketplace");
   return { ok: true, slug };
+}
+
+/** Tael-team wallet addresses allowed to grant/revoke the Verified badge. */
+const ADMIN_WALLETS = new Set(
+  (process.env.ADMIN_WALLET_ADDRESSES ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
+/** Whether the signed-in user is a Tael admin (can grant Verified). */
+export async function isCurrentUserAdmin(): Promise<boolean> {
+  const user = await getCurrentUser();
+  return user ? ADMIN_WALLETS.has(user.walletAddress) : false;
+}
+
+/**
+ * Grant or revoke the Verified badge on a capability. Admin-only. Publishing
+ * leaves a capability `pending`; Tael marks it `verified` after review (or back
+ * to `pending`). Usability is unaffected either way — verified is a trust badge.
+ */
+export async function setCapabilityVerified(id: string, verified: boolean): Promise<ActionResult> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+  if (!ADMIN_WALLETS.has(user.walletAddress)) return { ok: false, error: "Not authorized." };
+
+  try {
+    await db
+      .update(capabilities)
+      .set({ status: verified ? "verified" : "pending" })
+      .where(eq(capabilities.id, id));
+  } catch (error) {
+    console.error("[capabilities] verify update failed:", error);
+    return { ok: false, error: "Could not update. Try again." };
+  }
+
+  revalidatePath("/marketplace");
+  revalidatePath("/marketplace/[slug]", "page");
+  return { ok: true };
 }
 
 /** Delete a capability the signed-in user owns. */

--- a/apps/dashboard/features/capabilities/capabilities-table.tsx
+++ b/apps/dashboard/features/capabilities/capabilities-table.tsx
@@ -11,7 +11,7 @@ import type { CapabilityListItem } from "./list-item";
 
 export function CapabilitiesTable({ items }: { items: CapabilityListItem[] }) {
   const [query, setQuery] = useState("");
-  const [status, setStatus] = useState<"all" | "verified" | "draft">("all");
+  const [status, setStatus] = useState<"all" | "verified" | "pending" | "draft">("all");
   const [pendingDelete, setPendingDelete] = useState<CapabilityListItem | null>(null);
 
   const filtered = useMemo(
@@ -45,6 +45,7 @@ export function CapabilitiesTable({ items }: { items: CapabilityListItem[] }) {
         >
           <option value="all">All statuses</option>
           <option value="verified">Verified</option>
+          <option value="pending">Pending</option>
           <option value="draft">Draft</option>
         </select>
       </div>
@@ -93,6 +94,10 @@ export function CapabilitiesTable({ items }: { items: CapabilityListItem[] }) {
                     {c.status === "verified" ? (
                       <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700">
                         <BadgeCheck className="h-3.5 w-3.5" /> Verified
+                      </span>
+                    ) : c.status === "pending" ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700">
+                        <span className="h-1.5 w-1.5 rounded-full bg-amber-500" /> Pending
                       </span>
                     ) : (
                       <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">

--- a/apps/dashboard/features/capabilities/queries.ts
+++ b/apps/dashboard/features/capabilities/queries.ts
@@ -1,14 +1,15 @@
 import "server-only";
-import { and, capabilities, desc, eq, type Capability } from "@tael/database";
+import { and, capabilities, desc, eq, ne, type Capability } from "@tael/database";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "./current-user";
 
-/** Public capabilities for the marketplace, newest first. */
+/** Public, published capabilities for the marketplace, newest first. Excludes
+ *  drafts; includes both pending and verified (the badge distinguishes them). */
 export async function listPublicCapabilities(): Promise<Capability[]> {
   return db
     .select()
     .from(capabilities)
-    .where(eq(capabilities.visibility, "public"))
+    .where(and(eq(capabilities.visibility, "public"), ne(capabilities.status, "draft")))
     .orderBy(desc(capabilities.createdAt));
 }
 

--- a/apps/dashboard/features/capabilities/verify-toggle.tsx
+++ b/apps/dashboard/features/capabilities/verify-toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { BadgeCheck, ShieldCheck } from "lucide-react";
+import { Button } from "@tael/ui";
+import { setCapabilityVerified } from "./actions";
+
+/**
+ * Admin-only control to grant or revoke the Verified badge on a capability.
+ * Rendered on the marketplace detail page only when the viewer is a Tael admin.
+ */
+export function VerifyToggle({ id, verified }: { id: string; verified: boolean }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function toggle() {
+    setError(null);
+    startTransition(async () => {
+      const res = await setCapabilityVerified(id, !verified);
+      if (res.ok) router.refresh();
+      else setError(res.error ?? "Could not update.");
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-dashed px-3 py-2">
+      <ShieldCheck className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 text-xs text-muted-foreground">
+        Admin: {verified ? "this capability is verified." : "not verified yet."}
+      </span>
+      {verified ? (
+        <Button variant="outline" size="sm" onClick={toggle} disabled={pending}>
+          {pending ? "…" : "Unverify"}
+        </Button>
+      ) : (
+        <Button size="sm" onClick={toggle} disabled={pending}>
+          <BadgeCheck className="h-4 w-4" /> {pending ? "Verifying…" : "Verify"}
+        </Button>
+      )}
+      {error ? <span className="text-xs text-destructive">{error}</span> : null}
+    </div>
+  );
+}

--- a/packages/database/drizzle/0013_mixed_warhawk.sql
+++ b/packages/database/drizzle/0013_mixed_warhawk.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."capability_status" ADD VALUE 'pending' BEFORE 'verified';

--- a/packages/database/drizzle/meta/0013_snapshot.json
+++ b/packages/database/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1003 @@
+{
+  "id": "ab23f817-974e-4dbc-8aa0-018dfdd712fa",
+  "prevId": "04c96a3f-539e-4a53-95ce-de624bb0bc2d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_wallet_address_idx": {
+          "name": "users_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Main'"
+        },
+        "secret_enc": {
+          "name": "secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_cached": {
+          "name": "balance_cached",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallets_owner_id_idx": {
+          "name": "wallets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallets_owner_id_users_id_fk": {
+          "name": "wallets_owner_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_address_unique": {
+          "name": "wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "capability_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "capability_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "capability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "faqs": {
+          "name": "faqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pay_to": {
+          "name": "pay_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_secret_enc": {
+          "name": "upstream_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_auth": {
+          "name": "upstream_auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capabilities_publisher_id_idx": {
+          "name": "capabilities_publisher_id_idx",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_kind_idx": {
+          "name": "capabilities_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_visibility_idx": {
+          "name": "capabilities_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capabilities_publisher_id_users_id_fk": {
+          "name": "capabilities_publisher_id_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capabilities_slug_unique": {
+          "name": "capabilities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_wallet_id_wallets_id_fk": {
+          "name": "agents_wallet_id_wallets_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_name": {
+          "name": "capability_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer": {
+          "name": "payer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_capability_id_idx": {
+          "name": "payments_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_agent_id_idx": {
+          "name": "payments_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payer_idx": {
+          "name": "payments_payer_idx",
+          "columns": [
+            {
+              "expression": "payer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payee_idx": {
+          "name": "payments_payee_idx",
+          "columns": [
+            {
+              "expression": "payee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_status_idx": {
+          "name": "payments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_tx_hash_unique": {
+          "name": "payments_tx_hash_unique",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_capability_id_capabilities_id_fk": {
+          "name": "payments_capability_id_capabilities_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_agent_id_agents_id_fk": {
+          "name": "payments_agent_id_agents_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_owner_id_idx": {
+          "name": "api_keys_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_owner_id_users_id_fk": {
+          "name": "api_keys_owner_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_agent_id_agents_id_fk": {
+          "name": "api_keys_agent_id_agents_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_capability_id_idx": {
+          "name": "reviews_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_capability_id_capabilities_id_fk": {
+          "name": "reviews_capability_id_capabilities_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_reviewer_id_users_id_fk": {
+          "name": "reviews_reviewer_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_capability_reviewer_unique": {
+          "name": "reviews_capability_reviewer_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "capability_id",
+            "reviewer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.capability_kind": {
+      "name": "capability_kind",
+      "schema": "public",
+      "values": [
+        "api",
+        "mcp",
+        "agent",
+        "model",
+        "dataset",
+        "credit"
+      ]
+    },
+    "public.capability_status": {
+      "name": "capability_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "verified"
+      ]
+    },
+    "public.capability_visibility": {
+      "name": "capability_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "private"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "settled",
+        "failed",
+        "refunded"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1784303696530,
       "tag": "0012_perpetual_the_leader",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1784339350994,
+      "tag": "0013_mixed_warhawk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/_shared.ts
+++ b/packages/database/src/schema/_shared.ts
@@ -48,11 +48,14 @@ export const capabilityVisibility = pgEnum("capability_visibility", [
 ]);
 
 /**
- * Verification lifecycle of a capability. `draft` = created but not through the
- * publish/verify wizard; `verified` = the publisher answered the AI-generated
- * FAQ and it's listed with a trust badge.
+ * Verification lifecycle of a capability.
+ *  - `draft`    — created but not published through the wizard (not listed).
+ *  - `pending`  — published and fully usable (listed + callable), but Tael has
+ *                 not vetted it yet, so it shows without the trust badge.
+ *  - `verified` — Tael-vetted; carries the green "Verified" badge.
+ * Only Tael grants `verified` (first-party listings + reviewed third parties).
  */
-export const capabilityStatus = pgEnum("capability_status", ["draft", "verified"]);
+export const capabilityStatus = pgEnum("capability_status", ["draft", "pending", "verified"]);
 
 /** Lifecycle of a payment / settlement. Mirrors @tael/types paymentStatus. */
 export const paymentStatus = pgEnum("payment_status", ["pending", "settled", "failed", "refunded"]);


### PR DESCRIPTION
**Piece 2 of the plan.** Makes **Verified** a trust badge Tael controls, not an automatic result of publishing (Option A: publishes are usable + listed immediately, just marked *Pending*).

## Behavior
- New **`pending`** capability status: `draft → pending → verified` (**migration 0013**).
- **Publishing sets `pending`** (was auto-`verified`). The capability is **live + callable immediately**.
- **Gateway + catalog serve pending + verified** (anything not `draft`) — Verified is a badge, not a usability gate. So Pending capabilities work fully.
- **Marketplace + My Capabilities**: green **Verified** badge only when verified; amber **Pending** chip otherwise. Marketplace lists pending + verified (drafts hidden).
- **Admin control**: a `VerifyToggle` on the capability detail page (grant/revoke), shown only to Tael admins. Gated by `ADMIN_WALLET_ADDRESSES` (comma-separated wallets); the `setCapabilityVerified` server action enforces it.

## Deploy notes
1. **Apply migration 0013** (adds the `pending` enum value) — must land around the deploy, or publishing fails.
2. Set **`ADMIN_WALLET_ADDRESSES`** on Vercel (dashboard) to your team's wallet address(es) so you can grant Verified. Empty = no one can verify.

## Verified
typecheck (db + api + dashboard), api tests 32/32, lint + format clean.

Next: metered billing #56, then the model Run UI.