### PR TITLE
feat(gateway): metered (usage-based) billing — Stage A (measure, don't charge)

### DIFF
--- a/apps/api/src/modules/capabilities/capability.repository.ts
+++ b/apps/api/src/modules/capabilities/capability.repository.ts
@@ -8,6 +8,7 @@ import {
   or,
   type Database,
   type UpstreamAuth,
+  type CapabilityBilling,
 } from "@tael/database";
 import { TaelError } from "@tael/types";
 
@@ -39,6 +40,8 @@ export interface ServableCapability {
   upstreamSecretEnc: string | null;
   /** Upstream authentication scheme configuration. */
   upstreamAuth: UpstreamAuth;
+  /** Metered billing config, or null for flat per-call pricing. */
+  billing: CapabilityBilling | null;
   /** Priced operations, for `/c/<slug>/<op>`. Empty when the capability is flat. */
   operations: ServableOperation[];
 }
@@ -116,6 +119,7 @@ export class DbCapabilityRepository implements CapabilityRepository {
         upstreamUrl: capabilities.upstreamUrl,
         upstreamSecretEnc: capabilities.upstreamSecretEnc,
         upstreamAuth: capabilities.upstreamAuth,
+        billing: capabilities.billing,
         spec: capabilities.spec,
       })
       .from(capabilities)
@@ -145,6 +149,7 @@ export class DbCapabilityRepository implements CapabilityRepository {
       upstreamUrl: row.upstreamUrl,
       upstreamSecretEnc: row.upstreamSecretEnc,
       upstreamAuth: row.upstreamAuth ?? { scheme: "bearer" },
+      billing: row.billing ?? null,
       operations,
     };
   }

--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -3,6 +3,8 @@ import { PAYMENT_REQUEST_HEADER, splitFee } from "@tael/payments";
 import { type Container } from "../../container";
 import { applyPayerToken, proxyToUpstream, isBlockedUrl, resolveUpstreamUrl } from "./upstream";
 import { checkRateLimit } from "./rate-limit";
+import { computeMeteredCost, readTokenUsage } from "./metered";
+import { type ServableCapability } from "../capabilities/capability.repository";
 
 /** The slice of the container the gateway needs. */
 export type GatewayDeps = Pick<
@@ -88,6 +90,12 @@ export async function handleGatewayRequest(
     return json({ error: "Capability upstream is unavailable" }, 502);
   }
 
+  // Metered (usage-based) capability: call the upstream first, then bill by the
+  // actual token usage. A different flow from x402's pay-first, handled here.
+  if (capability.billing?.metered) {
+    return handleMeteredCall(deps, capability, request, targetUrl);
+  }
+
   // Free operation (price 0): no payment gate at all — just proxy and return.
   // Lets a capability mix free reads (balance, quote) with paid actions (swap).
   if (Number(price) <= 0) {
@@ -170,4 +178,85 @@ export async function handleGatewayRequest(
   });
 
   return paid(servedRequest);
