### PR TITLE
feat(capabilities): first-party Stellar capabilities service

### DIFF
--- a/apps/capabilities/README.md
+++ b/apps/capabilities/README.md
@@ -8,11 +8,11 @@ tools that any agent can use on day one, and they dogfood the SDK publish flow.
 
 Each endpoint is published as an operation of a Tael capability. Today:
 
-| Capability    | Operation                         | What it does                                                |
-| ------------- | --------------------------------- | ----------------------------------------------------------- |
-| Stellar Tools | `GET /stellar/balance?address=G…` | Balances (XLM + assets) for an account                      |
-| Stellar Tools | `GET /stellar/account?address=G…` | Account details: sequence, signers, home domain, trustlines |
-| Stellar Tools | `GET /stellar/tx?hash=…`          | A settled transaction by its hash                           |
+| Capability | Operation                         | What it does                                                |
+| ---------- | --------------------------------- | ----------------------------------------------------------- |
+| Stellar    | `GET /stellar/balance?address=G…` | Balances (XLM + assets) for an account                      |
+| Stellar    | `GET /stellar/account?address=G…` | Account details: sequence, signers, home domain, trustlines |
+| Stellar    | `GET /stellar/tx?hash=…`          | A settled transaction by its hash                           |
 
 All read-only, all public, all free.
 
@@ -41,25 +41,35 @@ A first-party capability must:
 
 1. Add the handler in `src/server.ts` (and a helper in `src/stellar.ts` if it
    reads the chain).
