### PR TITLE
fix(capabilities): make the Stellar asset op discoverable + consistent

### DIFF
--- a/apps/capabilities/README.md
+++ b/apps/capabilities/README.md
@@ -86,14 +86,18 @@ Adding an operation to an existing capability, e.g. `/stellar/asset` under
 Stellar. Copy an operation file as your template:
 
 1. `cp src/capabilities/stellar/operations/status.ts src/capabilities/stellar/operations/asset.ts`
-2. Edit `asset.ts` — set `name`, `path`, `price: "0"`, `sampleRequest`,
+2. Edit `asset.ts` — set a **single-word `name`** (it becomes the op slug, e.g.
+   `Asset` → `/c/stellar/asset`), `path`, `price: "0"`, `sampleRequest`,
    `sampleResponse`, and the `handler`. Put any fetch logic in the capability's
    helper (`stellar/horizon.ts`).
-3. That's it. The registry picks the file up automatically, nothing else to edit.
-   Run `pnpm --filter capabilities typecheck` and `pnpm --filter capabilities dev`,
+3. **Add a word to the capability's `description`** in `capability.ts` so the new
+   operation is discoverable — search matches on name + description, so an op the
+   description never mentions is callable but not findable.
+4. The registry picks the file up automatically, nothing else to edit. Run
+   `pnpm --filter capabilities typecheck` and `pnpm --filter capabilities dev`,
    then `curl "localhost:3004/stellar/asset?code=USDC&issuer=G…"`.
-4. Open a PR (`Closes #<issue>`). Because it's a new file, it can't conflict with
-   anyone else's operation.
+5. Open a PR (`Closes #<issue>`). Because it's a new file (plus one line in
+   `capability.ts`), it can't conflict with anyone else's operation.
 
 ## How to add a new capability
 

--- a/apps/capabilities/src/capabilities/stellar/capability.ts
+++ b/apps/capabilities/src/capabilities/stellar/capability.ts
@@ -9,7 +9,7 @@ export const meta: CapabilityMeta = {
   name: "Stellar",
   kind: "api",
   description:
-    "Read-only Stellar lookups for AI agents: account balances, account details, settled transactions, network status, and DEX orderbook. Free.",
+    "Read-only Stellar lookups for AI agents: account balances, account details, settled transactions, asset info, network status, and DEX orderbook. Free.",
   faqs: [
     {
       question: "Which network does this read from?",

--- a/apps/capabilities/src/capabilities/stellar/horizon.ts
+++ b/apps/capabilities/src/capabilities/stellar/horizon.ts
@@ -11,8 +11,7 @@ export function isStellarAddress(value: string): boolean {
 }
 
 async function horizon(path: string): Promise<{ ok: boolean; status: number; data: unknown }> {
-  const baseUrl = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
-  const res = await fetch(`${baseUrl}${path}`, {
+  const res = await fetch(`${HORIZON_URL}${path}`, {
     headers: { accept: "application/json" },
   });
   const data = await res.json().catch(() => null);

--- a/apps/capabilities/src/capabilities/stellar/operations/asset.ts
+++ b/apps/capabilities/src/capabilities/stellar/operations/asset.ts
@@ -3,7 +3,7 @@ import { getAssetInfo, isStellarAddress } from "../horizon";
 
 /** GET /stellar/asset?code=USDC&issuer=G... — supply, holders count, and flags for an issued asset. */
 export const operation: Operation = {
-  name: "Asset Info",
+  name: "Asset",
   path: "/stellar/asset",
   method: "GET",
   price: "0",


### PR DESCRIPTION
Small follow-ups after the asset operation merged (#115), the discoverability one is the real fix.

- **Search fix:** add "asset info" to the Stellar description. Search matches name + description, so `search("asset")` returned nothing even though `/stellar/asset` worked. Now an agent can find it.
- **Slug consistency:** op "Asset Info" → **"Asset"**, so it is `/c/stellar/asset` (matching its path and the other single-word Stellar ops), not `/c/stellar/asset-info`.
- **Cleanup:** revert the stray `horizon()` change that duplicated the env read and left `HORIZON_URL` unused.
- **Docs:** README now tells contributors to use a single-word op name and to add a word to the capability description, so future ops stay discoverable.

Verified: typecheck ✓, build ✓, `/stellar/asset` returns real data locally. After merge, one republish makes `/c/stellar/asset` live and `search("asset")` resolve to Stellar.