### PR TITLE
fix(capabilities): make quote/explain/portfolio searchable

### DIFF
--- a/apps/capabilities/src/capabilities/stellar/capability.ts
+++ b/apps/capabilities/src/capabilities/stellar/capability.ts
@@ -9,7 +9,7 @@ export const meta: CapabilityMeta = {
   name: "Stellar",
   kind: "api",
   description:
-    "Stellar lookups for AI agents: account balances, account details, settled transactions, asset info, network status, DEX orderbook, recent trades, and account payments (all free), plus best-price swap quotes, plain-English transaction explanations, and USDC portfolio valuation (priced per call).",
+    "Stellar lookups for AI agents: account balances, account details, settled transactions, asset info, network status, DEX orderbook, recent trades, and account payments (all free), plus quote (best-price swaps), explain (plain-English transactions), and portfolio (USDC valuation) — priced per call.",
   faqs: [
     {
       question: "Which network does this read from?",


### PR DESCRIPTION
Post-republish check found `search("explain")` returned nothing — the description said "explan**ations**" and `explain` is not a substring of that. Reworded so each paid op word (quote, explain, portfolio) appears literally. `search("quote")` and `search("portfolio")` already resolved; this fixes explain.

After merge: one republish updates the description.