### PR TITLE
content(blog): add the buy-side integration line

### DIFF
--- a/apps/web/app/blog/_posts/payments-infrastructure-for-agents.tsx
+++ b/apps/web/app/blog/_posts/payments-infrastructure-for-agents.tsx
@@ -35,6 +35,11 @@ export function PaymentsInfrastructureForAgents() {
           customer at a time.
         </li>
         <li>
+          <Strong>Integration, on their side.</Strong> You publish once. After that, anyone can wire
+          your product into theirs in a few lines: they point the Tael SDK at your capability, and
+          their agent pays for it and calls it. Every integration is theirs to write, not yours.
+        </li>
+        <li>
           <Strong>Migration.</Strong> None. Your endpoint stays exactly where it is. Tael sits in
           front of it as a metered gateway. There is nothing to rebuild.
         </li>


### PR DESCRIPTION
Adds one bullet to **What Tael runs for you** in the "Payments infrastructure for AI agents" post:

> **Integration, on their side.** You publish once. After that, anyone can wire your product into theirs in a few lines: they point the Tael SDK at your capability, and their agent pays for it and calls it. Every integration is theirs to write, not yours.

Rounds out the section: publishing is one line, and so is consuming.