+}
+
+/**
+ * Serve a metered (usage-based) capability: authenticate the key, cap the
+ * request to the configured max output tokens, call the upstream, then read the
+ * token usage and compute the exact pass-through cost.
+ *
+ * STAGE A: the cost is computed and logged but NOT charged ($0) — this proves
+ * the token-reading + math on real calls before any money moves. Stage B adds
+ * the actual charge from the Card (pre-checked against its caps + balance).
+ */
+async function handleMeteredCall(
+  deps: GatewayDeps,
+  capability: ServableCapability,
+  request: Request,
+  targetUrl: string,
+): Promise<Response> {
+  const billing = capability.billing!;
+
+  // Metered calls must be authenticated — we need a Card to bill (in Stage B).
+  const bearer = parseTaelKey(request.headers.get("authorization"));
+  if (!bearer) return json({ error: "This capability requires a Tael API key." }, 401);
+  const key = await deps.keys.authorize(bearer);
+  if (!key) return json({ error: "Invalid or revoked API key" }, 401);
+  if (!key.card) {
+    return json({ error: "This API key has no Card linked. Link one to spend from it." }, 402);
+  }
+
+  // Cap the request to our max output tokens so the cost stays bounded. We only
+  // ever lower the caller's max_tokens, never raise it.
+  let servedRequest = request;
+  const method = request.method.toUpperCase();
+  if (billing.maxTokens && method !== "GET" && method !== "HEAD") {
+    try {
+      const raw = await request.clone().text();
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const asked = typeof parsed.max_tokens === "number" ? parsed.max_tokens : billing.maxTokens;
+      parsed.max_tokens = Math.min(asked, billing.maxTokens);
+      const headers = new Headers(request.headers);
+      servedRequest = new Request(request, { headers, body: JSON.stringify(parsed) });
+    } catch {
+      // Body isn't JSON we can cap — proceed as-is; the upstream may still bound it.
+    }
+  }
+
+  // Call the upstream first (call-then-charge), forwarding the paying Card id.
+  let upstream: Response;
+  try {
+    upstream = await proxyToUpstream(capability, servedRequest, targetUrl, key.card.address);
+  } catch (error) {
+    console.error("[gateway] metered upstream call failed:", error);
+    return json({ error: "Upstream call failed" }, 502);
+  }
+
+  // Read the full response to count tokens (metered calls are non-streaming).
+  const bodyText = await upstream.text();
+  const usage = readTokenUsage(bodyText);
+  const model = billing.model ?? "";
+  const cost = usage ? computeMeteredCost(model, usage) : null;
+
+  // STAGE A: log the computed cost; do NOT charge. Stage B settles `cost` from
+  // the Card (pre-checked against caps + balance) before returning.
+  console.log(
+    `[metered] ${capability.slug} card=${key.card.address} model=${model} ` +
+      `usage=${JSON.stringify(usage)} cost=$${cost ?? "unknown"} (Stage A: not charged)`,
+  );
+  void deps.keys.touch(key.id).catch(() => {});
+
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete("content-encoding");
+  responseHeaders.delete("content-length");
+  if (cost !== null) responseHeaders.set("x-tael-metered-cost", cost);
+  if (usage) {
+    responseHeaders.set("x-tael-input-tokens", String(usage.inputTokens));
+    responseHeaders.set("x-tael-output-tokens", String(usage.outputTokens));
+  }
+  return new Response(bodyText, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  });
 }

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -49,6 +49,7 @@ const CAPABILITY: ServableCapability = {
   upstreamUrl: "https://api.example.com/age",
   upstreamSecretEnc: null,
   upstreamAuth: { scheme: "bearer" },
+  billing: null,
   operations: [
     { slug: "premium", path: "/premium", price: "0.05" },
     { slug: "ping", path: "/ping", price: "0" },
@@ -764,6 +765,91 @@ describe("capability gateway", () => {
         headers: { authorization: "Bearer tael_live_key2" },
       });
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe("metered (usage-based) capability — Stage A", () => {
+    const METERED: ServableCapability = {
+      ...CAPABILITY,
+      slug: "claude",
+      upstreamUrl: "https://api.anthropic.com/v1/messages",
+      billing: { metered: true, model: "claude-haiku-4-5", maxTokens: 1024 },
+      operations: [],
+    };
+
+    const cardKeys = () =>
+      fakeKeys({
+        authorize: (): Promise<AuthorizedKey | null> =>
+          Promise.resolve({
+            id: "k1",
+            card: {
+              agentId: "a1",
+              address: ADDRESS,
+              secretEnc: "unused",
+              policy: { maxPerCall: "1", dailyLimit: "10", blockedPublishers: [] },
+            },
+          }),
+      });
+
+    it("calls the upstream, reports the exact cost, and charges nothing (Stage A)", async () => {
+      const upstream = vi.fn<typeof fetch>(
+        async () =>
+          new Response(
+            JSON.stringify({
+              content: [{ text: "hi" }],
+              usage: { input_tokens: 1204, output_tokens: 388 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      );
+      vi.stubGlobal("fetch", upstream);
+
+      const { container, payments } = buildContainer(METERED, undefined, cardKeys());
+      const app = createServer(container);
+
+      const res = await app.request("/c/claude", {
+        method: "POST",
+        headers: { authorization: "Bearer tael_live_abc", "content-type": "application/json" },
+        body: JSON.stringify({ model: "claude-haiku-4-5", max_tokens: 500, messages: [] }),
+      });
+
+      expect(res.status).toBe(200);
+      // Exact pass-through cost is surfaced, and token usage.
+      expect(res.headers.get("x-tael-metered-cost")).toBe("0.0031440");
+      expect(res.headers.get("x-tael-input-tokens")).toBe("1204");
+      expect(res.headers.get("x-tael-output-tokens")).toBe("388");
+      // STAGE A: nothing is charged / recorded.
+      expect(await payments.list()).toHaveLength(0);
+    });
+
+    it("caps max_tokens to the configured limit (never raises it)", async () => {
+      const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+      vi.stubGlobal("fetch", upstream);
+
+      const { container } = buildContainer(METERED, undefined, cardKeys());
+      const app = createServer(container);
+
+      await app.request("/c/claude", {
+        method: "POST",
+        headers: { authorization: "Bearer tael_live_abc", "content-type": "application/json" },
+        // Caller asks for 5000; our cap is 1024.
+        body: JSON.stringify({ model: "claude-haiku-4-5", max_tokens: 5000, messages: [] }),
+      });
+
+      const forwarded = upstream.mock.calls[0]?.[1] as RequestInit;
+      const rawBody =
+        forwarded.body instanceof ArrayBuffer
+          ? new TextDecoder().decode(forwarded.body)
+          : String(forwarded.body);
+      const sentBody = JSON.parse(rawBody) as { max_tokens: number };
+      expect(sentBody.max_tokens).toBe(1024);
+    });
+
+    it("401s a metered call with no API key", async () => {
+      const { container } = buildContainer(METERED, undefined, cardKeys());
+      const app = createServer(container);
+      const res = await app.request("/c/claude", { method: "POST", body: "{}" });
+      expect(res.status).toBe(401);
     });
   });
 });

--- a/apps/api/src/modules/gateway/metered.test.ts
+++ b/apps/api/src/modules/gateway/metered.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { computeMeteredCost, readTokenUsage } from "./metered";
+
+describe("metered billing math", () => {
+  it("computes the exact pass-through cost for a known model", () => {
+    // Haiku: $1/1M input, $5/1M output. 1,000,000 in + 1,000,000 out = $6.
+    expect(
+      computeMeteredCost("claude-haiku-4-5", { inputTokens: 1_000_000, outputTokens: 1_000_000 }),
+    ).toBe("6.0000000");
+    // A realistic small call: 1,204 in + 388 out.
+    // 1204*1e-6 + 388*5e-6 = 0.001204 + 0.00194 = 0.003144
+    expect(computeMeteredCost("claude-haiku-4-5", { inputTokens: 1_204, outputTokens: 388 })).toBe(
+      "0.0031440",
+    );
+  });
+
+  it("uses the right per-model rates", () => {
+    // Opus: $5/$25 per 1M. 100k in + 10k out = 0.5 + 0.25 = 0.75.
+    expect(
+      computeMeteredCost("claude-opus-4-8", { inputTokens: 100_000, outputTokens: 10_000 }),
+    ).toBe("0.7500000");
+  });
+
+  it("returns null (fail-safe) for an unknown model — never guesses a charge", () => {
+    expect(
+      computeMeteredCost("some-unknown-model", { inputTokens: 100, outputTokens: 100 }),
+    ).toBeNull();
+  });
+
+  it("reads Anthropic-style usage", () => {
+    const body = JSON.stringify({ content: [], usage: { input_tokens: 12, output_tokens: 7 } });
+    expect(readTokenUsage(body)).toEqual({ inputTokens: 12, outputTokens: 7 });
+  });
+
+  it("reads OpenAI-style usage", () => {
+    const body = JSON.stringify({ usage: { prompt_tokens: 30, completion_tokens: 9 } });
+    expect(readTokenUsage(body)).toEqual({ inputTokens: 30, outputTokens: 9 });
+  });
+
+  it("returns null when usage is absent or unparseable", () => {
+    expect(readTokenUsage(JSON.stringify({ foo: "bar" }))).toBeNull();
+    expect(readTokenUsage("not json")).toBeNull();
+  });
+});

--- a/apps/api/src/modules/gateway/metered.ts
+++ b/apps/api/src/modules/gateway/metered.ts
@@ -1,0 +1,63 @@
+/**
+ * Metered (usage-based) billing for model capabilities — the "call → measure →
+ * charge" path, distinct from x402's "pay → call". A metered capability calls
+ * the upstream first, reads the token usage from the response, and charges the
+ * exact cost. Pass-through: the buyer pays what the model actually cost us, at
+ * 0% margin. Tael's revenue comes from the marketplace fee on OTHER capabilities.
+ *
+ * STAGE A: this module computes and reports the cost only. The gateway logs it
+ * and charges $0 while we prove the token-reading + math on real calls. Stage B
+ * wires the actual charge from the Card.
+ */
+
+/**
+ * Per-token USDC rates by model, derived from published per-1M-token prices
+ * (price ÷ 1,000,000). Keep in sync with the providers' pricing pages; this is
+ * the one place to update when prices change. Zero margin — these are our cost.
+ */
+export const MODEL_RATES: Record<string, { input: number; output: number }> = {
+  // Anthropic — https://www.anthropic.com/pricing ($ per 1M tokens)
+  "claude-haiku-4-5": { input: 1 / 1_000_000, output: 5 / 1_000_000 },
+  "claude-sonnet-4-6": { input: 3 / 1_000_000, output: 15 / 1_000_000 },
+  "claude-opus-4-8": { input: 5 / 1_000_000, output: 25 / 1_000_000 },
+};
+
+/** Token counts read from an upstream response. */
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
+ * The exact USDC cost of a metered call, as a 7-decimal string (USDC precision).
+ * Returns null when the model has no configured rate — the caller must treat
+ * that as "cannot bill" and fail safe rather than charge a guess.
+ */
+export function computeMeteredCost(model: string, usage: TokenUsage): string | null {
+  const rate = MODEL_RATES[model];
+  if (!rate) return null;
+  const cost = usage.inputTokens * rate.input + usage.outputTokens * rate.output;
+  return cost.toFixed(7);
+}
+
+/**
+ * Extract token usage from an upstream JSON body. Handles Anthropic's shape
+ * (`usage.input_tokens` / `usage.output_tokens`) and the OpenAI-style
+ * (`usage.prompt_tokens` / `usage.completion_tokens`). Returns null if absent.
+ */
+export function readTokenUsage(body: string): TokenUsage | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  const usage = (parsed as { usage?: Record<string, unknown> })?.usage;
+  if (!usage || typeof usage !== "object") return null;
+
+  const input = usage.input_tokens ?? usage.prompt_tokens;
+  const output = usage.output_tokens ?? usage.completion_tokens;
+  if (typeof input !== "number" || typeof output !== "number") return null;
+
+  return { inputTokens: input, outputTokens: output };
+}

--- a/packages/database/drizzle/0014_steady_starfox.sql
+++ b/packages/database/drizzle/0014_steady_starfox.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "capabilities" ADD COLUMN "billing" jsonb;

--- a/packages/database/drizzle/meta/0014_snapshot.json
+++ b/packages/database/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1009 @@
+{
+  "id": "fa33c0d2-e5fb-4fd0-a537-79113c955860",
+  "prevId": "ab23f817-974e-4dbc-8aa0-018dfdd712fa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_wallet_address_idx": {
+          "name": "users_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Main'"
+        },
+        "secret_enc": {
+          "name": "secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_cached": {
+          "name": "balance_cached",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallets_owner_id_idx": {
+          "name": "wallets_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallets_owner_id_users_id_fk": {
+          "name": "wallets_owner_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_address_unique": {
+          "name": "wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "capability_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "capability_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "capability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "faqs": {
+          "name": "faqs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pay_to": {
+          "name": "pay_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_secret_enc": {
+          "name": "upstream_secret_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_auth": {
+          "name": "upstream_auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing": {
+          "name": "billing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capabilities_publisher_id_idx": {
+          "name": "capabilities_publisher_id_idx",
+          "columns": [
+            {
+              "expression": "publisher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_kind_idx": {
+          "name": "capabilities_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capabilities_visibility_idx": {
+          "name": "capabilities_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capabilities_publisher_id_users_id_fk": {
+          "name": "capabilities_publisher_id_users_id_fk",
+          "tableFrom": "capabilities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capabilities_slug_unique": {
+          "name": "capabilities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_users_id_fk": {
+          "name": "agents_owner_id_users_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agents_wallet_id_wallets_id_fk": {
+          "name": "agents_wallet_id_wallets_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_name": {
+          "name": "capability_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer": {
+          "name": "payer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee": {
+          "name": "payee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "numeric(20, 7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_capability_id_idx": {
+          "name": "payments_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_agent_id_idx": {
+          "name": "payments_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payer_idx": {
+          "name": "payments_payer_idx",
+          "columns": [
+            {
+              "expression": "payer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payee_idx": {
+          "name": "payments_payee_idx",
+          "columns": [
+            {
+              "expression": "payee",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_status_idx": {
+          "name": "payments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_tx_hash_unique": {
+          "name": "payments_tx_hash_unique",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_capability_id_capabilities_id_fk": {
+          "name": "payments_capability_id_capabilities_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_agent_id_agents_id_fk": {
+          "name": "payments_agent_id_agents_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_owner_id_idx": {
+          "name": "api_keys_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_owner_id_users_id_fk": {
+          "name": "api_keys_owner_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_agent_id_agents_id_fk": {
+          "name": "api_keys_agent_id_agents_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviews_capability_id_idx": {
+          "name": "reviews_capability_id_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_capability_id_capabilities_id_fk": {
+          "name": "reviews_capability_id_capabilities_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_reviewer_id_users_id_fk": {
+          "name": "reviews_reviewer_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_capability_reviewer_unique": {
+          "name": "reviews_capability_reviewer_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "capability_id",
+            "reviewer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.capability_kind": {
+      "name": "capability_kind",
+      "schema": "public",
+      "values": [
+        "api",
+        "mcp",
+        "agent",
+        "model",
+        "dataset",
+        "credit"
+      ]
+    },
+    "public.capability_status": {
+      "name": "capability_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "verified"
+      ]
+    },
+    "public.capability_visibility": {
+      "name": "capability_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "private"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "settled",
+        "failed",
+        "refunded"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1784339350994,
       "tag": "0013_mixed_warhawk",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1784341312644,
+      "tag": "0014_steady_starfox",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/capabilities.ts
+++ b/packages/database/src/schema/capabilities.ts
@@ -59,6 +59,20 @@ export interface UpstreamAuth {
 }
 
 /**
+ * Usage-based (metered) billing config for a capability — used by model
+ * capabilities (Claude, etc.) that charge per token rather than a flat price.
+ * Null/absent = flat per-call pricing (every existing capability).
+ */
+export interface CapabilityBilling {
+  /** Bill by token usage (call-then-charge) instead of a flat per-call price. */
+  metered: boolean;
+  /** Model key the gateway bills at, e.g. "claude-haiku-4-5" (rate lookup). */
+  model?: string;
+  /** Max output tokens the gateway enforces, to bound the worst-case cost. */
+  maxTokens?: number;
+}
+
+/**
  * A published capability: a developer wraps an upstream service (API/MCP/agent)
  * and sells it per call. This is the core reason Tael needs a database — the
  * `upstreamUrl` and `upstreamSecretEnc` (the developer's real API key) are
@@ -99,6 +113,8 @@ export const capabilities = pgTable(
     upstreamSecretEnc: text("upstream_secret_enc"),
     /** Upstream authentication scheme configuration. Nullable (defaults to Bearer). */
     upstreamAuth: jsonb("upstream_auth").$type<UpstreamAuth>(),
+    /** Metered (token-based) billing config. Nullable = flat per-call pricing. */
+    billing: jsonb("billing").$type<CapabilityBilling>(),
 
     publisherId: uuid("publisher_id")
       .notNull()


### PR DESCRIPTION
**Piece 3, Stage A** of pay-per-token model capabilities. This is the safe half: it **measures** the exact cost of a metered call but **charges $0**, so we prove the token-reading + math on real Claude calls before any money moves.

## The flow (call → measure)
A metered capability (Claude) calls the upstream **first**, reads `usage.input_tokens/output_tokens` from the response, and computes the **exact pass-through cost** (0% margin). Distinct from x402's pay-first.

## What's in Stage A
- **`billing` config** on a capability (`metered` + `model` + `maxTokens`); **migration 0014** adds the nullable column. Null = flat pricing (every existing capability unchanged).
- **Per-model USDC rates** in one config (`metered.ts`) + **pure, tested** cost math.
- **Gateway** routes metered capabilities through `handleMeteredCall`: authenticate by API key, **cap `max_tokens`** (only ever lowers it), call upstream, read usage, and **log + surface** the cost via `x-tael-metered-cost` / `x-tael-input-tokens` / `x-tael-output-tokens` headers. **Charges nothing.**

## Safety
- No money moves in Stage A — by design.
- Unknown model → cost is `null` (fail-safe, never guesses a charge).
- `max_tokens` is only ever **capped**, never raised.

## Verified
Cost math to exact 7-decimal USDC (`6.0000000`, `0.0031440`, `0.7500000`), **api tests 41/41**, full monorepo typecheck + lint + format green.

## Deploy note
Apply **migration 0014** (nullable `billing` column, additive/safe).

## Next: Stage B
Wire the real charge — pre-check the Card can cover the worst case, then settle the exact cost from the Card after the call. Money-moving; will spec + verify on testnet before enabling.