### PR TITLE
feat(capabilities): Stellar network status (GET /stellar/status)

### DIFF
--- a/apps/capabilities/src/capabilities/status/horizon.ts
+++ b/apps/capabilities/src/capabilities/status/horizon.ts
@@ -1,0 +1,47 @@
+// The Stellar network's current state, read from Horizon's latest ledger.
+// Read-only and public, so a plain fetch is all we need.
+
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+
+export interface NetworkStatus {
+  /** Sequence number of the most recently closed ledger. */
+  latestLedger: number;
+  /** Protocol version the network is running. */
+  protocolVersion: number;
+  /** Base fee per operation, in stroops. */
+  baseFee: string;
+  /** Base reserve per entry, in stroops. */
+  baseReserve: string;
+  /** When the latest ledger closed (ISO 8601). */
+  closedAt: string;
+  /** Hash of the latest ledger. */
+  hash: string;
+}
+
+interface HorizonLedger {
+  sequence: number;
+  hash: string;
+  closed_at: string;
+  protocol_version: number;
+  base_fee_in_stroops: number;
+  base_reserve_in_stroops: number;
+}
+
+/** Latest ledger + the network parameters an agent needs before it transacts. */
+export async function getStatus(): Promise<NetworkStatus> {
+  const res = await fetch(`${HORIZON_URL}/ledgers?order=desc&limit=1`, {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) throw new Error("horizon unavailable");
+  const data = (await res.json()) as { _embedded?: { records?: HorizonLedger[] } };
+  const ledger = data._embedded?.records?.[0];
+  if (!ledger) throw new Error("no ledger");
+  return {
+    latestLedger: ledger.sequence,
+    protocolVersion: ledger.protocol_version,
+    baseFee: String(ledger.base_fee_in_stroops),
+    baseReserve: String(ledger.base_reserve_in_stroops),
+    closedAt: ledger.closed_at,
+    hash: ledger.hash,
+  };
+}

--- a/apps/capabilities/src/capabilities/status/index.ts
+++ b/apps/capabilities/src/capabilities/status/index.ts
@@ -1,0 +1,6 @@
+import type { CapabilityModule } from "../../types";
+import { routes } from "./routes";
+import { manifest } from "./manifest";
+
+/** Stellar network status: latest ledger + network parameters, published to Tael. */
+export const capability: CapabilityModule = { routes, manifest };

--- a/apps/capabilities/src/capabilities/status/manifest.ts
+++ b/apps/capabilities/src/capabilities/status/manifest.ts
@@ -1,0 +1,26 @@
+import type { CapabilityModule } from "../../types";
+
+/** Marketplace manifest for the Stellar network status capability. */
+export const manifest: CapabilityModule["manifest"] = {
+  name: "Stellar Status",
+  kind: "api",
+  description:
+    "The Stellar network's current state: latest ledger, protocol version, base fee and base reserve. Free.",
+  operations: [
+    {
+      name: "Status",
+      path: "/stellar/status",
+      method: "GET",
+      price: "0",
+      sampleRequest: "",
+      sampleResponse: `{ "latestLedger": 123456, "protocolVersion": 21, "baseFee": "100", "baseReserve": "5000000", "closedAt": "2026-…", "hash": "…" }`,
+    },
+  ],
+  faqs: [
+    {
+      question: "Which network does this read from?",
+      answer: "The Stellar network Tael is running on (testnet today).",
+    },
+    { question: "Is it free?", answer: "Yes, priced at 0." },
+  ],
+};

--- a/apps/capabilities/src/capabilities/status/routes.ts
+++ b/apps/capabilities/src/capabilities/status/routes.ts
@@ -1,0 +1,14 @@
+import { Hono } from "hono";
+import { getStatus } from "./horizon";
+
+/** Read-only Stellar network status. No params, no secrets. */
+export const routes = new Hono();
+
+// GET /stellar/status — latest ledger + network parameters.
+routes.get("/stellar/status", async (c) => {
+  try {
+    return c.json(await getStatus());
+  } catch {
+    return c.json({ error: "Stellar network status unavailable" }, 502);
+  }
+});


### PR DESCRIPTION
Reference capability #1 of 3 (a working example for the [good-first-capability](https://github.com/rahulsainlll/tael-protocol/labels/good-first-capability) issues).

Adds `src/capabilities/status/` — latest ledger, protocol version, base fee, base reserve from Horizon. One folder, no shared file touched; the registry picks it up.

Verified: typecheck ✓, build ✓, live route returns real data:
```json
{ "latestLedger": 3706216, "protocolVersion": 27, "baseFee": "100", "baseReserve": "5000000", "closedAt": "2026-…", "hash": "…" }
```

Closes #102.