### PR TITLE
fix(config): correct the USDC issuer in .env.example to the deployed value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,8 +35,11 @@ AUTH_SECRET=
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
-# Canonical USDC asset issuer on the selected network.
-USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+# Canonical USDC asset issuer on the selected network. This is the issuer Tael
+# settles in: buyer Cards hold USDC from it, and every capability's payout wallet
+# MUST hold a trustline for it, or payments are rejected on-chain (op_no_trust).
+# Keep this in sync with the deployed value and NEXT_PUBLIC_USDC_ISSUER below.
+USDC_ISSUER=GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA
 
 # --- Payments (x402) ---
 # Facilitator that verifies/settles x402 payment proofs.
@@ -68,7 +71,7 @@ NEXT_PUBLIC_DASHBOARD_URL=http://localhost:3002
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
 # USDC issuer Tael settles in (client-exposed) — shown to publishers so they add
 # the matching trustline on their payout wallet. Must equal the API's USDC_ISSUER.
-NEXT_PUBLIC_USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+NEXT_PUBLIC_USDC_ISSUER=GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA
 # Tael-team wallet addresses (comma-separated) allowed to grant the Verified
 # badge on capabilities. Server-only. Empty = no one can verify.
 ADMIN_WALLET_ADDRESSES=


### PR DESCRIPTION
**Root cause of the recurring partner trustline bug.** `.env.example` listed the USDC issuer as `GBBD47IF…`, but the deployed system settles in USDC from `GBCDXWBEN…`. Partners (Nebula, then TrustLine) followed the example and added trustlines for the **wrong issuer**, so their payout wallets couldn't receive payment (`op_no_trust` → the call 500s at settlement).

Points both `USDC_ISSUER` and `NEXT_PUBLIC_USDC_ISSUER` at the real deployed issuer and documents why they must match, so new partners set up the correct trustline.

**Follow-up:** enforcing this at publish time (block a listing whose `payTo` lacks the trustline, with a clear error) is tracked as an open issue for contributors.

Config only, no code change.