### PR TITLE
fix(gateway): forward the caller's query string to the upstream

### DIFF
--- a/apps/api/src/modules/gateway/gateway.test.ts
+++ b/apps/api/src/modules/gateway/gateway.test.ts
@@ -219,6 +219,21 @@ describe("capability gateway", () => {
     expect(upstream.mock.calls[0]?.[0]).toBe("https://api.example.com/age/premium");
   });
 
+  it("forwards the caller's query string to the upstream", async () => {
+    const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", upstream);
+
+    const { container } = buildContainer(CAPABILITY);
+    const app = createServer(container);
+    // A free op with a query param (e.g. stellar/balance?address=G…).
+    await app.request("/c/predict-age/ping?address=GABC&limit=5");
+
+    const calledUrl = String(upstream.mock.calls[0]?.[0]);
+    expect(calledUrl).toContain("address=GABC");
+    expect(calledUrl).toContain("limit=5");
+    expect(calledUrl).toContain("/age/ping");
+  });
+
   it("substitutes the {payer} token in the upstream URL with the caller's address", async () => {
     const upstream = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
     vi.stubGlobal("fetch", upstream);

--- a/apps/api/src/modules/gateway/upstream.ts
+++ b/apps/api/src/modules/gateway/upstream.ts
@@ -112,10 +112,21 @@ export async function proxyToUpstream(
   const method = request.method.toUpperCase();
   const hasBody = method !== "GET" && method !== "HEAD";
 
+  // Forward the caller's query string to the upstream (e.g. ?address=G…) so a
+  // capability can read GET params. Only rewrite the URL when the caller sent a
+  // query, so URLs without one are passed through byte-for-byte as before.
+  let finalUrl = targetUrl;
+  const callerQuery = new URL(request.url).searchParams;
+  if ([...callerQuery.keys()].length > 0) {
+    const merged = new URL(targetUrl);
+    callerQuery.forEach((value, key) => merged.searchParams.set(key, value));
+    finalUrl = merged.toString();
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
   try {
-    const upstream = await fetch(targetUrl, {
+    const upstream = await fetch(finalUrl, {
       method,
       headers,
       body: hasBody ? await request.arrayBuffer() : undefined,


### PR DESCRIPTION
**Bug caught while testing the new `stellar/balance` capability.** The gateway proxied to endpoint + operation path but **dropped the query string**, so `stellar/balance?address=G…` reached the upstream with no `address` and returned `Provide a valid Stellar address`.

Fix: merge the caller's query params onto the upstream URL. URLs without a query are unchanged (byte-for-byte), so nothing else is affected.

Verified: api tests **54/54** (new: query is forwarded), lint + format clean.