### PR TITLE
feat(capabilities): let publishers edit a published capability

### DIFF
--- a/apps/dashboard/app/(dashboard)/capabilities/[id]/edit/page.tsx
+++ b/apps/dashboard/app/(dashboard)/capabilities/[id]/edit/page.tsx
@@ -1,0 +1,61 @@
+import { notFound } from "next/navigation";
+import { PageHeader } from "../../../../../components/page-header";
+import { getEditableCapability } from "../../../../../features/capabilities/queries";
+import {
+  EditCapabilityForm,
+  type EditCapabilityData,
+  type EditOperation,
+} from "../../../../../features/capabilities/edit-capability-form";
+
+export const dynamic = "force-dynamic";
+
+/** Turn a stored UpstreamAuth's static headers back into "Name: value" lines. */
+function headersToLines(extra: Record<string, string> | undefined): string {
+  if (!extra) return "";
+  return Object.entries(extra)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n");
+}
+
+export default async function EditCapabilityPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const capability = await getEditableCapability(id);
+  if (!capability) notFound();
+
+  const auth = capability.upstreamAuth;
+  const operations: EditOperation[] = (capability.spec.operations ?? []).map((op) => ({
+    name: op.name ?? "",
+    method: op.method ?? "POST",
+    path: op.path ?? "",
+    price: op.price ?? "",
+    sampleRequest: op.sampleRequest ?? "",
+    sampleResponse: op.sampleResponse ?? "",
+  }));
+
+  const data: EditCapabilityData = {
+    id: capability.id,
+    name: capability.name,
+    kind: capability.kind,
+    description: capability.description,
+    logoUrl: capability.logoUrl ?? "",
+    contact: capability.contact ?? "",
+    visibility: capability.visibility,
+    payTo: capability.payTo,
+    upstreamUrl: capability.upstreamUrl,
+    authScheme: auth?.scheme ?? "bearer",
+    authHeader: auth?.header ?? "",
+    authExtraHeaders: headersToLines(auth?.extraHeaders),
+    hasSecret: capability.upstreamSecretEnc !== null,
+    operations,
+  };
+
+  return (
+    <>
+      <PageHeader
+        title="Edit capability"
+        description="Update your listing, payout, connection, and priced requests."
+      />
+      <EditCapabilityForm data={data} />
+    </>
+  );
+}

--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, BadgeCheck, ChevronDown, Code2 } from "lucide-react";
+import { ArrowLeft, BadgeCheck, ChevronDown, Code2, Pencil } from "lucide-react";
 import { cn } from "@tael/ui";
 import { getPublicCapabilityBySlug } from "../../../../features/capabilities/queries";
 import { isCurrentUserAdmin } from "../../../../features/capabilities/actions";
