### PR TITLE
feat(sdk): publish and manage capabilities from the SDK (Phase 1 of #83)

### DIFF
--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -27,6 +27,7 @@ import {
   DbCapabilityRepository,
   type CapabilityRepository,
 } from "./modules/capabilities/capability.repository";
+import { CapabilityWriteService } from "./modules/capabilities/capability-write";
 import { DbApiKeyRepository } from "./modules/keys/key.repository";
 import { KeyPaymentService } from "./modules/keys/key.service";
 import { type RateLimiter, InMemoryRateLimiter } from "./modules/gateway/rate-limit";
@@ -41,6 +42,8 @@ export interface Container {
   wallets: WalletService;
   payments: PaymentService;
   capabilities: CapabilityRepository;
+  /** Write side of capabilities (publish/update/delete from the SDK/API). */
+  capabilityWrites: CapabilityWriteService;
   /** Authenticates Tael API keys and auto-pays from their linked Card. */
   keys: KeyPaymentService;
   verifier: PaymentVerifier;
@@ -138,6 +141,7 @@ export function createContainer(env: Env): Container {
     db ? new DbPaymentRepository(db) : new InMemoryPaymentRepository(),
   );
   const capabilities = new DbCapabilityRepository(db);
+  const capabilityWrites = new CapabilityWriteService(db);
 
   // API-key auth: resolve a key to its Card and sign payments from that Card's
   // hot wallet, within the Card's caps. Needs the same Stellar settings the
@@ -158,6 +162,7 @@ export function createContainer(env: Env): Container {
     wallets,
     payments,
     capabilities,
+    capabilityWrites,
     keys,
     verifier,
     limiter,

--- a/apps/api/src/modules/capabilities/capability-write.handler.ts
+++ b/apps/api/src/modules/capabilities/capability-write.handler.ts
@@ -1,0 +1,96 @@
+import { type Container } from "../../container";
+import { publishInputSchema, updateInputSchema } from "./capability-write";
+
+/** The slice of the container these handlers need. */
+type WriteDeps = Pick<Container, "capabilityWrites" | "keys">;
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Resolve the publisher (owner user id) from the Tael API key, or null. */
+async function authenticatePublisher(deps: WriteDeps, request: Request): Promise<string | null> {
+  const header = request.headers.get("authorization");
+  const match = header ? /^Bearer\s+(tael_live_[A-Za-z0-9]+)$/i.exec(header.trim()) : null;
+  if (!match) return null;
+  const key = await deps.keys.authorize(match[1]!);
+  return key?.ownerId ?? null;
+}
+
+async function parseBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+/** POST /capabilities — publish a capability from the SDK. */
+export async function handleCreateCapability(deps: WriteDeps, request: Request): Promise<Response> {
+  const ownerId = await authenticatePublisher(deps, request);
+  if (!ownerId) return json({ error: "A valid Tael API key is required to publish." }, 401);
+
+  const parsed = publishInputSchema.safeParse(await parseBody(request));
+  if (!parsed.success) {
+    return json({ error: "Invalid capability", issues: parsed.error.issues }, 422);
+  }
+
+  try {
+    const result = await deps.capabilityWrites.create(ownerId, parsed.data);
+    return json({ id: result.id, slug: result.slug, status: "pending" }, 201);
+  } catch (error) {
+    console.error("[capabilities] SDK publish failed:", error);
+    return json({ error: "Could not publish. Try again." }, 500);
+  }
+}
+
+/** GET /me/capabilities — list the caller's own capabilities. */
+export async function handleListOwnCapabilities(
+  deps: WriteDeps,
+  request: Request,
+): Promise<Response> {
+  const ownerId = await authenticatePublisher(deps, request);
+  if (!ownerId) return json({ error: "A valid Tael API key is required." }, 401);
+  const items = await deps.capabilityWrites.listOwned(ownerId);
+  return json({ capabilities: items }, 200);
+}
+
+/** PATCH /capabilities/:id — update a capability the caller owns. */
+export async function handleUpdateCapability(
+  deps: WriteDeps,
+  id: string,
+  request: Request,
+): Promise<Response> {
+  const ownerId = await authenticatePublisher(deps, request);
+  if (!ownerId) return json({ error: "A valid Tael API key is required." }, 401);
+
+  const parsed = updateInputSchema.safeParse(await parseBody(request));
+  if (!parsed.success) {
+    return json({ error: "Invalid update", issues: parsed.error.issues }, 422);
+  }
+
+  try {
+    const result = await deps.capabilityWrites.update(ownerId, id, parsed.data);
+    if (!result) return json({ error: "Capability not found or not yours." }, 404);
+    return json({ id, slug: result.slug }, 200);
+  } catch (error) {
+    console.error("[capabilities] SDK update failed:", error);
+    return json({ error: "Could not update. Try again." }, 500);
+  }
+}
+
+/** DELETE /capabilities/:id — unpublish a capability the caller owns. */
+export async function handleDeleteCapability(
+  deps: WriteDeps,
+  id: string,
+  request: Request,
+): Promise<Response> {
+  const ownerId = await authenticatePublisher(deps, request);
+  if (!ownerId) return json({ error: "A valid Tael API key is required." }, 401);
+  const removed = await deps.capabilityWrites.remove(ownerId, id);
+  if (!removed) return json({ error: "Capability not found or not yours." }, 404);
+  return json({ ok: true }, 200);
+}

--- a/apps/api/src/modules/capabilities/capability-write.test.ts
+++ b/apps/api/src/modules/capabilities/capability-write.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleCreateCapability,
+  handleDeleteCapability,
+  handleListOwnCapabilities,
+  handleUpdateCapability,
+} from "./capability-write.handler";
+import { type CapabilityWriteService } from "./capability-write";
+import { type KeyPaymentService } from "../keys/key.service";
+
+const KEY = "tael_live_abcdef123456";
+const OWNER = "user-1";
+
+/** Fake key auth: any known key resolves to OWNER; anything else is unknown. */
+function fakeKeys(ownerId: string | null): KeyPaymentService {
+  return {
+    authorize: (raw: string) =>
+      Promise.resolve(raw === KEY && ownerId ? { id: "k1", ownerId, card: null } : null),
+  } as unknown as KeyPaymentService;
+}
+
+function fakeWrites(overrides: Partial<CapabilityWriteService> = {}): CapabilityWriteService {
+  return {
+    create: vi.fn(async () => ({ id: "cap-1", slug: "my-api" })),
+    listOwned: vi.fn(async () => [
+      {
+        id: "cap-1",
+        slug: "my-api",
+        name: "My API",
+        kind: "api",
+        status: "pending",
+        visibility: "public",
+        price: "0.01",
+        createdAt: new Date().toISOString(),
+      },
+    ]),
+    update: vi.fn(async () => ({ slug: "my-api" })),
+    remove: vi.fn(async () => true),
+    ...overrides,
+  } as unknown as CapabilityWriteService;
+}
+
+const validBody = {
+  name: "My API",
+  kind: "api",
+  description: "Does a useful thing for agents.",
+  endpoint: "https://api.example.com/v1",
+  payTo: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+  operations: [{ name: "Predict", path: "/predict", price: "0.01" }],
+};
+
+function req(body: unknown, key = KEY): Request {
+  return new Request("http://localhost/capabilities", {
+    method: "POST",
+    headers: { authorization: `Bearer ${key}`, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("capability write API", () => {
+  it("publishes a capability from a valid key + body (201, pending)", async () => {
+    const deps = { capabilityWrites: fakeWrites(), keys: fakeKeys(OWNER) };
+    const res = await handleCreateCapability(deps, req(validBody));
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; slug: string; status: string };
+    expect(body).toMatchObject({ id: "cap-1", slug: "my-api", status: "pending" });
+    expect(deps.capabilityWrites.create).toHaveBeenCalledWith(
+      OWNER,
+      expect.objectContaining({ name: "My API" }),
+    );
+  });
+
+  it("rejects publishing without a valid API key (401)", async () => {
+    const deps = { capabilityWrites: fakeWrites(), keys: fakeKeys(null) };
+    const res = await handleCreateCapability(deps, req(validBody, "tael_live_bogus"));
+    expect(res.status).toBe(401);
+    expect(deps.capabilityWrites.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid body (422) without touching the service", async () => {
+    const deps = { capabilityWrites: fakeWrites(), keys: fakeKeys(OWNER) };
+    const res = await handleCreateCapability(deps, req({ name: "x" }));
+    expect(res.status).toBe(422);
+    expect(deps.capabilityWrites.create).not.toHaveBeenCalled();
+  });
+
+  it("lists the caller's own capabilities", async () => {
+    const deps = { capabilityWrites: fakeWrites(), keys: fakeKeys(OWNER) };
+    const res = await handleListOwnCapabilities(
+      deps,
+      new Request("http://localhost/me/capabilities", {
+        headers: { authorization: `Bearer ${KEY}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { capabilities: unknown[] };
+    expect(body.capabilities).toHaveLength(1);
+  });
+
+  it("404s when updating a capability the caller doesn't own", async () => {
+    const deps = {
+      capabilityWrites: fakeWrites({ update: vi.fn(async () => null) as never }),
+      keys: fakeKeys(OWNER),
+    };
+    const res = await handleUpdateCapability(
+      deps,
+      "cap-x",
+      req({ description: "new description here" }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("deletes a capability the caller owns", async () => {
+    const deps = { capabilityWrites: fakeWrites(), keys: fakeKeys(OWNER) };
+    const res = await handleDeleteCapability(
+      deps,
+      "cap-1",
+      new Request("http://localhost/capabilities/cap-1", {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${KEY}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(deps.capabilityWrites.remove).toHaveBeenCalledWith(OWNER, "cap-1");
+  });
+});

--- a/apps/api/src/modules/capabilities/capability-write.ts
+++ b/apps/api/src/modules/capabilities/capability-write.ts
@@ -1,0 +1,241 @@
+import { z } from "zod";
+import {
+  and,
+  capabilities,
+  desc,
+  encryptSecret,
+  eq,
+  ilike,
+  type CapabilityBilling,
+  type CapabilitySpec,
+  type Database,
+  type UpstreamAuth,
+} from "@tael/database";
+import { TaelError } from "@tael/types";
+
+/** One priced operation in a publish request. */
+const operationInputSchema = z.object({
+  name: z.string().min(1),
+  path: z.string().max(200).optional().default(""),
+  method: z.string().max(10).optional().default("POST"),
+  price: z.string().regex(/^\d+(\.\d+)?$/, "price must be a decimal string, e.g. 0.01"),
+  sampleRequest: z.string().max(4000).optional().default(""),
+  sampleResponse: z.string().max(4000).optional().default(""),
+});
+
+/** How Tael authenticates to the publisher's upstream. */
+const authInputSchema = z
+  .object({
+    scheme: z.enum(["bearer", "header", "none"]).default("bearer"),
+    header: z.string().max(100).optional(),
+    extraHeaders: z.record(z.string()).optional(),
+  })
+  .optional();
+
+/** The shape a publisher (or their AI) sends to create a capability from code. */
+export const publishInputSchema = z.object({
+  name: z.string().min(2).max(80),
+  kind: z.enum(["api", "mcp", "agent", "model", "dataset", "credit"]),
+  description: z.string().min(10).max(500),
+  logoUrl: z.string().url().max(200_000).optional(),
+  contact: z.string().max(200).optional(),
+  visibility: z.enum(["public", "unlisted", "private"]).default("public"),
+  /** The real upstream endpoint Tael proxies to. */
+  endpoint: z.string().url(),
+  /** Upstream credential — encrypted at rest, never returned. */
+  secret: z.string().max(500).optional(),
+  auth: authInputSchema,
+  /** Stellar address that receives USDC earnings. */
+  payTo: z.string().regex(/^G[A-Z2-7]{55}$/, "payTo must be a Stellar public key"),
+  operations: z.array(operationInputSchema).min(1, "add at least one operation"),
+  faqs: z
+    .array(z.object({ question: z.string().min(1), answer: z.string().default("") }))
+    .optional()
+    .default([]),
+  /** Metered (per-token) billing for model capabilities. */
+  billing: z
+    .object({
+      metered: z.boolean(),
+      model: z.string().optional(),
+      maxTokens: z.number().int().positive().optional(),
+    })
+    .optional(),
+});
+
+export type PublishInput = z.infer<typeof publishInputSchema>;
+/** Update accepts the same fields, all optional. */
+export const updateInputSchema = publishInputSchema.partial();
+export type UpdateInput = z.infer<typeof updateInputSchema>;
+
+/** A capability as returned to its publisher (no secret). */
+export interface OwnedCapability {
+  id: string;
+  slug: string;
+  name: string;
+  kind: string;
+  status: string;
+  visibility: string;
+  price: string;
+  createdAt: string;
+}
+
+function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 60) || "capability"
+  );
+}
+
+function buildUpstreamAuth(auth: PublishInput["auth"]): UpstreamAuth | null {
+  if (!auth) return null;
+  const hasExtra = auth.extraHeaders && Object.keys(auth.extraHeaders).length > 0;
+  if (auth.scheme === "bearer" && !hasExtra) return null;
+  return {
+    scheme: auth.scheme,
+    header: auth.scheme === "header" ? auth.header : undefined,
+    extraHeaders: hasExtra ? auth.extraHeaders : undefined,
+  };
+}
+
+function buildSpec(operations: PublishInput["operations"]): CapabilitySpec {
+  const taken = new Set<string>();
+  return {
+    operations: operations.map((op, i) => {
+      const base = slugify(op.name) || `op-${i + 1}`;
+      let opSlug = base;
+      for (let n = 2; taken.has(opSlug); n += 1) opSlug = `${base}-${n}`;
+      taken.add(opSlug);
+      return {
+        name: op.name,
+        slug: opSlug,
+        path: op.path || undefined,
+        method: op.method || undefined,
+        sampleRequest: op.sampleRequest || undefined,
+        sampleResponse: op.sampleResponse || undefined,
+        price: op.price,
+      };
+    }),
+  };
+}
+
+function minPrice(operations: PublishInput["operations"]): string {
+  return operations.reduce(
+    (min, op) => (Number(op.price) < Number(min) ? op.price : min),
+    operations[0]?.price ?? "0",
+  );
+}
+
+/**
+ * Write side of capabilities for the public SDK/API: create, list, update, and
+ * delete a capability owned by the publisher resolved from their Tael API key.
+ * Mirrors the dashboard's publish/edit logic so both surfaces behave the same.
+ * A create lands `pending`; Tael still grants Verified.
+ */
+export class CapabilityWriteService {
+  constructor(private readonly db: Database | undefined) {}
+
+  private get database(): Database {
+    if (!this.db) throw new TaelError("INTERNAL", "DATABASE_URL is not configured.");
+    return this.db;
+  }
+
+  private async uniqueSlug(base: string): Promise<string> {
+    const rows = await this.database
+      .select({ slug: capabilities.slug })
+      .from(capabilities)
+      .where(ilike(capabilities.slug, `${base}%`));
+    const taken = new Set(rows.map((r) => r.slug));
+    if (!taken.has(base)) return base;
+    for (let i = 2; ; i += 1) if (!taken.has(`${base}-${i}`)) return `${base}-${i}`;
+  }
+
+  async create(ownerId: string, input: PublishInput): Promise<{ id: string; slug: string }> {
+    const slug = await this.uniqueSlug(slugify(input.name));
+    const [row] = await this.database
+      .insert(capabilities)
+      .values({
+        slug,
+        name: input.name,
+        description: input.description,
+        logoUrl: input.logoUrl ?? null,
+        contact: input.contact ?? null,
+        kind: input.kind,
+        visibility: input.visibility,
+        status: "pending",
+        faqs: input.faqs.filter((f) => f.answer.trim().length > 0),
+        spec: buildSpec(input.operations),
+        price: minPrice(input.operations),
+        payTo: input.payTo,
+        upstreamUrl: input.endpoint,
+        upstreamSecretEnc: input.secret ? encryptSecret(input.secret) : null,
+        upstreamAuth: buildUpstreamAuth(input.auth),
+        billing: (input.billing as CapabilityBilling | undefined) ?? null,
+        publisherId: ownerId,
+      })
+      .returning({ id: capabilities.id, slug: capabilities.slug });
+    return { id: row!.id, slug: row!.slug };
+  }
+
+  async listOwned(ownerId: string): Promise<OwnedCapability[]> {
+    const rows = await this.database
+      .select({
+        id: capabilities.id,
+        slug: capabilities.slug,
+        name: capabilities.name,
+        kind: capabilities.kind,
+        status: capabilities.status,
+        visibility: capabilities.visibility,
+        price: capabilities.price,
+        createdAt: capabilities.createdAt,
+      })
+      .from(capabilities)
+      .where(eq(capabilities.publisherId, ownerId))
+      .orderBy(desc(capabilities.createdAt));
+    return rows.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() }));
+  }
+
+  /** Update a capability the owner holds. Only provided fields change; a blank
+   *  secret keeps the existing one. Returns null if it doesn't exist / not owned. */
+  async update(ownerId: string, id: string, input: UpdateInput): Promise<{ slug: string } | null> {
+    const [existing] = await this.database
+      .select({ id: capabilities.id, slug: capabilities.slug })
+      .from(capabilities)
+      .where(and(eq(capabilities.id, id), eq(capabilities.publisherId, ownerId)))
+      .limit(1);
+    if (!existing) return null;
+
+    const set: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.name !== undefined) set.name = input.name;
+    if (input.description !== undefined) set.description = input.description;
+    if (input.logoUrl !== undefined) set.logoUrl = input.logoUrl || null;
+    if (input.contact !== undefined) set.contact = input.contact || null;
+    if (input.kind !== undefined) set.kind = input.kind;
+    if (input.visibility !== undefined) set.visibility = input.visibility;
+    if (input.endpoint !== undefined) set.upstreamUrl = input.endpoint;
+    if (input.payTo !== undefined) set.payTo = input.payTo;
+    if (input.secret) set.upstreamSecretEnc = encryptSecret(input.secret);
+    if (input.auth !== undefined) set.upstreamAuth = buildUpstreamAuth(input.auth);
+    if (input.billing !== undefined) set.billing = input.billing ?? null;
+    if (input.faqs !== undefined) set.faqs = input.faqs.filter((f) => f.answer.trim().length > 0);
+    if (input.operations !== undefined) {
+      set.spec = buildSpec(input.operations);
+      set.price = minPrice(input.operations);
+    }
+
+    await this.database.update(capabilities).set(set).where(eq(capabilities.id, id));
+    return { slug: existing.slug };
+  }
+
+  /** Delete a capability the owner holds. Returns false if not found / not owned. */
+  async remove(ownerId: string, id: string): Promise<boolean> {
+    const deleted = await this.database
+      .delete(capabilities)
+      .where(and(eq(capabilities.id, id), eq(capabilities.publisherId, ownerId)))
+      .returning({ id: capabilities.id });
+    return deleted.length > 0;
+  }
+}

--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -21,6 +21,7 @@ import {
   type ServableCapability,
 } from "../capabilities/capability.repository";
 import { KeyPaymentService, type AuthorizedKey, type KeyAuthorizer } from "../keys/key.service";
+import { CapabilityWriteService } from "../capabilities/capability-write";
 import { createServer } from "../../server";
 
 // The only novel-to-#55 dependency we can't run in a unit test is the on-chain
@@ -109,6 +110,7 @@ function buildContainer(
     wallets: new WalletService(new InMemoryWalletRepository()),
     payments,
     capabilities: fakeCapabilities(capability),
+    capabilityWrites: new CapabilityWriteService(undefined),
     keys,
     verifier: createMockVerifier(),
     limiter: testRateLimiter,
@@ -388,7 +390,8 @@ describe("capability gateway", () => {
 
   it("402s when the API key has no linked Card", async () => {
     const keys = fakeKeys({
-      authorize: (): Promise<AuthorizedKey | null> => Promise.resolve({ id: "k1", card: null }),
+      authorize: (): Promise<AuthorizedKey | null> =>
+        Promise.resolve({ id: "k1", ownerId: "u1", card: null }),
     });
     const { container } = buildContainer(CAPABILITY, undefined, keys);
     const app = createServer(container);
@@ -404,6 +407,7 @@ describe("capability gateway", () => {
       authorize: (): Promise<AuthorizedKey | null> =>
         Promise.resolve({
           id: "k1",
+          ownerId: "u1",
           card: {
             agentId: "a1",
             address: ADDRESS,
@@ -456,6 +460,7 @@ describe("capability gateway", () => {
       authorize: (): Promise<AuthorizedKey | null> =>
         Promise.resolve({
           id: "k1",
+          ownerId: "u1",
           card: {
             agentId: "a1",
             address: ADDRESS,
@@ -808,6 +813,7 @@ describe("capability gateway", () => {
         authorize: (): Promise<AuthorizedKey | null> =>
           Promise.resolve({
             id: "k1",
+            ownerId: "u1",
             card: {
               agentId: "a1",
               address: ADDRESS,

--- a/apps/api/src/modules/keys/key.repository.ts
+++ b/apps/api/src/modules/keys/key.repository.ts
@@ -30,6 +30,7 @@ export class DbApiKeyRepository implements KeyAuthorizer {
     const [row] = await this.db
       .select({
         id: apiKeys.id,
+        ownerId: apiKeys.ownerId,
         revokedAt: apiKeys.revokedAt,
         agentId: apiKeys.agentId,
         address: wallets.address,
@@ -53,7 +54,7 @@ export class DbApiKeyRepository implements KeyAuthorizer {
             policy: row.policy,
           }
         : null;
-    return { id: row.id, card };
+    return { id: row.id, ownerId: row.ownerId, card };
   }
 
   async touch(keyId: string): Promise<void> {

--- a/apps/api/src/modules/keys/key.service.ts
+++ b/apps/api/src/modules/keys/key.service.ts
@@ -12,9 +12,11 @@ export interface AuthorizedCard {
   policy: SpendingPolicy | null;
 }
 
-/** A resolved API key: its id, plus the linked Card (null = nothing to spend from). */
+/** A resolved API key: its id, the owning publisher, and the linked Card. */
 export interface AuthorizedKey {
   id: string;
+  /** The user who owns this key — the publisher for capability writes. */
+  ownerId: string;
   card: AuthorizedCard | null;
 }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,6 +3,12 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { type Container } from "./container";
 import { handleCatalogRequest, handleGatewayRequest } from "./modules/gateway/gateway.handler";
+import {
+  handleCreateCapability,
+  handleDeleteCapability,
+  handleListOwnCapabilities,
+  handleUpdateCapability,
+} from "./modules/capabilities/capability-write.handler";
 import { createContextFactory } from "./trpc/context";
 import { appRouter } from "./trpc/router";
 
@@ -21,6 +27,17 @@ export function createServer(container: Container) {
   // Public discovery catalog: list/search verified capabilities (no secrets).
   // Lets the SDK do `tael.list()` / `tael.search(...)` and buyers browse.
   app.get("/capabilities", (c) => handleCatalogRequest(container, c.req.raw));
+
+  // Publisher write API (authenticated by a Tael API key → its owner). Lets the
+  // SDK publish and manage capabilities from code: `tael.publish()`, etc.
+  app.post("/capabilities", (c) => handleCreateCapability(container, c.req.raw));
+  app.get("/me/capabilities", (c) => handleListOwnCapabilities(container, c.req.raw));
+  app.patch("/capabilities/:id", (c) =>
+    handleUpdateCapability(container, c.req.param("id"), c.req.raw),
+  );
+  app.delete("/capabilities/:id", (c) =>
+    handleDeleteCapability(container, c.req.param("id"), c.req.raw),
+  );
 
   // The capability gateway: agents call `/c/:slug` and pay per call over x402.
   // Public + unauthenticated by design — the payment *is* the authentication.

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -97,4 +97,39 @@ describe("Tael client", () => {
     expect(url.searchParams.get("q")).toBe("weather");
     expect(url.searchParams.get("limit")).toBe("10");
   });
+
+  it("publishes a capability with the key attached (POST /capabilities)", async () => {
+    const { fn, calls } = stubFetch(
+      jsonResponse({ id: "cap-1", slug: "my-api", status: "pending" }, { status: 201 }),
+    );
+    const tael = new Tael({ apiKey: KEY, baseUrl: "https://gw.test", fetch: fn });
+
+    const res = await tael.publish({
+      name: "My API",
+      kind: "api",
+      description: "Does a thing.",
+      endpoint: "https://api.example.com",
+      payTo: "G...",
+      operations: [{ name: "Predict", path: "/predict", price: "0.01" }],
+    });
+
+    expect(res).toEqual({ id: "cap-1", slug: "my-api", status: "pending" });
+    expect(calls[0]?.url).toBe("https://gw.test/capabilities");
+    expect(calls[0]?.init?.method).toBe("POST");
+    const headers = new Headers(calls[0]?.init?.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${KEY}`);
+    expect(JSON.parse(String(calls[0]?.init?.body)).name).toBe("My API");
+  });
+
+  it("updates and unpublishes with the right verbs", async () => {
+    const { fn, calls } = stubFetch(jsonResponse({ id: "cap-1", slug: "my-api" }));
+    const tael = new Tael({ apiKey: KEY, baseUrl: "https://gw.test", fetch: fn });
+
+    await tael.updateCapability("cap-1", { description: "new" });
+    expect(calls[0]?.url).toBe("https://gw.test/capabilities/cap-1");
+    expect(calls[0]?.init?.method).toBe("PATCH");
+
+    await tael.unpublish("cap-1");
+    expect(calls[1]?.init?.method).toBe("DELETE");
+  });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -55,6 +55,60 @@ export interface CallOptions {
   query?: Record<string, string | number>;
 }
 
+/** One priced operation when publishing a capability. */
+export interface PublishOperation {
+  name: string;
+  /** Path appended to the endpoint, e.g. "/swap". Empty selects the base URL. */
+  path?: string;
+  method?: string;
+  /** USDC per call, decimal string. "0" = free. */
+  price: string;
+  sampleRequest?: string;
+  sampleResponse?: string;
+}
+
+/** How Tael authenticates to your upstream endpoint. */
+export interface PublishAuth {
+  scheme: "bearer" | "header" | "none";
+  /** Header name when scheme = "header", e.g. "x-api-key". */
+  header?: string;
+  /** Static headers always sent, e.g. { "anthropic-version": "2023-06-01" }. */
+  extraHeaders?: Record<string, string>;
+}
+
+/** The manifest to publish a capability from code. */
+export interface PublishCapabilityInput {
+  name: string;
+  kind: "api" | "mcp" | "agent" | "model" | "dataset" | "credit";
+  description: string;
+  /** The real upstream endpoint Tael proxies to. */
+  endpoint: string;
+  /** Upstream credential — encrypted server-side, never returned. */
+  secret?: string;
+  auth?: PublishAuth;
+  /** Stellar address that receives USDC earnings (needs a USDC trustline). */
+  payTo: string;
+  operations: PublishOperation[];
+  /** Buyer-facing FAQ you write about your product. */
+  faqs?: { question: string; answer: string }[];
+  logoUrl?: string;
+  contact?: string;
+  visibility?: "public" | "unlisted" | "private";
+  billing?: { metered: boolean; model?: string; maxTokens?: number };
+}
+
+/** A capability as returned to its publisher. */
+export interface OwnedCapability {
+  id: string;
+  slug: string;
+  name: string;
+  kind: string;
+  status: string;
+  visibility: string;
+  price: string;
+  createdAt: string;
+}
+
 /** The full result of a paid call: the data, the HTTP status, and the receipt. */
 export interface TaelResponse<T = unknown> {
   data: T;
@@ -177,6 +231,56 @@ export class Tael {
   /** Search the catalog by free text — shorthand for `list({ q })`. */
   search(query: string, options: Omit<ListOptions, "q"> = {}): Promise<CatalogCapability[]> {
     return this.list({ ...options, q: query });
+  }
+
+  // --- Publish side: manage the capabilities YOU sell (authenticated by key) ---
+
+  /** An authenticated JSON request to the write API, keyed by your API key. */
+  private async write<T>(path: string, method: string, body?: unknown): Promise<T> {
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        ...(body !== undefined ? { "content-type": "application/json" } : {}),
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const data = await parseBody(res);
+    if (!res.ok) {
+      const message =
+        (data as { error?: string })?.error ?? `Tael ${method} ${path} failed (${res.status}).`;
+      throw new TaelError(message, res.status, data);
+    }
+    return data as T;
+  }
+
+  /**
+   * Publish a capability from code. It goes live immediately, marked `pending`
+   * until Tael grants Verified. Works for any kind (api, mcp, agent, model,
+   * dataset, credit). Returns the new capability's id, slug, and status.
+   */
+  publish(input: PublishCapabilityInput): Promise<{ id: string; slug: string; status: string }> {
+    return this.write("/capabilities", "POST", input);
+  }
+
+  /** List the capabilities you publish. */
+  async myCapabilities(): Promise<OwnedCapability[]> {
+    const data = await this.write<{ capabilities: OwnedCapability[] }>("/me/capabilities", "GET");
+    return data.capabilities ?? [];
+  }
+
+  /** Update a capability you own. Only the fields you pass change; a blank
+   *  secret keeps the current one. */
+  updateCapability(
+    id: string,
+    input: Partial<PublishCapabilityInput>,
+  ): Promise<{ id: string; slug: string }> {
+    return this.write(`/capabilities/${encodeURIComponent(id)}`, "PATCH", input);
+  }
+
+  /** Unpublish (delete) a capability you own. */
+  unpublish(id: string): Promise<{ ok: boolean }> {
+    return this.write(`/capabilities/${encodeURIComponent(id)}`, "DELETE");
   }
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,7 +8,8 @@
 //    the gateway pays from the Card your key is linked to, within its caps.
 export * from "./tael";
 
-// The buy-side client: call any capability with one API key.
+// The buy-side client: call any capability with one API key. Also the publish
+// side: manage the capabilities you sell (publish, update, list, unpublish).
 export {
   Tael,
   TaelError,
@@ -17,6 +18,10 @@ export {
   type CallOptions,
   type ListOptions,
   type CatalogCapability,
+  type PublishCapabilityInput,
+  type PublishOperation,
+  type PublishAuth,
+  type OwnedCapability,
 } from "./client";
 
 // Re-export the payment primitives SDK users commonly need at the call site.


### PR DESCRIPTION
Makes the SDK the **full loop** — discover, call, pay, **and publish**. A publisher (or their AI) can now publish, list, update, and unpublish a capability **from code** with just their Tael API key. No dashboard needed. Both the form and the SDK now publish.

```ts
const tael = new Tael({ apiKey });
await tael.publish({ name, kind, endpoint, auth, payTo, operations, faqs });
await tael.updateCapability(id, { secret, auth });   // e.g. fix a token in place
await tael.myCapabilities();
await tael.unpublish(id);
```

Works for **every kind** — api, mcp, agent, model, dataset, credit — through the same call.

## What's included
- **API write endpoints** (`apps/api`), authenticated by the Tael key: `POST /capabilities`, `GET /me/capabilities`, `PATCH /capabilities/:id`, `DELETE /capabilities/:id`. The publisher is resolved from `api_keys.ownerId`, so one key both **buys and publishes**.
- **`CapabilityWriteService`** mirrors the dashboard's publish/edit logic (validation, unique slug, secret encryption, `upstreamAuth`, operations spec, **partner-written FAQ**). A create lands **`pending`** (Tael still grants Verified). A blank secret on update **keeps** the current one.
- **SDK methods** + typed `PublishCapabilityInput`.
- **Tests:** write-handler auth (401) / validation (422) / ownership (404) / success (api 47/47), and SDK method wiring (sdk 9/9).

## Verified
Full monorepo: typecheck 11/11, tests 6/6, lint + format clean. No migration.

## Scope (Phase 1 of #83)
This is the programmatic core. **Auth = the existing `tael_live_` key.** The next phases (tracked in #83): `npx tael login` (browser token, npm-style) and `tael.diagnose()` + structured errors (self-healing onboarding).