### PR TITLE
feat(capabilities): first paid Stellar ops — quote, explain, portfolio

### DIFF
--- a/apps/capabilities/src/capabilities/stellar/capability.ts
+++ b/apps/capabilities/src/capabilities/stellar/capability.ts
@@ -9,12 +9,16 @@ export const meta: CapabilityMeta = {
   name: "Stellar",
   kind: "api",
   description:
-    "Read-only Stellar lookups for AI agents: account balances, account details, settled transactions, asset info, network status, DEX orderbook, recent trades, and account payments. Free.",
+    "Stellar lookups for AI agents: account balances, account details, settled transactions, asset info, network status, DEX orderbook, recent trades, and account payments (all free), plus best-price swap quotes, plain-English transaction explanations, and USDC portfolio valuation (priced per call).",
   faqs: [
     {
       question: "Which network does this read from?",
       answer: "The Stellar network Tael is running on (testnet today).",
     },
-    { question: "Is it free?", answer: "Yes, every operation is priced at 0." },
+    {
+      question: "Which operations cost money?",
+      answer:
+        "The chain reads (balance, account, transaction, asset, status, orderbook, trades, payments) are free. Quote, explain, and portfolio are priced per call because they aggregate or interpret data.",
+    },
   ],
 };

--- a/apps/capabilities/src/capabilities/stellar/horizon.ts
+++ b/apps/capabilities/src/capabilities/stellar/horizon.ts
@@ -263,6 +263,217 @@ export async function getAssetInfo(code: string, issuer: string): Promise<AssetI
   };
 }
 
