### PR TITLE
fix(capabilities): trades returns empty list for a pair with no market

### DIFF
--- a/apps/capabilities/src/capabilities/stellar/horizon.ts
+++ b/apps/capabilities/src/capabilities/stellar/horizon.ts
@@ -184,8 +184,11 @@ export async function getTrades(
     order: "desc",
     limit: String(limit),
   });
-  const { ok, data } = await horizon(`/trades?${params}`);
-  if (!ok) throw new Error("horizon unavailable");
+  const { ok, status, data } = await horizon(`/trades?${params}`);
+  // Horizon returns 404 for a pair that simply has no trades (unlike the
+  // orderbook, which returns 200 with empty arrays). Treat that as an empty
+  // result, not an error — a valid pair with no market is a normal answer.
+  if (!ok && status !== 404) throw new Error("horizon unavailable");
 
   const records =
     (data as { _embedded?: { records?: HorizonTradeRecord[] } })?._embedded?.records ?? [];


### PR DESCRIPTION
Found while verifying the republish: `/c/stellar/trades` returned **502 "Trades unavailable" for a valid pair that just has no trades**.

**Cause:** Horizon returns `404` for a `/trades` query on a pair with no market (unlike `/order_book`, which returns `200` + empty arrays). `getTrades` treated that 404 as `!ok` → threw → 502.

**Fix:** treat a 404 as an empty result; only a non-404 failure is a real error.

Verified locally:
- no-trade pair (native/USDC) → `200` `{ "trades": [] }`
- real traded pair → `200` with trades
- bad asset spec → `400`

Small follow-up to the trades op (#117); no republish needed (runtime-only, the manifest is unchanged).