### PR TITLE
fix(gateway): serve then settle — never charge a failed capability

### DIFF
--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -1,8 +1,11 @@
 import {
   createMockVerifier,
   type PaymentNetwork,
+  type PaymentPayload,
+  type PaymentRequirements,
   type PaymentVerifier,
   type SettlementReceipt,
+  type ValidatedPayment,
 } from "@tael/payments";
 import { PaymentVerificationError } from "@tael/types";
 import {
@@ -67,35 +70,55 @@ function createStellarVerifier(env: Env): PaymentVerifier {
   });
   const network = toPaymentNetwork(env.STELLAR_NETWORK);
 
-  return {
-    async verify(payload, requirements): Promise<SettlementReceipt> {
-      // Validate — offline — that the signed tx actually pays the required legs
-      // (builder + any fee) in USDC, BEFORE submitting. Without this the gateway
-      // would settle and serve any well-formed transaction (submit-and-trust).
-      const expected: ExpectedPayment[] = [
-        { to: requirements.payTo, minAmount: requirements.maxAmountRequired },
-      ];
-      if (requirements.fee) {
-        expected.push({ to: requirements.fee.payTo, minAmount: requirements.fee.amount });
-      }
-      const check = verifyTransactionPayments(
-        payload.payload.transaction,
-        env.STELLAR_NETWORK,
-        env.USDC_ISSUER,
-        expected,
-      );
-      if (!check.ok) {
-        throw new PaymentVerificationError(check.reason ?? "Payment does not satisfy requirements");
-      }
+  // Offline check that the signed tx actually pays the required legs (builder +
+  // any fee) in USDC, BEFORE submitting. Without this the gateway would settle
+  // and serve any well-formed transaction (submit-and-trust).
+  function assertPays(payload: PaymentPayload, requirements: PaymentRequirements): string {
+    const expected: ExpectedPayment[] = [
+      { to: requirements.payTo, minAmount: requirements.maxAmountRequired },
+    ];
+    if (requirements.fee) {
+      expected.push({ to: requirements.fee.payTo, minAmount: requirements.fee.amount });
+    }
+    const check = verifyTransactionPayments(
+      payload.payload.transaction,
+      env.STELLAR_NETWORK,
+      env.USDC_ISSUER,
+      expected,
+    );
+    if (!check.ok) {
+      throw new PaymentVerificationError(check.reason ?? "Payment does not satisfy requirements");
+    }
+    return check.payer ?? "";
+  }
 
+  return {
+    validate(payload, requirements): Promise<ValidatedPayment> {
+      const payer = assertPays(payload, requirements);
+      return Promise.resolve({ payer, payload, requirements });
+    },
+    async settle(validated): Promise<SettlementReceipt> {
+      const receipt = await settlement.submitSignedTransaction(
+        validated.payload.payload.transaction,
+      );
+      return {
+        txHash: receipt.txHash,
+        network,
+        settledAt: new Date().toISOString(),
+        payer: validated.payer || receipt.payer,
+        amount: validated.requirements.maxAmountRequired,
+        asset: "USDC",
+      };
+    },
+    // Combined path (validate + settle) for callers that settle up front.
+    async verify(payload, requirements): Promise<SettlementReceipt> {
+      const payer = assertPays(payload, requirements);
       const receipt = await settlement.submitSignedTransaction(payload.payload.transaction);
       return {
         txHash: receipt.txHash,
         network,
         settledAt: new Date().toISOString(),
-        payer: check.payer ?? receipt.payer,
-        // The builder's net share and asset, so a reader (e.g. an underwriter) can
-        // attribute this settlement's revenue straight from the receipt.
+        payer: payer || receipt.payer,
         amount: requirements.maxAmountRequired,
         asset: "USDC",
       };

--- a/apps/api/src/modules/gateway/gateway.handler.ts
+++ b/apps/api/src/modules/gateway/gateway.handler.ts
@@ -1,5 +1,14 @@
-import { tael } from "@tael/sdk";
-import { PAYMENT_REQUEST_HEADER, splitFee } from "@tael/payments";
+import {
+  buildPaymentRequirements,
+  decodePaymentHeader,
+  PAYMENT_REQUEST_HEADER,
+  PAYMENT_RESPONSE_HEADER,
+  settlePayment,
+  splitFee,
+  validatePayment,
+  X402_VERSION,
+} from "@tael/payments";
+import { PaymentVerificationError } from "@tael/types";
 import { type Container } from "../../container";
 import { applyPayerToken, proxyToUpstream, isBlockedUrl, resolveUpstreamUrl } from "./upstream";
 import { checkRateLimit } from "./rate-limit";
@@ -139,45 +148,90 @@ export async function handleGatewayRequest(
     void deps.keys.touch(key.id).catch(() => {});
   }
 
-  const paid = tael({
+  // Build the x402 challenge requirements once (used for the 402 and to validate).
+  const requirements = buildPaymentRequirements({
     price,
     payTo: capability.payTo,
     issuer: deps.gateway.issuer,
     network: deps.gateway.network,
-    verifier: deps.verifier,
+    resource: new URL(servedRequest.url).pathname,
     description: capability.name,
     fee,
-    handler: async ({ request: paidRequest, receipt }) => {
-      // The payment settled during verification — record it before doing the
-      // work, so the ledger is correct even if the upstream then misbehaves.
-      try {
-        await deps.payments.recordSettled({
-          capabilityId: capability.id,
-          capabilityName: capability.name,
-          payer: receipt.payer,
-          payee: capability.payTo,
-          amount: split.net,
-          fee: split.fee,
-          txHash: receipt.txHash,
-        });
-      } catch (error) {
-        console.error("[gateway] failed to record payment:", error);
-      }
-
-      try {
-        // Substitute `{payer}` in the URL with the verified caller so per-caller
-        // capabilities (e.g. TrustLine's `/agent/{payer}/available-credit`) hit
-        // the right resource. No token → unchanged.
-        const upstreamUrl = applyPayerToken(targetUrl, receipt.payer);
-        return await proxyToUpstream(capability, paidRequest, upstreamUrl, receipt.payer);
-      } catch (error) {
-        console.error("[gateway] upstream call failed:", error);
-        return json({ error: "Upstream call failed" }, 502);
-      }
-    },
   });
 
-  return paid(servedRequest);
+  // No payment attached → return the 402 challenge.
+  const paymentHeader = servedRequest.headers.get(PAYMENT_REQUEST_HEADER);
+  if (!paymentHeader) {
+    return json({ x402Version: X402_VERSION, accepts: [requirements] }, 402);
+  }
+
+  // Serve-then-settle: VALIDATE the payment (no on-chain submit), CALL the
+  // upstream, and only SETTLE if the upstream succeeded. A failed capability is
+  // therefore never charged — the signed transaction is simply never submitted.
+  let validated;
+  try {
+    const payload = decodePaymentHeader(paymentHeader);
+    validated = await validatePayment(payload, requirements, deps.verifier);
+  } catch (error) {
+    if (error instanceof PaymentVerificationError) {
+      return json(
+        { x402Version: X402_VERSION, accepts: [requirements], error: error.message },
+        402,
+      );
+    }
+    throw error;
+  }
+
+  // Substitute `{payer}` in the URL with the validated caller so per-caller
+  // capabilities (e.g. TrustLine's `/agent/{payer}/available-credit`) hit the
+  // right resource. No token → unchanged.
+  const upstreamUrl = applyPayerToken(targetUrl, validated.payer);
+  let upstream: Response;
+  try {
+    upstream = await proxyToUpstream(capability, servedRequest, upstreamUrl, validated.payer);
+  } catch (error) {
+    console.error("[gateway] upstream call failed:", error);
+    return json({ error: "Upstream call failed" }, 502);
+  }
+
+  // The upstream failed → do NOT settle. Return its error untouched, unpaid.
+  if (!upstream.ok) {
+    return upstream;
+  }
+
+  // The call succeeded → settle the payment on-chain and record it.
+  let receipt;
+  try {
+    receipt = await settlePayment(validated, deps.verifier);
+  } catch (error) {
+    console.error("[gateway] settlement failed after a successful call:", error);
+    return json({ error: "Payment settlement failed. You were not charged." }, 402);
+  }
+
+  try {
+    await deps.payments.recordSettled({
+      capabilityId: capability.id,
+      capabilityName: capability.name,
+      payer: receipt.payer,
+      payee: capability.payTo,
+      amount: split.net,
+      fee: split.fee,
+      txHash: receipt.txHash,
+    });
+  } catch (error) {
+    console.error("[gateway] failed to record payment:", error);
+  }
+
+  const headers = new Headers(upstream.headers);
+  headers.set(
+    PAYMENT_RESPONSE_HEADER,
+    Buffer.from(JSON.stringify(receipt), "utf8").toString("base64"),
+  );
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
 }
 
 /**

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -279,6 +279,32 @@ describe("capability gateway", () => {
     expect(ledger[0]?.payer).toContain("mock_payer_");
   });
 
+  it("does NOT charge when the upstream fails (serve-then-settle)", async () => {
+    // The upstream rejects the call (e.g. a 401 from the capability's server).
+    const upstream = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ reason: "unauthorized" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", upstream);
+
+    const { container, payments } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+
+    const res = await app.request("/c/predict-age", {
+      method: "POST",
+      headers: { [PAYMENT_REQUEST_HEADER]: paymentHeader() },
+    });
+
+    // The buyer sees the upstream's error, unchanged…
+    expect(res.status).toBe(401);
+    // …and crucially, NO payment settled and NO receipt was attached.
+    expect(res.headers.get(PAYMENT_RESPONSE_HEADER)).toBeNull();
+    expect(await payments.list()).toHaveLength(0);
+  });
+
   it("splits out the marketplace fee when one is configured", async () => {
     const feeAddress = "GC62IXD4GCRMGDR34NIWG3TVCECGBJHVW3UW7URX4F6CF54WIOMSLBRK";
     const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));

--- a/packages/payments/src/verify.ts
+++ b/packages/payments/src/verify.ts
@@ -20,24 +20,37 @@ export interface SettlementReceipt {
 }
 
 /**
+ * A payment that has been validated (its signed tx pays the required legs) but
+ * NOT yet submitted on-chain. Carries the payer so a resource can be served
+ * before settlement, and the payload/requirements needed to settle afterwards.
+ */
+export interface ValidatedPayment {
+  /** The account that will pay — the source of the (not-yet-submitted) tx. */
+  payer: string;
+  payload: PaymentPayload;
+  requirements: PaymentRequirements;
+}
+
+/**
  * Port: verifies (and settles) a payment proof against stated requirements.
  * The Stellar implementation lives in `@tael/stellar`; tests and local dev use
  * {@link createMockVerifier}. Keeping this an interface is what stops the
  * payment protocol from depending on any specific chain.
+ *
+ * `validate` + `settle` let a caller serve the resource BETWEEN the two, so a
+ * failed resource is never charged (serve-then-settle). `verify` is the combined
+ * validate-then-settle, kept for callers that settle up front (the `tael()` SDK).
  */
 export interface PaymentVerifier {
   verify(payload: PaymentPayload, requirements: PaymentRequirements): Promise<SettlementReceipt>;
+  /** Check the signed tx satisfies the requirements, WITHOUT submitting it. */
+  validate(payload: PaymentPayload, requirements: PaymentRequirements): Promise<ValidatedPayment>;
+  /** Submit a previously-validated payment on-chain and return the receipt. */
+  settle(validated: ValidatedPayment): Promise<SettlementReceipt>;
 }
 
-/**
- * Validate protocol-level invariants (scheme/network match) then delegate the
- * cryptographic + on-chain verification to the injected verifier.
- */
-export async function verifyPayment(
-  payload: PaymentPayload,
-  requirements: PaymentRequirements,
-  verifier: PaymentVerifier,
-): Promise<SettlementReceipt> {
+/** Protocol-level checks (scheme + network) shared by validate and verify. */
+function assertProtocol(payload: PaymentPayload, requirements: PaymentRequirements): void {
   if (payload.scheme !== requirements.scheme) {
     throw new PaymentVerificationError(
       `Scheme mismatch: got "${payload.scheme}", expected "${requirements.scheme}"`,
@@ -48,7 +61,39 @@ export async function verifyPayment(
       `Network mismatch: got "${payload.network}", expected "${requirements.network}"`,
     );
   }
+}
+
+/**
+ * Validate protocol-level invariants (scheme/network match) then delegate the
+ * cryptographic + on-chain verification to the injected verifier. Verifies AND
+ * settles in one step — use {@link validatePayment} + {@link settlePayment} when
+ * you need to serve a resource before charging for it.
+ */
+export async function verifyPayment(
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  verifier: PaymentVerifier,
+): Promise<SettlementReceipt> {
+  assertProtocol(payload, requirements);
   return verifier.verify(payload, requirements);
+}
+
+/** Validate a payment (no on-chain submission) after the protocol checks. */
+export async function validatePayment(
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  verifier: PaymentVerifier,
+): Promise<ValidatedPayment> {
+  assertProtocol(payload, requirements);
+  return verifier.validate(payload, requirements);
+}
+
+/** Settle a previously-validated payment on-chain. */
+export function settlePayment(
+  validated: ValidatedPayment,
+  verifier: PaymentVerifier,
+): Promise<SettlementReceipt> {
+  return verifier.settle(validated);
 }
 
 /**
@@ -56,18 +101,31 @@ export async function verifyPayment(
  * For tests and the local playground only — never wire this into production.
  */
 export function createMockVerifier(): PaymentVerifier {
+  const mockPayer = (payload: PaymentPayload): string =>
+    `mock_payer_${Buffer.from(payload.payload.transaction).toString("hex").slice(0, 16)}`;
+
+  const receiptFor = (validated: ValidatedPayment): SettlementReceipt => {
+    const network = paymentNetworkSchema.parse(validated.payload.network);
+    const hex = Buffer.from(validated.payload.payload.transaction).toString("hex");
+    return {
+      txHash: `mock_${hex.slice(0, 32)}`,
+      network,
+      settledAt: new Date().toISOString(),
+      payer: validated.payer,
+      amount: validated.requirements.maxAmountRequired,
+      asset: "USDC",
+    };
+  };
+
   return {
+    validate(payload, requirements) {
+      return Promise.resolve({ payer: mockPayer(payload), payload, requirements });
+    },
+    settle(validated) {
+      return Promise.resolve(receiptFor(validated));
+    },
     verify(payload, requirements) {
-      const network = paymentNetworkSchema.parse(payload.network);
-      const hex = Buffer.from(payload.payload.transaction).toString("hex");
-      return Promise.resolve({
-        txHash: `mock_${hex.slice(0, 32)}`,
-        network,
-        settledAt: new Date().toISOString(),
-        payer: `mock_payer_${hex.slice(0, 16)}`,
-        amount: requirements.maxAmountRequired,
-        asset: "USDC",
-      });
+      return Promise.resolve(receiptFor({ payer: mockPayer(payload), payload, requirements }));
     },
   };
 }


### PR DESCRIPTION
**Fixes the money-loss bug you caught with Nebula.** The gateway settled the x402 payment on-chain **before** calling the upstream, so a capability that returned an error (Nebula's 401) **still charged the buyer** — money left the Card, no result came back. (Three wasted $0.001 Nebula calls confirmed it live.)

## The fix: serve-then-settle
- Split the `PaymentVerifier` port into **`validate`** (check the signed tx pays the required legs, **without submitting**) and **`settle`** (submit on-chain). `verify` stays as the combined path for the SDK's `tael()` wrapper — **no SDK break**.
- The gateway now: **validate** the payment (an invalid one is still rejected before any work) → **call the upstream** → **settle + record only on a 2xx**. A non-2xx upstream returns its error untouched, and the signed transaction is **never submitted** — so the buyer isn't charged.

## Safety
- Validation still runs **first**, so a bad payment can't get free service.
- If settlement somehow fails *after* a 2xx (rare), the buyer gets a clear "not charged" error rather than a silent double state.

## Verified
Full monorepo: typecheck 11/11, tests 6/6 (api 42/42 including a **new test that a 401 upstream settles nothing** — `payments.list()` is empty, no receipt header). Lint + format clean. No migration.

Closes the correctness gap that has to be right before mainnet.