### PR TITLE
feat(capabilities): Stellar DEX orderbook (GET /stellar/orderbook)

### DIFF
--- a/apps/capabilities/src/capabilities/orderbook/horizon.ts
+++ b/apps/capabilities/src/capabilities/orderbook/horizon.ts
@@ -1,0 +1,53 @@
+// A Stellar DEX orderbook snapshot from Horizon. Read-only and public.
+// Assets are given as `native` (XLM) or `CODE:ISSUER`.
+
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+
+export interface Order {
+  price: string;
+  amount: string;
+}
+export interface Orderbook {
+  selling: string;
+  buying: string;
+  bids: Order[];
+  asks: Order[];
+}
+
+/** Turn `native` or `CODE:ISSUER` into Horizon's asset query params for a side. */
+function assetParams(prefix: "selling" | "buying", spec: string): Record<string, string> {
+  if (spec === "native" || spec === "XLM") return { [`${prefix}_asset_type`]: "native" };
+  const [code, issuer] = spec.split(":");
+  if (!code || !issuer) throw new Error("bad asset");
+  const type = code.length <= 4 ? "credit_alphanum4" : "credit_alphanum12";
+  return {
+    [`${prefix}_asset_type`]: type,
+    [`${prefix}_asset_code`]: code,
+    [`${prefix}_asset_issuer`]: issuer,
+  };
+}
+
+/** Top `limit` bids and asks for a pair. Throws on a malformed asset spec. */
+export async function getOrderbook(
+  selling: string,
+  buying: string,
+  limit: number,
+): Promise<Orderbook> {
+  const params = new URLSearchParams({
+    ...assetParams("selling", selling),
+    ...assetParams("buying", buying),
+    limit: String(limit),
+  });
+  const res = await fetch(`${HORIZON_URL}/order_book?${params}`, {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) throw new Error("horizon unavailable");
+  const data = (await res.json()) as { bids?: Order[]; asks?: Order[] };
+  const trim = (o: Order): Order => ({ price: o.price, amount: o.amount });
+  return {
+    selling,
+    buying,
+    bids: (data.bids ?? []).map(trim),
+    asks: (data.asks ?? []).map(trim),
+  };
+}

--- a/apps/capabilities/src/capabilities/orderbook/index.ts
+++ b/apps/capabilities/src/capabilities/orderbook/index.ts
@@ -1,0 +1,6 @@
+import type { CapabilityModule } from "../../types";
+import { routes } from "./routes";
+import { manifest } from "./manifest";
+
+/** Stellar DEX orderbook: top bids/asks for a pair, published to Tael. */
+export const capability: CapabilityModule = { routes, manifest };

--- a/apps/capabilities/src/capabilities/orderbook/manifest.ts
+++ b/apps/capabilities/src/capabilities/orderbook/manifest.ts
@@ -1,0 +1,26 @@
+import type { CapabilityModule } from "../../types";
+
+/** Marketplace manifest for the Stellar DEX orderbook capability. */
+export const manifest: CapabilityModule["manifest"] = {
+  name: "Stellar Orderbook",
+  kind: "api",
+  description:
+    "A Stellar DEX orderbook snapshot: top bids and asks for a trading pair. Assets as `native` or `CODE:ISSUER`. Free.",
+  operations: [
+    {
+      name: "Orderbook",
+      path: "/stellar/orderbook",
+      method: "GET",
+      price: "0",
+      sampleRequest: "selling=native&buying=USDC:<issuer-address>&limit=10",
+      sampleResponse: `{ "selling": "native", "buying": "USDC:G…", "bids": [{ "price": "0.1", "amount": "100" }], "asks": [{ "price": "0.11", "amount": "50" }] }`,
+    },
+  ],
+  faqs: [
+    {
+      question: "How do I specify an asset?",
+      answer: "Use `native` for XLM, or `CODE:ISSUER` (e.g. `USDC:G…`) for an issued asset.",
+    },
+    { question: "Is it free?", answer: "Yes, priced at 0." },
+  ],
+};

--- a/apps/capabilities/src/capabilities/orderbook/routes.ts
+++ b/apps/capabilities/src/capabilities/orderbook/routes.ts
@@ -1,0 +1,23 @@
+import { Hono } from "hono";
+import { getOrderbook } from "./horizon";
+
+/** Read-only Stellar DEX orderbook. No secrets. */
+export const routes = new Hono();
+
+// GET /stellar/orderbook?selling=native&buying=USDC:G...&limit=10
+routes.get("/stellar/orderbook", async (c) => {
+  const selling = c.req.query("selling") ?? "";
+  const buying = c.req.query("buying") ?? "";
+  if (!selling || !buying) {
+    return c.json({ error: "Provide selling and buying (native or CODE:ISSUER)" }, 400);
+  }
+  const limit = Math.min(Math.max(Number(c.req.query("limit")) || 10, 1), 50);
+  try {
+    return c.json(await getOrderbook(selling, buying, limit));
+  } catch (err) {
+    if (err instanceof Error && err.message === "bad asset") {
+      return c.json({ error: "Assets must be `native` or `CODE:ISSUER`" }, 400);
+    }
+    return c.json({ error: "Orderbook unavailable" }, 502);
+  }
+});


### PR DESCRIPTION
Reference capability #2 of 3.

Adds `src/capabilities/orderbook/` — top bids/asks for a pair (`selling`/`buying` as `native` or `CODE:ISSUER`, `limit` capped at 50). One folder, registry auto-picks it up.

Verified: typecheck ✓, build ✓, live:
- valid pair → `200` `{ "selling": "native", "buying": "USDC:G…", "bids": [...], "asks": [...] }`
- missing params → `400`
- bad asset spec → `400`

Closes #104.