-2. Add its operation to the `Stellar Tools` manifest in `src/publish.ts` (name,
+2. Add its operation to the `Stellar` manifest in `src/publish.ts` (name,
    path, method, price, sample request/response).
 3. `pnpm --filter capabilities typecheck` and run it locally (`pnpm dev`).
 4. Deploy, then publish (below).
 
 ## Deploy and publish
 
-```bash
-# 1. Deploy this service (Render/Fly/Vercel). It binds $PORT.
-pnpm --filter capabilities build && pnpm --filter capabilities start
+**1. Deploy this service.** On Render, create a new Web Service from the repo with:
 
-# 2. Publish the capabilities to Tael via the SDK.
+| Setting       | Value                                                                                                |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| Build command | `corepack enable && pnpm install --frozen-lockfile --prod=false && pnpm --filter capabilities build` |
+| Start command | `pnpm --filter capabilities start`                                                                   |
+| Environment   | `STELLAR_HORIZON_URL` (optional, defaults to testnet). `PORT` is injected.                           |
+
+It binds `$PORT` and exposes `/health`, `/stellar/balance`, `/stellar/account`, `/stellar/tx`.
+
+**2. Publish the capabilities to Tael** with the SDK, pointing at the deployed URL:
+
+```bash
 TAEL_KEY=tael_live_… \
 PAY_TO=G… \
-CAPABILITIES_URL=https://capabilities.taelprotocol.xyz \
+CAPABILITIES_URL=https://<your-render-service>.onrender.com \
   pnpm --filter capabilities publish:capabilities
 ```
 
-They go live as `pending`; a Tael admin grants Verified from the marketplace.
+This creates the `stellar` capability (operations `stellar/balance`, `stellar/account`,
+`stellar/tx`). They go live as `pending`; a Tael admin grants Verified from the marketplace.
+An agent then calls them with one key: `await tael.get("stellar/balance", { query: { address } })`.
 
 ## Want a capability that isn't here?
 

--- a/apps/capabilities/README.md
+++ b/apps/capabilities/README.md
@@ -1,0 +1,68 @@
+# Tael first-party capabilities
+
+A small service of useful, **Stellar-native** endpoints that Tael builds, hosts,
+and publishes to the marketplace. These seed the marketplace with real, verified
+tools that any agent can use on day one, and they dogfood the SDK publish flow.
+
+## What lives here
+
+Each endpoint is published as an operation of a Tael capability. Today:
+
+| Capability    | Operation                         | What it does                                                |
+| ------------- | --------------------------------- | ----------------------------------------------------------- |
+| Stellar Tools | `GET /stellar/balance?address=G…` | Balances (XLM + assets) for an account                      |
+| Stellar Tools | `GET /stellar/account?address=G…` | Account details: sequence, signers, home domain, trustlines |
+| Stellar Tools | `GET /stellar/tx?hash=…`          | A settled transaction by its hash                           |
+
+All read-only, all public, all free.
+
+## The rules (what belongs here)
+
+A first-party capability must:
+
+1. **Be Stellar-native and genuinely useful to an agent.** On-chain reads,
+   quotes, account/asset lookups. If it isn't about Stellar, it doesn't belong
+   here. Keep the surface focused.
+2. **Be read-only or otherwise safe.** No destructive or state-changing action
+   without an explicit, well-understood design. These run unauthenticated behind
+   Tael's payment gate, so they must be safe to call.
+3. **Need no secrets.** Everything here talks to public infrastructure (Horizon).
+   If an endpoint needs an API key, it is a third-party capability, not a
+   first-party one.
+4. **Return clean, documented JSON.** Small, stable shapes. Include a
+   `sampleRequest` and `sampleResponse` in the publish manifest.
+5. **Be listed in the table above and in `src/publish.ts`.** The manifest in
+   `publish.ts` is the source of truth for what is published.
+6. **Price at 0 unless there is a real per-call cost.** First-party utilities are
+   free to seed the marketplace; Tael earns on the marketplace fee of other
+   capabilities, not on these.
+
+## How to add one
+
+1. Add the handler in `src/server.ts` (and a helper in `src/stellar.ts` if it
+   reads the chain).
+2. Add its operation to the `Stellar Tools` manifest in `src/publish.ts` (name,
+   path, method, price, sample request/response).
+3. `pnpm --filter capabilities typecheck` and run it locally (`pnpm dev`).
+4. Deploy, then publish (below).
+
+## Deploy and publish
+
+```bash
+# 1. Deploy this service (Render/Fly/Vercel). It binds $PORT.
+pnpm --filter capabilities build && pnpm --filter capabilities start
+
+# 2. Publish the capabilities to Tael via the SDK.
+TAEL_KEY=tael_live_… \
+PAY_TO=G… \
+CAPABILITIES_URL=https://capabilities.taelprotocol.xyz \
+  pnpm --filter capabilities publish:capabilities
+```
+
+They go live as `pending`; a Tael admin grants Verified from the marketplace.
+
+## Want a capability that isn't here?
+
+Open an issue labelled `good-first-capability` describing the Stellar tool you
+want. Contributors can build it here and we publish it. This is how the
+first-party surface grows.

--- a/apps/capabilities/package.json
+++ b/apps/capabilities/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "capabilities",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Tael's first-party capabilities: a small service of useful, Stellar-native endpoints that are published to the Tael marketplace.",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist .turbo",
+    "publish:capabilities": "tsx src/publish.ts"
+  },
+  "dependencies": {
+    "@hono/node-server": "catalog:",
+    "@tael/sdk": "workspace:*",
+    "hono": "catalog:"
+  },
+  "devDependencies": {
+    "@tael/config": "workspace:*",
+    "@types/node": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/capabilities/src/index.ts
+++ b/apps/capabilities/src/index.ts
@@ -1,0 +1,11 @@
+import { serve } from "@hono/node-server";
+import { createServer } from "./server";
+
+const app = createServer();
+
+// The platform injects the port to bind via `PORT`; fall back to 3004 locally.
+const port = Number(process.env.PORT) || 3004;
+
+serve({ fetch: app.fetch, port, hostname: "0.0.0.0" }, (info) => {
+  console.log(`▲ Tael capabilities listening on port ${info.port}`);
+});

--- a/apps/capabilities/src/publish.ts
+++ b/apps/capabilities/src/publish.ts
@@ -20,7 +20,7 @@ if (!apiKey || !payTo) {
 /** The first-party capabilities, as SDK publish manifests. Stellar-native, free. */
 const CAPABILITIES: PublishCapabilityInput[] = [
   {
-    name: "Stellar Tools",
+    name: "Stellar",
     kind: "api",
     description:
       "Read-only Stellar lookups for AI agents: account balances, account details, and settled transactions. Free.",

--- a/apps/capabilities/src/publish.ts
+++ b/apps/capabilities/src/publish.ts
@@ -1,0 +1,80 @@
+// Publish (or update) Tael's first-party capabilities to the marketplace using
+// the SDK. Run after deploying this service:
+//
+//   TAEL_KEY=tael_live_… PAY_TO=G… CAPABILITIES_URL=https://… \
+//     pnpm --filter capabilities publish:capabilities
+//
+// It publishes each capability defined below, then prints its slug. Re-running
+// re-publishes; use the dashboard (or tael.updateCapability) to change a live one.
+import { Tael, TaelError, type PublishCapabilityInput } from "@tael/sdk";
+
+const apiKey = process.env.TAEL_KEY;
+const payTo = process.env.PAY_TO;
+const endpoint = process.env.CAPABILITIES_URL ?? "http://localhost:3004";
+
+if (!apiKey || !payTo) {
+  console.error("Set TAEL_KEY and PAY_TO (and CAPABILITIES_URL to the deployed service).");
+  process.exit(1);
+}
+
+/** The first-party capabilities, as SDK publish manifests. Stellar-native, free. */
+const CAPABILITIES: PublishCapabilityInput[] = [
+  {
+    name: "Stellar Tools",
+    kind: "api",
+    description:
+      "Read-only Stellar lookups for AI agents: account balances, account details, and settled transactions. Free.",
+    endpoint,
+    payTo,
+    operations: [
+      {
+        name: "Balance",
+        path: "/stellar/balance",
+        method: "GET",
+        price: "0",
+        sampleRequest: "GET /stellar/balance?address=G...",
+        sampleResponse: `{ "address": "G...", "balances": [{ "asset": "XLM", "issuer": null, "balance": "100.5" }] }`,
+      },
+      {
+        name: "Account",
+        path: "/stellar/account",
+        method: "GET",
+        price: "0",
+        sampleRequest: "GET /stellar/account?address=G...",
+        sampleResponse: `{ "id": "G...", "sequence": "123", "homeDomain": null, "numTrustlines": 2 }`,
+      },
+      {
+        name: "Transaction",
+        path: "/stellar/tx",
+        method: "GET",
+        price: "0",
+        sampleRequest: "GET /stellar/tx?hash=<64-hex>",
+        sampleResponse: `{ "hash": "...", "successful": true, "ledger": 1, "operationCount": 1 }`,
+      },
+    ],
+    faqs: [
+      {
+        question: "Which network does this read from?",
+        answer: "The Stellar network Tael is running on (testnet today).",
+      },
+      { question: "Is it free?", answer: "Yes, every operation is priced at 0." },
+    ],
+  },
+];
+
+const tael = new Tael({ apiKey });
+
+for (const manifest of CAPABILITIES) {
+  try {
+    const result = await tael.publish(manifest);
+    console.log(`Published "${manifest.name}" → ${result.slug} (${result.status})`);
+    console.log(`  https://app.taelprotocol.xyz/marketplace/${result.slug}`);
+  } catch (err) {
+    if (err instanceof TaelError) {
+      console.error(`Failed to publish "${manifest.name}": ${err.status} ${err.message}`);
+    } else {
+      console.error(`Failed to publish "${manifest.name}":`, err);
+    }
+    process.exitCode = 1;
+  }
+}

