### PR TITLE
docs: npm links, professional badges, safer publish example (0.2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Agents, MCP tools, and APIs supported. Payments settled in USDC on Stellar.
 </div>
 
 <p align="center">
+  <a href="https://www.npmjs.com/package/@tael/sdk"><img alt="npm version" src="https://img.shields.io/npm/v/@tael/sdk?logo=npm&label=%40tael%2Fsdk&color=000000" /></a>
+  <a href="https://github.com/rahulsainlll/tael-protocol/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/rahulsainlll/tael-protocol?logo=github&color=000000" /></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-000000.svg" /></a>
   <a href="https://discord.gg/UtW9dZKwBW"><img alt="Discord community" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white" /></a>
   <a href="https://x.com/taelprotocol"><img alt="Follow @taelprotocol" src="https://img.shields.io/badge/Follow-%40taelprotocol-000000?logo=x&logoColor=white" /></a>
@@ -100,17 +102,17 @@ and shows up in your ledger.
 A Turborepo + pnpm monorepo. The payment engine is chain-agnostic; Stellar is the first settlement
 backend.
 
-| Package          | What it does                                                    |
-| ---------------- | --------------------------------------------------------------- |
-| `@tael/sdk`      | Wrap any handler with x402 payments — `tael()` / `createTael()` |
-| `@tael/payments` | x402 protocol wire format + non-custodial fee split             |
-| `@tael/stellar`  | Stellar settlement + the hardened on-chain payment verifier     |
-| `@tael/types`    | `Money` value object, zod schemas, shared errors                |
-| `@tael/auth`     | Sign-In-With-Stellar sessions (edge-safe, `jose`)               |
-| `@tael/database` | Drizzle schema + AES-256-GCM secret encryption                  |
-| `@tael/ui`       | Shared React components (shadcn/ui-based)                       |
-| `@tael/config`   | Shared TypeScript / Tailwind / ESLint config                    |
-| `@tael/claude`   | AI helpers (e.g. capability FAQ generation)                     |
+| Package                                                | What it does                                                                            |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| [`@tael/sdk`](https://www.npmjs.com/package/@tael/sdk) | Buy, publish, and sell capabilities from code: the `Tael` client + the `tael()` wrapper |
+| `@tael/payments`                                       | x402 protocol wire format + non-custodial fee split                                     |
+| `@tael/stellar`                                        | Stellar settlement + the hardened on-chain payment verifier                             |
+| `@tael/types`                                          | `Money` value object, zod schemas, shared errors                                        |
+| `@tael/auth`                                           | Sign-In-With-Stellar sessions (edge-safe, `jose`)                                       |
+| `@tael/database`                                       | Drizzle schema + AES-256-GCM secret encryption                                          |
+| `@tael/ui`                                             | Shared React components (shadcn/ui-based)                                               |
+| `@tael/config`                                         | Shared TypeScript / Tailwind / ESLint config                                            |
+| `@tael/claude`                                         | AI helpers (e.g. capability FAQ generation)                                             |
 
 Apps: **`web`** (marketing site), **`dashboard`** (the console), **`api`** (the capability gateway).
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,5 +1,9 @@
 # @tael/sdk
 
+[![npm version](https://img.shields.io/npm/v/@tael/sdk?logo=npm&color=000000)](https://www.npmjs.com/package/@tael/sdk)
+[![npm downloads](https://img.shields.io/npm/dm/@tael/sdk?color=000000)](https://www.npmjs.com/package/@tael/sdk)
+[![license](https://img.shields.io/npm/l/@tael/sdk?color=000000)](https://github.com/rahulsainlll/tael-protocol/blob/main/LICENSE)
+
 The official SDK for [Tael](https://taelprotocol.xyz), the payment layer for AI agents. Two sides in one package:
 
 - **Buy** any capability on the Tael marketplace with a single API key.
@@ -68,13 +72,13 @@ import { Tael } from "@tael/sdk";
 const tael = new Tael({ apiKey: process.env.TAEL_KEY! });
 
 const capability = await tael.publish({
-  name: "Nebula",
+  name: "Treasury Tools",
   kind: "mcp",
   description: "On-Stellar agentic actions and treasury tools for AI agents.",
-  endpoint: "https://nebula.example.com/api/tools",
+  endpoint: "https://api.example.com/tools",
   auth: { scheme: "header", header: "x-api-key" },
-  secret: process.env.NEBULA_TOKEN,
-  payTo: "GAUQW55J4QANRD4JPEBU4HL23L7SYWU2YSBQRBE6UU2UASOKZ2LZ4KZ5",
+  secret: process.env.MY_UPSTREAM_TOKEN,
+  payTo: "G...", // your Stellar payout address (needs a USDC trustline for Tael's issuer)
   operations: [
     { name: "Check balance", path: "/check-balance", method: "POST", price: "0.001" },
     { name: "Get address", path: "/get-address", method: "POST", price: "0" },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tael/sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "The Tael SDK: call any capability with one API key, or wrap your own service with x402 payments in one line.",
   "license": "MIT",


### PR DESCRIPTION
Polish + a fix.

**Fix:** the SDK publish example used a real partner payout address. A Stellar address is public (not a secret like a key), so it's not a leak, but a real one doesn't belong in a generic sample. Replaced with a `G...` placeholder.

**Polish (more professional):**
- **Root README:** `@tael/sdk` now links to npm; added **npm version** + **GitHub stars** badges to the header.
- **SDK README:** **version / downloads / license** badges at the top.

Bumps to **0.2.2** so the corrected README republishes. No em dashes, formatted.