### PR TITLE
chore(sdk): 0.2.0 — publish + manage capabilities from the SDK

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -58,6 +58,33 @@ try {
 }
 ```
 
+## Publish: list your product as a capability from code
+
+Publish and manage capabilities with the same API key, no dashboard needed. It goes live immediately, marked `pending`, until Tael grants Verified. Works for every kind (`api`, `mcp`, `agent`, `model`, `dataset`, `credit`).
+
+```ts
+const tael = new Tael({ apiKey: process.env.TAEL_KEY! });
+
+const cap = await tael.publish({
+  name: "Nebula",
+  kind: "mcp",
+  description: "On-Stellar agentic actions and treasury tools.",
+  endpoint: "https://nebulaonchain.xyz/api/tools",
+  auth: { scheme: "header", header: "x-api-key" }, // or "bearer" | "none"; extraHeaders too
+  secret: process.env.NEBULA_TOKEN, // encrypted server-side, never returned
+  payTo: "G...", // must hold a USDC trustline for Tael's issuer
+  operations: [
+    { name: "Check balance", path: "/check-balance", method: "POST", price: "0.001" },
+    { name: "Get address", path: "/get-address", method: "POST", price: "0" },
+  ],
+  faqs: [{ question: "What does check_balance return?", answer: "The calling card's balances." }],
+});
+
+await tael.updateCapability(cap.id, { secret: NEW_TOKEN }); // fix a token in place
+const mine = await tael.myCapabilities(); // list what you publish
+await tael.unpublish(cap.id);
+```
+
 ## Sell: put a price on your own service
 
 The `tael()` wrapper turns any Fetch handler into a payment-gated one. `createTael()` binds your settlement details once and returns a `paid()` factory:

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tael/sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "description": "The Tael SDK: call any capability with one API key, or wrap your own service with x402 payments in one line.",
   "license": "MIT",


### PR DESCRIPTION
Bumps `@tael/sdk` to **0.2.0** for the new publish side (`publish` / `updateCapability` / `myCapabilities` / `unpublish`, shipped in #84), and documents it in the README.

After this merges, republish to npm (`npm publish --access public`) so partners like Nebula can `pnpm add @tael/sdk` and publish a capability from code.

Verified: SDK typecheck clean, publish methods bundled into `dist` (JS + `.d.ts`), dry-run shows `0.2.0`.