--- a/apps/capabilities/src/server.ts
+++ b/apps/capabilities/src/server.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+import { getAccount, getBalances, getTransaction, isStellarAddress } from "./stellar";
+
+/**
+ * The first-party capabilities service. Each route here is published to the Tael
+ * marketplace as an operation of the `stellar` capability. Everything is a
+ * read-only, public Stellar lookup, so there are no secrets and no auth: the
+ * payment at Tael's gateway is the only gate.
+ */
+export function createServer() {
+  const app = new Hono();
+
+  app.get("/health", (c) => c.json({ status: "ok", service: "tael-capabilities" }));
+
+  // GET /stellar/balance?address=G... — balances for an account.
+  app.get("/stellar/balance", async (c) => {
+    const address = c.req.query("address") ?? "";
+    if (!isStellarAddress(address))
+      return c.json({ error: "Provide a valid Stellar address" }, 400);
+    try {
+      return c.json({ address, balances: await getBalances(address) });
+    } catch {
+      return c.json({ error: "Account not found or not funded" }, 404);
+    }
+  });
+
+  // GET /stellar/account?address=G... — account details.
+  app.get("/stellar/account", async (c) => {
+    const address = c.req.query("address") ?? "";
+    if (!isStellarAddress(address))
+      return c.json({ error: "Provide a valid Stellar address" }, 400);
+    try {
+      return c.json(await getAccount(address));
+    } catch {
+      return c.json({ error: "Account not found" }, 404);
+    }
+  });
+
+  // GET /stellar/tx?hash=... — look up a settled transaction.
+  app.get("/stellar/tx", async (c) => {
+    const hash = c.req.query("hash") ?? "";
+    if (!/^[a-f0-9]{64}$/i.test(hash)) return c.json({ error: "Provide a 64-char tx hash" }, 400);
+    try {
+      return c.json(await getTransaction(hash));
+    } catch {
+      return c.json({ error: "Transaction not found" }, 404);
+    }
+  });
+
+  return app;
+}