+// --- Paid reads: quote, explain, portfolio ---------------------------------
+
+/** Canonical asset spec for path queries: "native" or "CODE:ISSUER". */
+function canonicalAsset(spec: string): string {
+  if (spec === "native" || spec === "XLM") return "native";
+  const [code, issuer] = spec.split(":");
+  if (!code || !issuer) throw new Error("bad asset");
+  return `${code}:${issuer}`;
+}
+
+/** Add a `<prefix>_asset_type/code/issuer` triple for a source-side asset. */
+function sourceAssetParams(spec: string): Record<string, string> {
+  if (spec === "native" || spec === "XLM") return { source_asset_type: "native" };
+  const [code, issuer] = spec.split(":");
+  if (!code || !issuer) throw new Error("bad asset");
+  return {
+    source_asset_type: code.length <= 4 ? "credit_alphanum4" : "credit_alphanum12",
+    source_asset_code: code,
+    source_asset_issuer: issuer,
+  };
+}
+
+export interface Quote {
+  source: string;
+  sourceAmount: string;
+  dest: string;
+  destAmount: string;
+  /** The intermediate hops (asset codes) the best route passes through. */
+  path: string[];
+}
+
+/**
+ * Best strict-send quote: send exactly `amount` of `source`, receive `dest`.
+ * Picks the route with the highest destination amount. Throws "no path" when no
+ * route exists (thin liquidity), "bad asset" on a malformed spec.
+ */
+export async function getQuote(source: string, dest: string, amount: string): Promise<Quote> {
+  const params = new URLSearchParams({
+    ...sourceAssetParams(source),
+    source_amount: amount,
+    destination_assets: canonicalAsset(dest),
+  });
+  const { ok, data } = await horizon(`/paths/strict-send?${params}`);
+  if (!ok) throw new Error("horizon unavailable");
+  const records = (data as { _embedded?: { records?: HorizonPath[] } })._embedded?.records ?? [];
+  const best = records.reduce<HorizonPath | null>(
+    (b, r) => (!b || Number(r.destination_amount) > Number(b.destination_amount) ? r : b),
+    null,
+  );
+  if (!best) throw new Error("no path");
+  return {
+    source,
+    sourceAmount: best.source_amount,
+    dest,
+    destAmount: best.destination_amount,
+    path: (best.path ?? []).map((p) => (p.asset_type === "native" ? "XLM" : (p.asset_code ?? "?"))),
+  };
+}
+
+export interface ExplainedOp {
+  type: string;
+  summary: string;
+}
+export interface TxExplanation {
+  hash: string;
+  successful: boolean;
+  createdAt: string;
+  feeCharged: string;
+  summary: string;
+  operations: ExplainedOp[];
+}
+
+/** A short, human-readable form of a Stellar address: `GABC…WXYZ`. */
+function shortAddr(a?: string): string {
+  return a ? `${a.slice(0, 4)}…${a.slice(-4)}` : "someone";
+}
+function opAsset(type?: string, code?: string): string {
+  return type === "native" ? "XLM" : (code ?? "an asset");
+}
+
+/** Turn one Horizon operation into a plain-English line. */
+function explainOp(op: HorizonOp): ExplainedOp {
+  switch (op.type) {
+    case "payment":
+      return {
+        type: op.type,
+        summary: `${shortAddr(op.from)} paid ${op.amount} ${opAsset(op.asset_type, op.asset_code)} to ${shortAddr(op.to)}`,
+      };
+    case "create_account":
+      return {
+        type: op.type,
+        summary: `${shortAddr(op.funder)} created account ${shortAddr(op.account)} with ${op.starting_balance} XLM`,
+      };
+    case "path_payment_strict_send":
+    case "path_payment_strict_receive":
+      return {
+        type: op.type,
+        summary: `${shortAddr(op.from)} swapped ${op.source_amount ?? "?"} ${opAsset(op.source_asset_type, op.source_asset_code)} for ${op.amount} ${opAsset(op.asset_type, op.asset_code)} to ${shortAddr(op.to)}`,
+      };
+    case "change_trust":
+      return {
+        type: op.type,
+        summary: `${shortAddr(op.trustor ?? op.source_account)} set a trustline for ${opAsset(op.asset_type, op.asset_code)}`,
+      };
+    case "manage_sell_offer":
+    case "manage_buy_offer":
+    case "create_passive_sell_offer":
+      return { type: op.type, summary: `${shortAddr(op.source_account)} placed a DEX offer` };
+    default:
+      return {
+        type: op.type,
+        summary: `${shortAddr(op.source_account)} performed ${op.type.replace(/_/g, " ")}`,
+      };
+  }
+}
+
+/** Decode a settled transaction into a readable summary of what it did. */
+export async function explainTransaction(hash: string): Promise<TxExplanation> {
+  const tx = await horizon(`/transactions/${hash}`);
+  if (!tx.ok) throw new Error("transaction not found");
+  const t = tx.data as HorizonTx;
+  const opsRes = await horizon(`/transactions/${hash}/operations?limit=50`);
+  const records =
+    (opsRes.data as { _embedded?: { records?: HorizonOp[] } })._embedded?.records ?? [];
+  const operations = records.map(explainOp);
+  const summary =
+    `Transaction ${t.successful ? "succeeded" : "failed"} with ` +
+    `${operations.length} operation${operations.length === 1 ? "" : "s"}` +
+    (operations.length ? `: ${operations.map((o) => o.summary).join("; ")}.` : ".");
+  return {
+    hash: t.hash,
+    successful: t.successful,
+    createdAt: t.created_at,
+    feeCharged: t.fee_charged,
+    summary,
+    operations,
+  };
+}
+
+/** The USDC asset portfolio values are quoted in. Overridable per deployment. */
+const USDC_ASSET =
+  process.env.USDC_ASSET ?? "USDC:GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+
+export interface Holding {
+  asset: string;
+  issuer: string | null;
+  balance: string;
+  /** Value of this balance in USDC, or null if no route to USDC exists. */
+  valueUsdc: string | null;
+}
+export interface Portfolio {
+  address: string;
+  holdings: Holding[];
+  /** Sum of the priced holdings, in USDC. */
+  totalUsdc: string;
+}
+
+/**
+ * Value every balance in an account in USDC. USDC is counted directly; every
+ * other asset is priced by quoting its full balance to USDC across the DEX
+ * (so the value already reflects realisable liquidity). Assets with no route to
+ * USDC are returned with `valueUsdc: null` and excluded from the total.
+ */
+export async function getPortfolio(address: string): Promise<Portfolio> {
+  const balances = await getBalances(address);
+  const [usdcCode, usdcIssuer] = USDC_ASSET.split(":");
+  let total = 0;
+  const holdings: Holding[] = [];
+  for (const b of balances) {
+    let valueUsdc: string | null;
+    if (b.asset === usdcCode && b.issuer === usdcIssuer) {
+      valueUsdc = b.balance;
+    } else if (Number(b.balance) === 0) {
+      valueUsdc = "0";
+    } else {
+      const spec = b.issuer ? `${b.asset}:${b.issuer}` : "native";
+      try {
+        valueUsdc = (await getQuote(spec, USDC_ASSET, b.balance)).destAmount;
+      } catch {
+        valueUsdc = null;
+      }
+    }
+    if (valueUsdc !== null) total += Number(valueUsdc);
+    holdings.push({ asset: b.asset, issuer: b.issuer, balance: b.balance, valueUsdc });
+  }
+  return { address, holdings, totalUsdc: total.toFixed(7) };
+}
+
+interface HorizonPath {
+  source_amount: string;
+  destination_amount: string;
+  path?: { asset_type: string; asset_code?: string; asset_issuer?: string }[];
+}
+interface HorizonOp {
+  type: string;
+  source_account: string;
+  from?: string;
+  to?: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  funder?: string;
+  account?: string;
+  starting_balance?: string;
+  source_amount?: string;
+  source_asset_type?: string;
+  source_asset_code?: string;
+  trustor?: string;
+}
+
 interface HorizonBalance {
   balance: string;
   asset_type: string;

--- a/apps/capabilities/src/capabilities/stellar/operations/explain.ts
+++ b/apps/capabilities/src/capabilities/stellar/operations/explain.ts
@@ -1,0 +1,28 @@
+import type { Operation } from "../../../types";
+import { explainTransaction } from "../horizon";
+
+/**
+ * GET /stellar/explain?hash=… — decode a settled transaction into a plain-English
+ * summary of what it did (payments, swaps, trustlines, offers…). Paid: it turns a
+ * raw ledger entry into something an agent can reason about, which is interpretation
+ * on top of Horizon, not a mirror of it.
+ */
+export const operation: Operation = {
+  name: "Explain",
+  path: "/stellar/explain",
+  method: "GET",
+  price: "0.001",
+  sampleRequest: "hash=<64-hex-transaction-hash>",
+  sampleResponse: `{ "hash": "…", "successful": true, "summary": "Transaction succeeded with 1 operation: GABC…WXYZ paid 5 XLM to GDEF…7890.", "operations": [{ "type": "payment", "summary": "GABC…WXYZ paid 5 XLM to GDEF…7890" }] }`,
+  handler: async (c) => {
+    const hash = c.req.query("hash") ?? "";
+    if (!/^[a-f0-9]{64}$/i.test(hash)) {
+      return c.json({ error: "Provide a 64-char tx hash" }, 400);
+    }
+    try {
+      return c.json(await explainTransaction(hash));
+    } catch {
+      return c.json({ error: "Transaction not found" }, 404);
+    }
+  },
+};

--- a/apps/capabilities/src/capabilities/stellar/operations/portfolio.ts
+++ b/apps/capabilities/src/capabilities/stellar/operations/portfolio.ts
@@ -1,0 +1,27 @@
+import type { Operation } from "../../../types";
+import { getPortfolio, isStellarAddress } from "../horizon";
+
+/**
+ * GET /stellar/portfolio?address=G… — value every asset in an account in USDC,
+ * priced across the DEX, with a total. Paid: it aggregates balances and live
+ * pricing into one number an agent would otherwise have to assemble itself.
+ */
+export const operation: Operation = {
+  name: "Portfolio",
+  path: "/stellar/portfolio",
+  method: "GET",
+  price: "0.002",
+  sampleRequest: "address=<stellar-account-address>",
+  sampleResponse: `{ "address": "G…", "holdings": [{ "asset": "USDC", "issuer": "G…", "balance": "10.5", "valueUsdc": "10.5" }, { "asset": "XLM", "issuer": null, "balance": "100", "valueUsdc": "12.3" }], "totalUsdc": "22.8000000" }`,
+  handler: async (c) => {
+    const address = c.req.query("address") ?? "";
+    if (!isStellarAddress(address)) {
+      return c.json({ error: "Provide a valid Stellar address" }, 400);
+    }
+    try {
+      return c.json(await getPortfolio(address));
+    } catch {
+      return c.json({ error: "Account not found or not funded" }, 404);
+    }
+  },
+};

--- a/apps/capabilities/src/capabilities/stellar/operations/quote.ts
+++ b/apps/capabilities/src/capabilities/stellar/operations/quote.ts
@@ -1,0 +1,39 @@
+import type { Operation } from "../../../types";
+import { getQuote } from "../horizon";
+
+/**
+ * GET /stellar/quote?source=USDC:G…&dest=native&amount=100 — best price to send
+ * exactly `amount` of `source` and receive `dest`, across the Stellar DEX + pools.
+ * Paid: aggregating every book and pool into one best-route answer is real work
+ * an agent won't do itself.
+ */
+export const operation: Operation = {
+  name: "Quote",
+  path: "/stellar/quote",
+  method: "GET",
+  price: "0.001",
+  sampleRequest: "source=USDC:<issuer-address>&dest=native&amount=100",
+  sampleResponse: `{ "source": "USDC:G…", "sourceAmount": "100", "dest": "native", "destAmount": "812.44", "path": [] }`,
+  handler: async (c) => {
+    const source = c.req.query("source") ?? "";
+    const dest = c.req.query("dest") ?? "";
+    const amount = c.req.query("amount") ?? "";
+    if (!source || !dest || !(Number(amount) > 0)) {
+      return c.json(
+        { error: "Provide source, dest (native or CODE:ISSUER) and a positive amount" },
+        400,
+      );
+    }
+    try {
+      return c.json(await getQuote(source, dest, amount));
+    } catch (err) {
+      if (err instanceof Error && err.message === "bad asset") {
+        return c.json({ error: "Assets must be `native` or `CODE:ISSUER`" }, 400);
+      }
+      if (err instanceof Error && err.message === "no path") {
+        return c.json({ error: "No route found for this pair and amount" }, 404);
+      }
+      return c.json({ error: "Quote unavailable" }, 502);
+    }
+  },
+};


### PR DESCRIPTION
The Stellar reads so far are free mirrors of public data. These three are the **first priced operations** — they aggregate or interpret (real work an agent won't do itself), so they finally exercise the payment rail.

| Op | Price | What it does |
|---|---|---|
| **Quote** | $0.001 | Best strict-send price + route for a pair (Horizon pathfinding across DEX + pools) |
| **Explain** | $0.001 | Decodes a settled tx into a plain-English summary of each operation |
| **Portfolio** | $0.002 | Values every balance in an account in USDC across the DEX, with a total |

Each is one file under `stellar/operations/` + shared helpers in `horizon.ts`; the Stellar description now lists them so search finds them.

**Verified against live testnet:**
- Quote → `100 CUP → 3.9230301 MAMEY` (real path)
- Explain → `"GB5F…RLCH paid 2.0000000 XLM to GBTO…JJZV"` (payment), and a clean fallback for Soroban txs
- Portfolio → USDC valued directly, XLM `valueUsdc: null` where testnet has no route, total correct

**After merge:** redeploy + republish, then the gateway will return a **402 challenge** on `/c/stellar/quote|explain|portfolio` (first real USDC through the rail). Full pay-and-settle is testable from the dashboard Run flow with a funded card.