### PR TITLE
feat(capabilities): FX rates (GET /fx/rates)

### DIFF
--- a/apps/capabilities/src/capabilities/fx/index.ts
+++ b/apps/capabilities/src/capabilities/fx/index.ts
@@ -1,0 +1,6 @@
+import type { CapabilityModule } from "../../types";
+import { routes } from "./routes";
+import { manifest } from "./manifest";
+
+/** FX rates: reference fiat exchange rates, a non-Stellar utility published to Tael. */
+export const capability: CapabilityModule = { routes, manifest };

--- a/apps/capabilities/src/capabilities/fx/manifest.ts
+++ b/apps/capabilities/src/capabilities/fx/manifest.ts
@@ -1,0 +1,27 @@
+import type { CapabilityModule } from "../../types";
+
+/** Marketplace manifest for the FX rates capability. */
+export const manifest: CapabilityModule["manifest"] = {
+  name: "FX Rates",
+  kind: "api",
+  description:
+    "Reference fiat exchange rates for a base currency (USD, EUR, NGN, …). A self-contained, non-Stellar utility. Free.",
+  operations: [
+    {
+      name: "Rates",
+      path: "/fx/rates",
+      method: "GET",
+      price: "0",
+      sampleRequest: "base=USD",
+      sampleResponse: `{ "base": "USD", "rates": { "EUR": 0.92, "NGN": 1600 }, "asOf": "Mon, 20 Jul 2026 00:00:00 +0000" }`,
+    },
+  ],
+  faqs: [
+    {
+      question: "Which currencies are supported?",
+      answer:
+        "Any 3-letter currency code as the base; the response lists rates to every other currency.",
+    },
+    { question: "Is it free?", answer: "Yes, priced at 0." },
+  ],
+};

--- a/apps/capabilities/src/capabilities/fx/rates.ts
+++ b/apps/capabilities/src/capabilities/fx/rates.ts
@@ -1,0 +1,28 @@
+// Reference fiat FX rates from a free, no-key public source. Non-Stellar on
+// purpose: it shows Tael hosts any self-contained capability, not just chain
+// reads. If the source ever needs a key, this becomes a third-party capability.
+
+const FX_SOURCE = process.env.FX_SOURCE_URL ?? "https://open.er-api.com/v6/latest";
+
+export interface Rates {
+  base: string;
+  rates: Record<string, number>;
+  /** When the source last updated the rates (as reported upstream). */
+  asOf: string;
+}
+
+interface FxResponse {
+  result: string;
+  base_code: string;
+  rates: Record<string, number>;
+  time_last_update_utc: string;
+}
+
+/** Latest rates for `base` (a 3-letter currency). Throws if the lookup fails. */
+export async function getRates(base: string): Promise<Rates> {
+  const res = await fetch(`${FX_SOURCE}/${base}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error("fx source unavailable");
+  const data = (await res.json()) as FxResponse;
+  if (data.result !== "success") throw new Error("fx lookup failed");
+  return { base: data.base_code, rates: data.rates, asOf: data.time_last_update_utc };
+}

--- a/apps/capabilities/src/capabilities/fx/routes.ts
+++ b/apps/capabilities/src/capabilities/fx/routes.ts
@@ -1,0 +1,18 @@
+import { Hono } from "hono";
+import { getRates } from "./rates";
+
+/** Read-only fiat FX rates. No secrets. */
+export const routes = new Hono();
+
+// GET /fx/rates?base=USD — reference rates for a base currency (defaults to USD).
+routes.get("/fx/rates", async (c) => {
+  const base = (c.req.query("base") ?? "USD").toUpperCase();
+  if (!/^[A-Z]{3}$/.test(base)) {
+    return c.json({ error: "Provide a 3-letter currency code (e.g. USD)" }, 400);
+  }
+  try {
+    return c.json(await getRates(base));
+  } catch {
+    return c.json({ error: "FX rates unavailable" }, 502);
+  }
+});


### PR DESCRIPTION
Reference capability #3 of 3, and the first **non-Stellar** one, proving the pattern works for any self-contained capability.

Adds `src/capabilities/fx/` — reference fiat FX rates for a base currency, from a free no-key source (`open.er-api.com`, overridable via `FX_SOURCE_URL`). One folder, registry auto-picks it up.

Verified: typecheck ✓, build ✓, live:
- `?base=USD` (default) → `{ "base": "USD", "rates": { "EUR": 0.875, "INR": 96.48, … }, "asOf": "…" }`
- `?base=EUR` → `200`
- bad base → `400`

Closes #110.