@@ -131,7 +131,17 @@ export default async function CapabilityDetailPage({
         </Meta>
       </div>
 
-      {isAdmin ? <VerifyToggle id={capability.id} verified={verified} /> : null}
+      {isAdmin ? (
+        <div className="flex flex-wrap items-center gap-3">
+          <VerifyToggle id={capability.id} verified={verified} />
+          <Link
+            href={`/capabilities/${capability.id}/edit`}
+            className="inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:bg-muted"
+          >
+            <Pencil className="h-4 w-4" /> Edit
+          </Link>
+        </div>
+      ) : null}
 
       {contact ? (
         <p className="text-sm text-muted-foreground">

--- a/apps/dashboard/features/capabilities/actions.ts
+++ b/apps/dashboard/features/capabilities/actions.ts
@@ -14,7 +14,14 @@ import {
 import { generateFaqQuestions } from "@tael/claude";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "./current-user";
-import { minPrice, parseHeaderLines, publishCapabilitySchema, slugify } from "./schema";
+import {
+  describeCapabilitySchema,
+  minPrice,
+  parseHeaderLines,
+  publishCapabilitySchema,
+  slugify,
+  type PublishCapabilityInput,
+} from "./schema";
 
 /** Build the stored UpstreamAuth from the publisher's choices, or null for the
  *  plain Bearer default (keeps existing behavior + a compact row). */
@@ -185,6 +192,87 @@ export async function publishCapability(
   revalidatePath("/capabilities");
   revalidatePath("/marketplace");
   return { ok: true, slug };
+}
+
+/** Build the operations spec from the form's operation list (shared with publish). */
+function buildOperationsSpec(operations: PublishCapabilityInput["operations"]): CapabilitySpec {
+  const opSlugs = new Set<string>();
+  return {
+    operations: operations.map((op, i) => {
+      const base = slugify(op.name || `op-${i + 1}`) || `op-${i + 1}`;
+      let opSlug = base;
+      for (let n = 2; opSlugs.has(opSlug); n += 1) opSlug = `${base}-${n}`;
+      opSlugs.add(opSlug);
+      return {
+        name: op.name || "Request",
+        slug: opSlug,
+        path: op.path || undefined,
+        method: op.method || undefined,
+        sampleRequest: op.sampleRequest || undefined,
+        sampleResponse: op.sampleResponse || undefined,
+        price: op.price,
+      };
+    }),
+  };
+}
+
+/**
+ * Edit a capability the current user owns (or any capability, if the user is a
+ * Tael admin). Updates the editable fields and the operation list; the slug and
+ * the answered FAQ are preserved. The upstream secret is only re-encrypted when
+ * a new one is provided, so leaving the field blank keeps the existing key.
+ * Status is left as-is (a verified capability stays verified) — an admin can
+ * always revoke the badge if an edit changes what was reviewed.
+ */
+export async function editCapability(
+  id: string,
+  formData: FormData,
+): Promise<ActionResult & { slug?: string }> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  // Load the row and check the caller may edit it (owner or admin).
+  const [existing] = await db.select().from(capabilities).where(eq(capabilities.id, id)).limit(1);
+  if (!existing) return { ok: false, error: "Capability not found." };
+  const isOwner = existing.publisherId === user.id;
+  const isAdmin = ADMIN_WALLETS.has(user.walletAddress);
+  if (!isOwner && !isAdmin) return { ok: false, error: "Not authorized." };
+
+  const parsed = describeCapabilitySchema.safeParse(readDescribe(formData));
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.issues[0]?.message ?? "Invalid input." };
+  }
+  const input = parsed.data;
+
+  try {
+    await db
+      .update(capabilities)
+      .set({
+        name: input.name,
+        description: input.description,
+        logoUrl: input.logoUrl || null,
+        contact: input.contact || null,
+        kind: input.kind,
+        visibility: input.visibility,
+        spec: buildOperationsSpec(input.operations),
+        price: minPrice(input.operations),
+        payTo: input.payTo,
+        upstreamUrl: input.upstreamUrl,
+        // Only overwrite the secret when a new one is entered; blank keeps it.
+        ...(input.upstreamSecret ? { upstreamSecretEnc: encryptSecret(input.upstreamSecret) } : {}),
+        upstreamAuth: buildUpstreamAuth(input),
+        updatedAt: new Date(),
+      })
+      .where(eq(capabilities.id, id));
+  } catch (error) {
+    console.error("[capabilities] edit failed:", error);
+    return { ok: false, error: "Could not save. Try again." };
+  }
+
+  revalidatePath("/capabilities");
+  revalidatePath("/marketplace");
+  revalidatePath(`/marketplace/${existing.slug}`);
+  return { ok: true, slug: existing.slug };
 }
 
 /** Tael-team wallet addresses allowed to grant/revoke the Verified badge. */

--- a/apps/dashboard/features/capabilities/capabilities-table.tsx
+++ b/apps/dashboard/features/capabilities/capabilities-table.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { BadgeCheck, Search, Trash2 } from "lucide-react";
+import { BadgeCheck, Pencil, Search, Trash2 } from "lucide-react";
 import { cn, Input } from "@tael/ui";
 import { formatPrice, kindMeta, timeAgo } from "./kind-meta";
 import { CapabilityLogo } from "./capability-logo";
@@ -116,14 +116,23 @@ export function CapabilitiesTable({ items }: { items: CapabilityListItem[] }) {
                     {timeAgo(c.createdAt)}
                   </td>
                   <td className="px-2 py-3 text-right">
-                    <button
-                      type="button"
-                      aria-label={`Delete ${c.name}`}
-                      onClick={() => setPendingDelete(c)}
-                      className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
+                    <div className="flex items-center justify-end gap-1">
+                      <Link
+                        href={`/capabilities/${c.id}/edit`}
+                        aria-label={`Edit ${c.name}`}
+                        className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Link>
+                      <button
+                        type="button"
+                        aria-label={`Delete ${c.name}`}
+                        onClick={() => setPendingDelete(c)}
+                        className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
                   </td>
                 </tr>
               );

--- a/apps/dashboard/features/capabilities/edit-capability-form.tsx
+++ b/apps/dashboard/features/capabilities/edit-capability-form.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, Trash2 } from "lucide-react";
+import { Button, Input } from "@tael/ui";
+import { editCapability } from "./actions";
+import { HTTP_METHODS } from "./kind-fields";
+
+/** A single editable operation row in the form. */
+export interface EditOperation {
+  name: string;
+  method: string;
+  path: string;
+  price: string;
+  sampleRequest: string;
+  sampleResponse: string;
+}
+
+/** The capability data the form is prefilled from (plain + serializable). */
+export interface EditCapabilityData {
+  id: string;
+  name: string;
+  kind: string;
+  description: string;
+  logoUrl: string;
+  contact: string;
+  visibility: string;
+  payTo: string;
+  upstreamUrl: string;
+  authScheme: "bearer" | "header" | "none";
+  authHeader: string;
+  authExtraHeaders: string;
+  hasSecret: boolean;
+  operations: EditOperation[];
+}
+
+const fieldClass = "h-9 w-full rounded-md border border-input bg-transparent px-2 text-sm";
+
+/**
+ * Edit an existing capability: its metadata, payout, upstream connection, and
+ * the list of priced operations. The upstream secret is never shown; leaving it
+ * blank keeps the current one. Only the owner (or a Tael admin) can save.
+ */
+export function EditCapabilityForm({ data }: { data: EditCapabilityData }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const [name, setName] = useState(data.name);
+  const [description, setDescription] = useState(data.description);
+  const [contact, setContact] = useState(data.contact);
+  const [payTo, setPayTo] = useState(data.payTo);
+  const [upstreamUrl, setUpstreamUrl] = useState(data.upstreamUrl);
+  const [upstreamSecret, setUpstreamSecret] = useState("");
+  const [authScheme, setAuthScheme] = useState(data.authScheme);
+  const [authHeader, setAuthHeader] = useState(data.authHeader);
+  const [authExtraHeaders, setAuthExtraHeaders] = useState(data.authExtraHeaders);
+  const [visibility, setVisibility] = useState(data.visibility);
+  const [operations, setOperations] = useState<EditOperation[]>(
+    data.operations.length > 0
+      ? data.operations
+      : [{ name: "", method: "POST", path: "", price: "", sampleRequest: "", sampleResponse: "" }],
+  );
+
+  function updateOp(i: number, patch: Partial<EditOperation>) {
+    setOperations((prev) => prev.map((op, j) => (j === i ? { ...op, ...patch } : op)));
+  }
+  function addOp() {
+    setOperations((prev) => [
+      ...prev,
+      { name: "", method: "POST", path: "", price: "", sampleRequest: "", sampleResponse: "" },
+    ]);
+  }
+  function removeOp(i: number) {
+    setOperations((prev) => prev.filter((_, j) => j !== i));
+  }
+
+  function save() {
+    setError(null);
+    const fd = new FormData();
+    fd.set("name", name);
+    fd.set("kind", data.kind);
+    fd.set("description", description);
+    fd.set("logoUrl", data.logoUrl);
+    fd.set("contact", contact);
+    fd.set("payTo", payTo);
+    fd.set("upstreamUrl", upstreamUrl);
+    fd.set("upstreamSecret", upstreamSecret);
+    fd.set("authScheme", authScheme);
+    fd.set("authHeader", authHeader);
+    fd.set("authExtraHeaders", authExtraHeaders);
+    fd.set("visibility", visibility);
+    fd.set("operations", JSON.stringify(operations));
+
+    startTransition(async () => {
+      const res = await editCapability(data.id, fd);
+      if (res.ok) router.push(`/marketplace/${res.slug}`);
+      else setError(res.error ?? "Could not save.");
+    });
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <Field label="Product name">
+        <Input value={name} onChange={(e) => setName(e.target.value)} />
+      </Field>
+
+      <Field label="Description">
+        <textarea
+          rows={3}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+        />
+      </Field>
+
+      <Field label="Support contact" hint="Email, link, or @handle buyers can reach you at.">
+        <Input
+          value={contact}
+          onChange={(e) => setContact(e.target.value)}
+          placeholder="you@example.com"
+        />
+      </Field>
+
+      <Field label="Pay to" hint="The Stellar address that receives your USDC earnings.">
+        <Input value={payTo} onChange={(e) => setPayTo(e.target.value)} placeholder="G…" />
+      </Field>
+
+      <Field label="Visibility">
+        <select
+          value={visibility}
+          onChange={(e) => setVisibility(e.target.value)}
+          className={fieldClass}
+        >
+          <option value="public">Public</option>
+          <option value="unlisted">Unlisted</option>
+          <option value="private">Private</option>
+        </select>
+      </Field>
+
+      <div className="space-y-4 rounded-xl border p-4">
+        <p className="text-sm font-medium">Connection</p>
+        <Field label="Endpoint URL">
+          <Input
+            value={upstreamUrl}
+            onChange={(e) => setUpstreamUrl(e.target.value)}
+            placeholder="https://…"
+          />
+        </Field>
+        <Field
+          label="Upstream secret"
+          hint={
+            data.hasSecret
+              ? "Leave blank to keep the current key."
+              : "Add a key if your endpoint needs one."
+          }
+        >
+          <Input
+            value={upstreamSecret}
+            onChange={(e) => setUpstreamSecret(e.target.value)}
+            type="password"
+            placeholder={data.hasSecret ? "•••••••• (unchanged)" : "sk-…"}
+          />
+        </Field>
+        <Field
+          label="Auth scheme"
+          hint="How Tael sends your secret. Use a header like x-api-key for Anthropic."
+        >
+          <select
+            value={authScheme}
+            onChange={(e) => setAuthScheme(e.target.value as EditCapabilityData["authScheme"])}
+            className={fieldClass}
+          >
+            <option value="bearer">Bearer (Authorization: Bearer …)</option>
+            <option value="header">Custom header (e.g. x-api-key)</option>
+            <option value="none">None (no secret sent)</option>
+          </select>
+        </Field>
+        {authScheme === "header" ? (
+          <Field label="Header name">
+            <Input
+              value={authHeader}
+              onChange={(e) => setAuthHeader(e.target.value)}
+              placeholder="x-api-key"
+            />
+          </Field>
+        ) : null}
+        <Field label="Extra headers" hint="Static headers, one per line as Name: value.">
+          <textarea
+            rows={2}
+            value={authExtraHeaders}
+            onChange={(e) => setAuthExtraHeaders(e.target.value)}
+            placeholder="anthropic-version: 2023-06-01"
+            className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs"
+          />
+        </Field>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">Requests</span>
+          <button
+            type="button"
+            onClick={addOp}
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="h-4 w-4" /> Add request
+          </button>
+        </div>
+        {operations.map((op, i) => (
+          <div key={i} className="space-y-3 rounded-xl border p-4">
+            <div className="flex items-center gap-2">
+              <select
+                value={op.method}
+                onChange={(e) => updateOp(i, { method: e.target.value })}
+                className="h-8 rounded-md border border-input bg-transparent px-2 text-xs"
+              >
+                {HTTP_METHODS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+              <Input
+                value={op.name}
+                onChange={(e) => updateOp(i, { name: e.target.value })}
+                placeholder="Request name"
+                className="h-8"
+              />
+              {operations.length > 1 ? (
+                <button
+                  type="button"
+                  onClick={() => removeOp(i)}
+                  aria-label="Remove request"
+                  className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:text-destructive"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              ) : null}
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Path" hint="Appended to the endpoint URL, e.g. /swap.">
+                <Input
+                  value={op.path}
+                  onChange={(e) => updateOp(i, { path: e.target.value })}
+                  placeholder="/…"
+                />
+              </Field>
+              <Field label="Price" hint="USDC per call. 0 = free.">
+                <Input
+                  value={op.price}
+                  onChange={(e) => updateOp(i, { price: e.target.value })}
+                  placeholder="0.01"
+                />
+              </Field>
+            </div>
+            <Field label="Sample request">
+              <textarea
+                rows={2}
+                value={op.sampleRequest}
+                onChange={(e) => updateOp(i, { sampleRequest: e.target.value })}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs"
+              />
+            </Field>
+          </div>
+        ))}
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="flex items-center gap-3">
+        <Button onClick={save} disabled={pending || !name.trim()}>
+          {pending ? "Saving…" : "Save changes"}
+        </Button>
+        <Button variant="outline" onClick={() => router.back()} disabled={pending}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block space-y-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+      {hint ? <span className="block text-xs text-muted-foreground">{hint}</span> : null}
+    </label>
+  );
+}

--- a/apps/dashboard/features/capabilities/queries.ts
+++ b/apps/dashboard/features/capabilities/queries.ts
@@ -45,3 +45,24 @@ export async function getMyCapability(id: string): Promise<Capability | null> {
     .limit(1);
   return rows[0] ?? null;
 }
+
+/** Wallets allowed to edit any capability (Tael admins), from env. */
+const ADMIN_WALLETS = new Set(
+  (process.env.ADMIN_WALLET_ADDRESSES ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
+/**
+ * Load a capability the current user may edit: their own, or any capability if
+ * they are a Tael admin. Returns null (→ 404) otherwise.
+ */
+export async function getEditableCapability(id: string): Promise<Capability | null> {
+  const user = await getCurrentUser();
+  if (!user) return null;
+  const [row] = await db.select().from(capabilities).where(eq(capabilities.id, id)).limit(1);
+  if (!row) return null;
+  const canEdit = row.publisherId === user.id || ADMIN_WALLETS.has(user.walletAddress);
+  return canEdit ? row : null;
+}


### PR DESCRIPTION
Publishers (and Tael admins) can now **edit a live capability** instead of deleting and republishing. Directly unblocks partners who need to change their **payout address**, **fix an upstream token / auth scheme**, tweak the **description**, or **add / reprice operations** after listing.

## What's included
- **`editCapability` action** — owner-or-admin checked update of name, description, contact, visibility, payTo, upstream URL + auth (scheme / header / extra headers), and the operation list. The **slug and answered FAQ are preserved**. The **upstream secret is only re-encrypted when a new one is entered** — blank keeps the current key (never shown). Status is left unchanged.
- **`getEditableCapability` query** — loads a capability for its owner or a Tael admin (else 404).
- **Edit form + `/capabilities/[id]/edit` route**, prefilled from the capability (`upstreamAuth` mapped back to the scheme/header/extra-headers fields).
- **Entry points** — a pencil action on **My Capabilities**, and an **Edit** button in the admin block on the marketplace detail page.

## Why this matters now
This is the fix path for the **Nebula 401**: Nebula's stored token/auth is being rejected, and there was no way to update it without republishing. With this, they (or an admin) can edit the upstream secret / auth scheme in place.

## Verified
dashboard typecheck + eslint + prettier clean. No migration. Needs a live smoke test after deploy (edit a capability → save → confirm the change).

## Note
Editing keeps the current Verified status. A material change (e.g. payout or endpoint) does not auto-reset to Pending; an admin can unverify + re-review if needed. Easy to make that automatic later if we want stricter re-verification.