### PR TITLE
fix(capabilities): make the trades op discoverable

### DIFF
--- a/apps/capabilities/src/capabilities/stellar/capability.ts
+++ b/apps/capabilities/src/capabilities/stellar/capability.ts
@@ -9,7 +9,7 @@ export const meta: CapabilityMeta = {
   name: "Stellar",
   kind: "api",
   description:
-    "Read-only Stellar lookups for AI agents: account balances, account details, settled transactions, asset info, network status, and DEX orderbook. Free.",
+    "Read-only Stellar lookups for AI agents: account balances, account details, settled transactions, asset info, network status, DEX orderbook, and recent trades. Free.",
   faqs: [
     {
       question: "Which network does this read from?",


### PR DESCRIPTION
One line: adds "recent trades" to the Stellar description so `search("trades")` resolves to Stellar. The trades op (#117) works, it just was not mentioned in the description, which is what search matches on (same rule as #118).