--- a/apps/capabilities/src/stellar.ts
+++ b/apps/capabilities/src/stellar.ts
@@ -1,0 +1,97 @@
+// Thin, dependency-free reads against Stellar Horizon. Every capability here is
+// read-only and public, so a plain fetch is all we need. The network's Horizon
+// URL comes from the environment, defaulting to testnet.
+
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+
+/** A Stellar public key: `G` followed by 55 base32 characters. */
+export function isStellarAddress(value: string): boolean {
+  return /^G[A-Z2-7]{55}$/.test(value);
+}
+
+async function horizon(path: string): Promise<{ ok: boolean; status: number; data: unknown }> {
+  const res = await fetch(`${HORIZON_URL}${path}`, {
+    headers: { accept: "application/json" },
+  });
+  const data = await res.json().catch(() => null);
+  return { ok: res.ok, status: res.status, data };
+}
+
+export interface Balance {
+  asset: string;
+  issuer: string | null;
+  balance: string;
+}
+
+/** Balances (XLM + every trusted asset) for an account. */
+export async function getBalances(address: string): Promise<Balance[]> {
+  const { ok, data } = await horizon(`/accounts/${address}`);
+  if (!ok) throw new Error("account not found");
+  const balances = (data as { balances?: HorizonBalance[] }).balances ?? [];
+  return balances.map((b) => ({
+    asset: b.asset_type === "native" ? "XLM" : (b.asset_code ?? "?"),
+    issuer: b.asset_issuer ?? null,
+    balance: b.balance,
+  }));
+}
+
+/** Core account details: sequence, thresholds, signers, home domain, flags. */
+export async function getAccount(address: string): Promise<unknown> {
+  const { ok, data } = await horizon(`/accounts/${address}`);
+  if (!ok) throw new Error("account not found");
+  const a = data as HorizonAccount;
+  return {
+    id: a.id,
+    sequence: a.sequence,
+    subentryCount: a.subentry_count,
+    homeDomain: a.home_domain ?? null,
+    thresholds: a.thresholds,
+    flags: a.flags,
+    signers: a.signers,
+    numTrustlines: (a.balances ?? []).filter((b) => b.asset_type !== "native").length,
+  };
+}
+
+/** A settled transaction by its hash. */
+export async function getTransaction(hash: string): Promise<unknown> {
+  const { ok, data } = await horizon(`/transactions/${hash}`);
+  if (!ok) throw new Error("transaction not found");
+  const t = data as HorizonTx;
+  return {
+    hash: t.hash,
+    ledger: t.ledger,
+    successful: t.successful,
+    createdAt: t.created_at,
+    sourceAccount: t.source_account,
+    feeCharged: t.fee_charged,
+    operationCount: t.operation_count,
+    memo: t.memo ?? null,
+  };
+}
+
+interface HorizonBalance {
+  balance: string;
+  asset_type: string;
+  asset_code?: string;
+  asset_issuer?: string;
+}
+interface HorizonAccount {
+  id: string;
+  sequence: string;
+  subentry_count: number;
+  home_domain?: string;
+  thresholds: unknown;
+  flags: unknown;
+  signers: unknown;
+  balances?: HorizonBalance[];
+}
+interface HorizonTx {
+  hash: string;
+  ledger: number;
+  successful: boolean;
+  created_at: string;
+  source_account: string;
+  fee_charged: string;
+  operation_count: number;
+  memo?: string;
+}

--- a/apps/capabilities/tsconfig.json
+++ b/apps/capabilities/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@tael/config/tsconfig/library.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/capabilities/tsup.config.ts
+++ b/apps/capabilities/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  platform: "node",
+  target: "node22",
+  clean: true,
+  sourcemap: true,
+  dts: false,
+  noExternal: [/^@tael\//],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,34 @@ importers:
         specifier: 'catalog:'
         version: 3.2.6(@types/node@22.20.0)(jiti@1.21.7)(tsx@4.23.0)
 
+  apps/capabilities:
+    dependencies:
+      '@hono/node-server':
+        specifier: 'catalog:'
+        version: 1.19.14(hono@4.12.27)
+      '@tael/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      hono:
+        specifier: 'catalog:'
+        version: 4.12.27
+    devDependencies:
+      '@tael/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.0
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   apps/chat:
     dependencies:
       '@creit.tech/stellar-wallets-kit':


### PR DESCRIPTION
A new **`apps/capabilities`** service that hosts Tael's own useful, **Stellar-native** endpoints and publishes them to the marketplace via the SDK. This solves the marketplace cold-start problem (real, verified tools agents can use on day one) and dogfoods the publish flow.

## What's in it
- **Stellar Tools** capability with three read-only operations:
  - `GET /stellar/balance?address=G…` — account balances (XLM + assets)
  - `GET /stellar/account?address=G…` — account details (sequence, signers, home domain, trustlines)
  - `GET /stellar/tx?hash=…` — a settled transaction by hash
- Public Horizon reads, **no secrets, free**. Verified live against testnet Horizon (real data returned; bad input → 400).
- **`src/publish.ts`** publishes the manifests with the SDK (`tael.publish`).
- **README with the rules** for what qualifies as a first-party capability (Stellar-native, read-only/safe, no secrets, clean JSON, free unless a real per-call cost) and how to add one.

## Verified
typecheck (whole monorepo) + eslint + format clean; endpoints return real testnet data.

## To go live (after merge)
1. Deploy `apps/capabilities` (Render/Fly), it binds `$PORT`.
2. `TAEL_KEY=… PAY_TO=… CAPABILITIES_URL=https://… pnpm --filter capabilities publish:capabilities`

Then Verify them from the dashboard. This is also the home for the OSS **good-first-capability** requests.