### PR TITLE
feat(marketplace): expandable operations table with inline run + live results

### DIFF
--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, BadgeCheck, ChevronDown, Pencil } from "lucide-react";
+import { ArrowLeft, BadgeCheck, Check, ChevronDown, Pencil } from "lucide-react";
 import { cn } from "@tael/ui";
 import { getPublicCapabilityBySlug } from "../../../../features/capabilities/queries";
 import { isCurrentUserAdmin } from "../../../../features/capabilities/actions";
@@ -74,7 +74,14 @@ export default async function CapabilityDetailPage({
           <p className="text-sm text-muted-foreground">Capability</p>
           <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
             {capability.name}
-            {verified ? <BadgeCheck className="h-5 w-5 text-emerald-600" /> : null}
+            {verified ? (
+              <span
+                title="Verified by Tael"
+                className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-emerald-500 text-white shadow-sm"
+              >
+                <Check className="h-3 w-3" strokeWidth={3.5} />
+              </span>
+            ) : null}
           </h1>
         </div>
         <div className="flex items-center gap-2">

--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -8,7 +8,6 @@ import { CapabilityLogo } from "../../../../features/capabilities/capability-log
 import { formatPrice, kindMeta, timeAgo } from "../../../../features/capabilities/kind-meta";
 import { UseCapabilityDialog } from "../../../../features/capabilities/use-capability-dialog";
 import { VerifyToggle } from "../../../../features/capabilities/verify-toggle";
-import { RunCapabilityDialog } from "../../../../features/agents/run-capability-dialog";
 import { OperationsExplorer } from "../../../../features/agents/operations-explorer";
 import { listAgentsForRun } from "../../../../features/agents/queries";
 import { ReviewsSection } from "../../../../features/reviews/reviews-section";
@@ -44,13 +43,6 @@ export default async function CapabilityDetailPage({
   const meta = kindMeta(capability.kind);
   const Icon = meta.icon;
   const operations = capability.spec.operations ?? [];
-  const runOp = (op: (typeof operations)[number], i: number) => ({
-    slug: op.slug || opSlug(op.name, i),
-    name: op.name || `Request ${i + 1}`,
-    price: formatPrice(op.price),
-    method: op.method || "GET",
-    body: op.sampleRequest ?? "",
-  });
   const contact = capability.contact;
   const contactHref = contact
     ? contact.startsWith("http")
@@ -86,12 +78,9 @@ export default async function CapabilityDetailPage({
           </h1>
         </div>
         <div className="flex items-center gap-2">
-          <RunCapabilityDialog
-            slug={capability.slug}
-            price={formatPrice(capability.price)}
-            agents={agentOptions}
-            operation={operations.length > 0 ? runOp(operations[0]!, 0) : undefined}
-          />
+          {isAdmin ? (
+            <VerifyToggle id={capability.id} verified={verified} variant="compact" />
+          ) : null}
           <UseCapabilityDialog
             endpoint={`${API_URL}/c/${capability.slug}`}
             price={`$${formatPrice(capability.price)}`}
@@ -133,11 +122,13 @@ export default async function CapabilityDetailPage({
       </div>
 
       {isAdmin ? (
-        <div className="flex flex-wrap items-center gap-3">
-          <VerifyToggle id={capability.id} verified={verified} />
+        <div className="flex flex-wrap items-center gap-3 rounded-lg border border-dashed px-3 py-2">
+          <span className="text-xs text-muted-foreground">
+            Admin — set this capability&apos;s status from the header.
+          </span>
           <Link
             href={`/capabilities/${capability.id}/edit`}
-            className="inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:bg-muted"
+            className="ml-auto inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-muted"
           >
             <Pencil className="h-4 w-4" /> Edit
           </Link>
@@ -167,7 +158,10 @@ export default async function CapabilityDetailPage({
         <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
           Verification
         </h2>
-        <VerificationTimeline verified={verified} />
+        <VerificationTimeline
+          status={capability.status}
+          publishedLabel={timeAgo(capability.createdAt.toISOString())}
+        />
       </section>
 
       {/* Description */}

--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -62,7 +62,7 @@ export default async function CapabilityDetailPage({
       </Link>
 
       {/* Header */}
-      <div className="flex items-start gap-4">
+      <div className="flex items-center gap-4">
         <CapabilityLogo
           src={capability.logoUrl}
           name={capability.name}

--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, BadgeCheck, ChevronDown, Code2, Pencil } from "lucide-react";
+import { ArrowLeft, BadgeCheck, ChevronDown, Pencil } from "lucide-react";
 import { cn } from "@tael/ui";
 import { getPublicCapabilityBySlug } from "../../../../features/capabilities/queries";
 import { isCurrentUserAdmin } from "../../../../features/capabilities/actions";
@@ -9,6 +9,7 @@ import { formatPrice, kindMeta, timeAgo } from "../../../../features/capabilitie
 import { UseCapabilityDialog } from "../../../../features/capabilities/use-capability-dialog";
 import { VerifyToggle } from "../../../../features/capabilities/verify-toggle";
 import { RunCapabilityDialog } from "../../../../features/agents/run-capability-dialog";
+import { OperationsExplorer } from "../../../../features/agents/operations-explorer";
 import { listAgentsForRun } from "../../../../features/agents/queries";
 import { ReviewsSection } from "../../../../features/reviews/reviews-section";
 import { VerificationTimeline } from "../../../../features/capabilities/verification-timeline";
@@ -179,59 +180,21 @@ export default async function CapabilityDetailPage({
         </section>
       ) : null}
 
-      {/* Requests — each operation with its price + sample request/response */}
+      {/* Operations — expandable table: edit params, run inline, see the result. */}
       {operations.length > 0 ? (
-        <section className="space-y-3">
-          <h2 className="flex items-center gap-1.5 text-sm font-medium uppercase tracking-wide text-muted-foreground">
-            <Code2 className="h-4 w-4" /> Requests
-          </h2>
-          <div className="space-y-4">
-            {operations.map((op, i) => (
-              <div key={i} className="space-y-3 rounded-xl border p-4">
-                <div className="flex flex-wrap items-center gap-2">
-                  {op.method ? (
-                    <span className="rounded-md border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 font-mono text-xs font-semibold text-blue-600">
-                      {op.method}
-                    </span>
-                  ) : null}
-                  <span className="font-medium">{op.name || `Request ${i + 1}`}</span>
-                  <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
-                    /{capability.slug}/{op.slug || opSlug(op.name, i)}
-                  </code>
-                  <span className="ml-auto text-sm font-semibold tabular-nums">
-                    {Number(op.price) > 0 ? (
-                      <>
-                        ${formatPrice(op.price)}
-                        <span className="text-xs font-normal text-muted-foreground">USDC/call</span>
-                      </>
-                    ) : (
-                      <span className="rounded-md bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
-                        Free
-                      </span>
-                    )}
-                  </span>
-                  <RunCapabilityDialog
-                    slug={capability.slug}
-                    price={formatPrice(op.price)}
-                    agents={agentOptions}
-                    operation={runOp(op, i)}
-                    trigger="compact"
-                  />
-                </div>
-                {op.sampleRequest || op.sampleResponse ? (
-                  <div className="grid gap-4 md:grid-cols-2">
-                    {op.sampleRequest ? (
-                      <CodeBlock title="Sample request" code={op.sampleRequest} />
-                    ) : null}
-                    {op.sampleResponse ? (
-                      <CodeBlock title="Sample response" code={op.sampleResponse} />
-                    ) : null}
-                  </div>
-                ) : null}
-              </div>
-            ))}
-          </div>
-        </section>
+        <OperationsExplorer
+          slug={capability.slug}
+          agents={agentOptions}
+          operations={operations.map((op, i) => ({
+            name: op.name || `Request ${i + 1}`,
+            opSlug: op.slug || opSlug(op.name, i),
+            method: op.method || "GET",
+            price: formatPrice(op.price),
+            priceRaw: op.price ?? "0",
+            sampleRequest: op.sampleRequest ?? "",
+            sampleResponse: op.sampleResponse ?? "",
+          }))}
+        />
       ) : null}
 
       {/* FAQ — visible to buyers, collapsed by default */}
@@ -256,19 +219,6 @@ export default async function CapabilityDetailPage({
 
       {/* Reviews */}
       <ReviewsSection capabilityId={capability.id} slug={capability.slug} />
-    </div>
-  );
-}
-
-function CodeBlock({ title, code }: { title: string; code: string }) {
-  return (
-    <div className="overflow-hidden rounded-xl border">
-      <div className="border-b bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground">
-        {title}
-      </div>
-      <pre className="overflow-x-auto p-3 text-xs leading-relaxed">
-        <code>{code}</code>
-      </pre>
     </div>
   );
 }

--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -71,7 +71,6 @@ export default async function CapabilityDetailPage({
           iconClassName="h-6 w-6"
         />
         <div className="min-w-0 flex-1 space-y-1">
-          <p className="text-sm text-muted-foreground">Capability</p>
           <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
             {capability.name}
             {verified ? (

--- a/apps/dashboard/app/providers.tsx
+++ b/apps/dashboard/app/providers.tsx
@@ -2,11 +2,14 @@
 
 import type { ReactNode } from "react";
 import { ThemeProvider } from "next-themes";
+import { Toaster } from "sonner";
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
       {children}
+      {/* Toasts follow the app theme; subtle, dismissible, bottom-right. */}
+      <Toaster theme="system" richColors closeButton position="bottom-right" />
     </ThemeProvider>
   );
 }

--- a/apps/dashboard/app/providers.tsx
+++ b/apps/dashboard/app/providers.tsx
@@ -8,8 +8,24 @@ export function Providers({ children }: { children: ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
       {children}
-      {/* Toasts follow the app theme; subtle, dismissible, bottom-right. */}
-      <Toaster theme="system" richColors closeButton position="bottom-right" />
+      {/* Clean, neutral toasts that match the app surface (no heavy color fills).
+          A green tick for success comes from the icon, not the background. */}
+      <Toaster
+        theme="system"
+        position="bottom-right"
+        gap={8}
+        toastOptions={{
+          classNames: {
+            toast:
+              "!rounded-xl !border !border-border !bg-popover !text-popover-foreground !shadow-lg",
+            title: "!text-sm !font-medium",
+            description: "!text-muted-foreground",
+            success: "!text-foreground [&_[data-icon]]:!text-emerald-600",
+            error: "!text-foreground [&_[data-icon]]:!text-destructive",
+            closeButton: "!bg-popover !border-border !text-muted-foreground",
+          },
+        }}
+      />
     </ThemeProvider>
   );
 }

--- a/apps/dashboard/features/agents/operations-explorer.tsx
+++ b/apps/dashboard/features/agents/operations-explorer.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
-import { Check, ChevronRight, CreditCard, Play, Sparkles, TriangleAlert } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  CreditCard,
+  Play,
+  Sparkles,
+  TriangleAlert,
+} from "lucide-react";
 import {
   Button,
   cn,
@@ -90,46 +98,58 @@ function CardPicker({
   selected: AgentOption | null;
   onSelect: (id: string) => void;
 }) {
+  // No card yet — make the requirement (and the fix) explicit, not a dead chip.
   if (agents.length === 0) {
     return (
-      <a href="/agents" className="text-sm font-medium text-foreground hover:underline">
-        Add a card to run
+      <a
+        href="/agents"
+        className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-amber-500/40 bg-amber-500/5 px-3 py-1.5 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-500/10"
+      >
+        <CreditCard className="h-3.5 w-3.5" /> Add a card to run
       </a>
     );
   }
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="transition-transform duration-100 ease-out active:scale-[0.98]"
-        >
-          <CreditCard className="h-3.5 w-3.5" />
-          <span className="max-w-[10rem] truncate">{selected?.name ?? "Select a card"}</span>
-          {selected ? (
-            <span className="tabular-nums text-muted-foreground">${formatUsdc(selected.usdc)}</span>
-          ) : null}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-64">
-        <DropdownMenuLabel>Run with card</DropdownMenuLabel>
-        {agents.map((a) => (
-          <DropdownMenuItem
-            key={a.agentId}
-            onSelect={() => onSelect(a.agentId)}
-            className="flex items-center gap-2"
+    <div className="flex items-center gap-2">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Card
+      </span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5 transition-transform duration-100 ease-out active:scale-[0.98]"
           >
-            <CreditCard className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className="min-w-0 flex-1 truncate">{a.name}</span>
-            <span className="shrink-0 tabular-nums text-muted-foreground">
-              ${formatUsdc(a.usdc)}
-            </span>
-            {a.agentId === selected?.agentId ? <Check className="h-4 w-4 shrink-0" /> : null}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+            <CreditCard className="h-3.5 w-3.5" />
+            <span className="max-w-[9rem] truncate">{selected?.name ?? "Select a card"}</span>
+            {selected ? (
+              <span className="tabular-nums text-muted-foreground">
+                ${formatUsdc(selected.usdc)}
+              </span>
+            ) : null}
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-64">
+          <DropdownMenuLabel>Run with card</DropdownMenuLabel>
+          {agents.map((a) => (
+            <DropdownMenuItem
+              key={a.agentId}
+              onSelect={() => onSelect(a.agentId)}
+              className="flex items-center gap-2"
+            >
+              <CreditCard className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate">{a.name}</span>
+              <span className="shrink-0 tabular-nums text-muted-foreground">
+                ${formatUsdc(a.usdc)}
+              </span>
+              {a.agentId === selected?.agentId ? <Check className="h-4 w-4 shrink-0" /> : null}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 
@@ -250,15 +270,15 @@ function OperationRow({
             }
           }}
           className={cn(
-            "inline-flex w-16 items-center justify-center gap-1 rounded-md border px-2 py-1.5 text-xs font-medium transition-all duration-100 ease-out hover:bg-muted active:scale-[0.96]",
-            pending && "pointer-events-none opacity-60",
+            "inline-flex w-[4.5rem] items-center justify-center gap-1 rounded-md bg-foreground px-2 py-1.5 text-xs font-medium text-background shadow-sm transition-all duration-100 ease-out hover:bg-foreground/90 active:scale-[0.96]",
+            pending && "pointer-events-none opacity-70",
           )}
         >
           {pending ? (
-            <span className="h-3 w-3 animate-spin rounded-full border-2 border-muted-foreground/40 border-t-foreground" />
+            <span className="h-3 w-3 animate-spin rounded-full border-2 border-background/40 border-t-background" />
           ) : (
             <>
-              <Play className="h-3 w-3" /> Run
+              <Play className="h-3 w-3" /> {paid ? "Pay" : "Run"}
             </>
           )}
         </span>
@@ -282,37 +302,20 @@ function OperationRow({
                 className="w-full rounded-lg border border-input bg-background px-3 py-2 font-mono text-xs outline-none transition-shadow focus:ring-2 focus:ring-ring/30"
               />
             </label>
-            <div className="flex items-center justify-between gap-2">
-              <span className="text-xs text-muted-foreground">
-                {paid ? (
-                  <>
-                    Costs{" "}
-                    <span className="font-medium tabular-nums text-foreground">
-                      ${op.price} USDC
-                    </span>
-                  </>
-                ) : (
-                  "Free to run"
-                )}
-              </span>
-              <Button
-                size="sm"
-                onClick={run}
-                disabled={pending || !agent || !canPay}
-                className="transition-transform duration-100 ease-out active:scale-[0.97]"
-              >
-                {pending ? (
-                  <>
-                    <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-background/40 border-t-background" />
-                    {paid ? "Paying…" : "Running…"}
-                  </>
-                ) : (
-                  <>
-                    <Play className="h-3.5 w-3.5" /> {paid ? "Pay & run" : "Run"}
-                  </>
-                )}
-              </Button>
-            </div>
+            <p className="text-xs text-muted-foreground">
+              {paid ? (
+                <>
+                  Costs{" "}
+                  <span className="font-medium tabular-nums text-foreground">${op.price} USDC</span>
+                  {" · use "}
+                  <span className="font-medium text-foreground">Pay</span> above to run.
+                </>
+              ) : (
+                <>
+                  Free to run · use <span className="font-medium text-foreground">Run</span> above.
+                </>
+              )}
+            </p>
             {agent && !canPay ? (
               <p className="flex items-start gap-1.5 text-xs text-amber-600">
                 <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />

--- a/apps/dashboard/features/agents/operations-explorer.tsx
+++ b/apps/dashboard/features/agents/operations-explorer.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { Check, ChevronRight, CreditCard, Play, Sparkles, TriangleAlert } from "lucide-react";
+import {
+  Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@tael/ui";
+import { toast } from "sonner";
+import { formatUsdc } from "../../lib/format";
+import { runCapability, type RunResult } from "./run-capability";
+import type { AgentOption } from "./queries";
+
+/** One operation, as the explorer needs it (mirrors the marketplace detail page). */
+export interface ExplorerOperation {
+  name: string;
+  opSlug: string;
+  method: string;
+  /** Formatted price for display, e.g. "0.001". */
+  price: string;
+  /** Raw decimal price, for the paid/free + affordability checks. */
+  priceRaw: string;
+  sampleRequest: string;
+  sampleResponse: string;
+}
+
+/**
+ * The operations of a capability as an expandable table: click a row to open its
+ * parameters and sample, edit the request, and run it inline with a card — the
+ * live result renders on the right, no modal. Replaces the old stacked-cards +
+ * dialog. Motion follows the design rules: ease-out entrances, press feedback.
+ */
+export function OperationsExplorer({
+  slug,
+  agents,
+  operations,
+}: {
+  slug: string;
+  agents: AgentOption[];
+  operations: ExplorerOperation[];
+}) {
+  const [openIdx, setOpenIdx] = useState<number | null>(operations.length ? 0 : null);
+  const [agentId, setAgentId] = useState(agents[0]?.agentId ?? "");
+  const selected = agents.find((a) => a.agentId === agentId) ?? agents[0] ?? null;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          Operations
+        </h2>
+        <CardPicker agents={agents} selected={selected} onSelect={setAgentId} />
+      </div>
+
+      <div className="overflow-hidden rounded-xl border">
+        {/* Column header — table look without a semantic table (rows expand). */}
+        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-3 border-b bg-muted/40 px-4 py-2.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <span>Operation</span>
+          <span className="text-right">Price</span>
+          <span className="w-16" />
+        </div>
+
+        {operations.map((op, i) => (
+          <OperationRow
+            key={op.opSlug || i}
+            slug={slug}
+            op={op}
+            agent={selected}
+            open={openIdx === i}
+            last={i === operations.length - 1}
+            onToggle={() => setOpenIdx(openIdx === i ? null : i)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CardPicker({
+  agents,
+  selected,
+  onSelect,
+}: {
+  agents: AgentOption[];
+  selected: AgentOption | null;
+  onSelect: (id: string) => void;
+}) {
+  if (agents.length === 0) {
+    return (
+      <a href="/agents" className="text-sm font-medium text-foreground hover:underline">
+        Add a card to run
+      </a>
+    );
+  }
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="transition-transform duration-100 ease-out active:scale-[0.98]"
+        >
+          <CreditCard className="h-3.5 w-3.5" />
+          <span className="max-w-[10rem] truncate">{selected?.name ?? "Select a card"}</span>
+          {selected ? (
+            <span className="tabular-nums text-muted-foreground">${formatUsdc(selected.usdc)}</span>
+          ) : null}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuLabel>Run with card</DropdownMenuLabel>
+        {agents.map((a) => (
+          <DropdownMenuItem
+            key={a.agentId}
+            onSelect={() => onSelect(a.agentId)}
+            className="flex items-center gap-2"
+          >
+            <CreditCard className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 truncate">{a.name}</span>
+            <span className="shrink-0 tabular-nums text-muted-foreground">
+              ${formatUsdc(a.usdc)}
+            </span>
+            {a.agentId === selected?.agentId ? <Check className="h-4 w-4 shrink-0" /> : null}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function OperationRow({
+  slug,
+  op,
+  agent,
+  open,
+  last,
+  onToggle,
+}: {
+  slug: string;
+  op: ExplorerOperation;
+  agent: AgentOption | null;
+  open: boolean;
+  last: boolean;
+  onToggle: () => void;
+}) {
+  const method = (op.method || "GET").toUpperCase();
+  const isGet = method === "GET" || method === "HEAD";
+  const priceNum = Number(op.priceRaw);
+  const paid = priceNum > 0;
+
+  const [input, setInput] = useState(op.sampleRequest);
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [pending, start] = useTransition();
+
+  // Can the chosen card cover this call (balance + per-call cap)?
+  const canPay = useMemo(() => {
+    if (!agent) return false;
+    if (!paid) return true;
+    const funded = Number(agent.usdc) >= priceNum;
+    const withinCap = agent.policy ? priceNum <= Number(agent.policy.maxPerCall) : true;
+    return funded && withinCap;
+  }, [agent, paid, priceNum]);
+
+  function run() {
+    if (!agent) {
+      toast.error("Select a card to run this call.");
+      return;
+    }
+    if (!canPay) {
+      toast.error(`${agent.name} can't pay $${op.price} for this call.`);
+      return;
+    }
+    setResult(null);
+    start(async () => {
+      const r = await runCapability({
+        agentId: agent.agentId,
+        slug,
+        operation: op.opSlug,
+        method,
+        body: isGet ? undefined : input,
+        query: isGet ? input : undefined,
+      });
+      setResult(r);
+      if (r.ok) {
+        toast.success(
+          Number(r.paid) > 0 ? `Ran ${op.name} · paid $${r.paid} USDC` : `Ran ${op.name}`,
+        );
+      } else {
+        toast.error(r.error ?? "The call failed.");
+      }
+    });
+  }
+
+  return (
+    <div className={cn(!last && "border-b")}>
+      {/* Row — click anywhere to expand. */}
+      <button
+        type="button"
+        onClick={onToggle}
+        className="grid w-full grid-cols-[1fr_auto_auto] items-center gap-3 px-4 py-3 text-left transition-colors duration-150 hover:bg-muted/40"
+      >
+        <span className="flex min-w-0 items-center gap-2.5">
+          <ChevronRight
+            className={cn(
+              "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 ease-out",
+              open && "rotate-90",
+            )}
+          />
+          <span className="rounded border border-blue-500/20 bg-blue-500/10 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-blue-600">
+            {method}
+          </span>
+          <span className="truncate font-medium">{op.name}</span>
+          <code className="hidden truncate font-mono text-xs text-muted-foreground sm:inline">
+            /{slug}/{op.opSlug}
+          </code>
+        </span>
+
+        <span className="text-right text-sm tabular-nums">
+          {paid ? (
+            <>
+              <span className="font-semibold">${op.price}</span>
+              <span className="text-xs font-normal text-muted-foreground"> USDC</span>
+            </>
+          ) : (
+            <span className="rounded-md bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+              Free
+            </span>
+          )}
+        </span>
+
+        <span
+          role="button"
+          tabIndex={0}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (!open) onToggle();
+            run();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              e.stopPropagation();
+              if (!open) onToggle();
+              run();
+            }
+          }}
+          className={cn(
+            "inline-flex w-16 items-center justify-center gap-1 rounded-md border px-2 py-1.5 text-xs font-medium transition-all duration-100 ease-out hover:bg-muted active:scale-[0.96]",
+            pending && "pointer-events-none opacity-60",
+          )}
+        >
+          {pending ? (
+            <span className="h-3 w-3 animate-spin rounded-full border-2 border-muted-foreground/40 border-t-foreground" />
+          ) : (
+            <>
+              <Play className="h-3 w-3" /> Run
+            </>
+          )}
+        </span>
+      </button>
+
+      {/* Expanded detail — request on the left, live/sample response on the right. */}
+      {open ? (
+        <div className="grid gap-4 border-t bg-muted/20 p-4 duration-200 ease-out animate-in fade-in slide-in-from-top-1 md:grid-cols-2">
+          {/* Request */}
+          <div className="min-w-0 space-y-2">
+            <label className="block space-y-1.5">
+              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {isGet ? "Parameters" : "Request body"}
+              </span>
+              <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                rows={isGet ? 2 : 4}
+                spellCheck={false}
+                placeholder={isGet ? "key=value&key2=value2" : '{ "key": "value" }'}
+                className="w-full rounded-lg border border-input bg-background px-3 py-2 font-mono text-xs outline-none transition-shadow focus:ring-2 focus:ring-ring/30"
+              />
+            </label>
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs text-muted-foreground">
+                {paid ? (
+                  <>
+                    Costs{" "}
+                    <span className="font-medium tabular-nums text-foreground">
+                      ${op.price} USDC
+                    </span>
+                  </>
+                ) : (
+                  "Free to run"
+                )}
+              </span>
+              <Button
+                size="sm"
+                onClick={run}
+                disabled={pending || !agent || !canPay}
+                className="transition-transform duration-100 ease-out active:scale-[0.97]"
+              >
+                {pending ? (
+                  <>
+                    <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-background/40 border-t-background" />
+                    {paid ? "Paying…" : "Running…"}
+                  </>
+                ) : (
+                  <>
+                    <Play className="h-3.5 w-3.5" /> {paid ? "Pay & run" : "Run"}
+                  </>
+                )}
+              </Button>
+            </div>
+            {agent && !canPay ? (
+              <p className="flex items-start gap-1.5 text-xs text-amber-600">
+                <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                {agent.name} can&apos;t pay ${op.price} for this call. Pick another card or fund it.
+              </p>
+            ) : null}
+          </div>
+
+          {/* Response */}
+          <div className="min-w-0 space-y-1.5">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {result?.ok ? "Response" : result?.error ? "Error" : "Sample response"}
+            </span>
+            <ResultPanel result={result} sample={op.sampleResponse} />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ResultPanel({ result, sample }: { result: RunResult | null; sample: string }) {
+  if (result?.error) {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs leading-relaxed text-destructive duration-200 ease-out animate-in fade-in">
+        <span className="flex items-start gap-1.5">
+          <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" /> {result.error}
+        </span>
+        {result.body ? (
+          <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap font-mono text-[11px] opacity-80">
+            {prettyJson(result.body)}
+          </pre>
+        ) : null}
+      </div>
+    );
+  }
+
+  const body = result?.ok ? result.body : sample;
+  const live = Boolean(result?.ok);
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-lg border bg-background",
+        live && "duration-200 ease-out animate-in fade-in zoom-in-95",
+      )}
+    >
+      {live ? (
+        <div className="flex items-center gap-1.5 border-b bg-emerald-500/5 px-3 py-1.5 text-xs font-medium text-emerald-600">
+          <Sparkles className="h-3.5 w-3.5" />
+          {Number(result?.paid) > 0 ? `Paid $${result?.paid} USDC` : "Ran free"} · {result?.status}{" "}
+          OK
+        </div>
+      ) : null}
+      <pre className="max-h-72 min-w-0 overflow-auto p-3 font-mono text-[11px] leading-relaxed">
+        <code className={cn(!live && "text-muted-foreground")}>
+          {body ? prettyJson(body) : "Run to see the live result."}
+        </code>
+      </pre>
+    </div>
+  );
+}
+
+/** Pretty-print a JSON string; leave it as-is if it isn't JSON. */
+function prettyJson(s: string): string {
+  try {
+    return JSON.stringify(JSON.parse(s), null, 2);
+  } catch {
+    return s;
+  }
+}

--- a/apps/dashboard/features/capabilities/verification-timeline.tsx
+++ b/apps/dashboard/features/capabilities/verification-timeline.tsx
@@ -1,56 +1,84 @@
-import { BadgeCheck, Circle, FlaskConical, Sparkles } from "lucide-react";
+"use client";
+
+import { useEffect, useState } from "react";
 import type { ComponentType } from "react";
+import { Rocket, ScanEye, ShieldCheck } from "lucide-react";
 import type { LucideProps } from "lucide-react";
 import { cn } from "@tael/ui";
 
-type Tone = "neutral" | "blue" | "green";
+type State = "done" | "active" | "todo";
 
-interface TimelineStep {
+interface Step {
   label: string;
   subtitle: string;
+  detail: string;
   icon: ComponentType<LucideProps>;
-  tone: Tone;
-  done: boolean;
+  state: State;
 }
 
-const PILL: Record<Tone, string> = {
-  neutral: "bg-muted text-muted-foreground",
-  blue: "bg-blue-500/10 text-blue-600",
-  green: "bg-emerald-500/10 text-emerald-700",
+const TILE: Record<State, string> = {
+  done: "border-emerald-500/30 text-emerald-600",
+  active: "border-blue-500/40 text-blue-600",
+  todo: "border-dashed border-border text-muted-foreground",
 };
-
-const ICON: Record<Tone, string> = {
-  neutral: "text-muted-foreground",
-  blue: "text-blue-600",
-  green: "text-emerald-600",
+const PILL: Record<State, string> = {
+  done: "bg-emerald-500/10 text-emerald-700",
+  active: "bg-blue-500/10 text-blue-600",
+  todo: "bg-muted text-muted-foreground",
 };
 
 /**
- * Resend-style stepped progress for a capability's publish → verify journey.
- * Described → AI reviewed → Verified, on a dotted canvas with tile icons + pills.
+ * The capability's real publish → verify journey, tied to its actual status
+ * (`pending` | `verified`), not fabricated stages. Published is always reached;
+ * "Under review" is the manual Tael review; "Verified" turns green only once
+ * Tael grants the badge. Animations follow Emil Kowalski's rules: transform +
+ * opacity only, ease-out, a mount-triggered line draw and a staggered entrance,
+ * a gentle pulse on the in-flight step — all disabled under reduced motion.
  */
-export function VerificationTimeline({ verified }: { verified: boolean }) {
-  const steps: TimelineStep[] = [
+export function VerificationTimeline({
+  status,
+  publishedLabel,
+}: {
+  status: "draft" | "pending" | "verified";
+  publishedLabel: string;
+}) {
+  const verified = status === "verified";
+  const [mounted, setMounted] = useState(false);
+  // Which step's detail is open. Defaults to the current stage (the active one,
+  // else the last done one) so there's something to read without a click.
+  const [openStep, setOpenStep] = useState<number | null>(verified ? 2 : 1);
+  // Flip on the next frame so the line fill + entrances animate from their
+  // initial state instead of rendering already-complete.
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  const steps: Step[] = [
     {
-      label: "Endpoint tested",
-      subtitle: "Live response captured",
-      icon: FlaskConical,
-      tone: "neutral",
-      done: true,
+      label: "Published",
+      subtitle: `Live ${publishedLabel}`,
+      detail: "Your endpoint is live in the marketplace and any agent can call it.",
+      icon: Rocket,
+      state: "done",
     },
     {
-      label: "AI reviewed",
-      subtitle: "Response checked",
-      icon: Sparkles,
-      tone: "blue",
-      done: true,
+      label: "Under review",
+      subtitle: verified ? "Reviewed by Tael" : "Tael is reviewing",
+      detail: verified
+        ? "Tael reviewed the capability and confirmed it responds correctly and is safe to call."
+        : "Tael is checking that the capability responds correctly and is safe before granting trust.",
+      icon: ScanEye,
+      state: verified ? "done" : "active",
     },
     {
-      label: "Verified",
-      subtitle: verified ? "Live in marketplace" : "Pending",
-      icon: verified ? BadgeCheck : Circle,
-      tone: verified ? "green" : "neutral",
-      done: verified,
+      label: verified ? "Verified" : "Not yet verified",
+      subtitle: verified ? "Trusted and live" : "Awaiting the Tael badge",
+      detail: verified
+        ? "Tael granted the trust badge — buyers see this capability as verified."
+        : "It works and can be called, but hasn't received the Tael trust badge yet.",
+      icon: ShieldCheck,
+      state: verified ? "done" : "todo",
     },
   ];
 
@@ -66,35 +94,90 @@ export function VerificationTimeline({ verified }: { verified: boolean }) {
       <div className="grid grid-cols-3 items-start gap-2 text-foreground">
         {steps.map((step, i) => {
           const Icon = step.icon;
+          const next = steps[i + 1];
+          // The connector to the next node fills once this node is done and the
+          // next one has been reached (done or active).
+          const filled = step.state === "done" && next && next.state !== "todo";
+          const isOpen = openStep === i;
           return (
-            <div
+            <button
               key={step.label}
-              className="relative flex flex-col items-center gap-2.5 text-center"
+              type="button"
+              onClick={() => setOpenStep(isOpen ? null : i)}
+              className="group relative flex flex-col items-center gap-2.5 text-center outline-none"
             >
-              {i < steps.length - 1 ? (
-                <span
-                  className={cn(
-                    "absolute left-1/2 top-6 -z-0 h-px w-full",
-                    steps[i + 1]?.done ? "bg-emerald-500/30" : "bg-border",
-                  )}
-                />
+              {/* Connector: a grey track with an emerald fill that draws in. */}
+              {next ? (
+                <span className="absolute left-1/2 top-6 -z-0 h-px w-full overflow-hidden bg-border">
+                  <span
+                    className="block h-full w-full origin-left bg-emerald-500/40 transition-transform duration-700 ease-out motion-reduce:transition-none"
+                    style={{
+                      transform: mounted && filled ? "scaleX(1)" : "scaleX(0)",
+                      transitionDelay: `${i * 180 + 260}ms`,
+                    }}
+                  />
+                </span>
               ) : null}
+
+              {/* Icon tile — staggered entrance; hover/press feedback; selected ring. */}
               <span
                 className={cn(
-                  "z-10 flex h-12 w-12 items-center justify-center rounded-xl border bg-background shadow-sm",
-                  step.done ? "border-border" : "border-dashed",
+                  "relative z-10 flex h-12 w-12 items-center justify-center rounded-xl border bg-background shadow-sm",
+                  "transition-transform duration-150 ease-out group-hover:scale-105 group-active:scale-95",
+                  "motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-90",
+                  isOpen && "ring-2 ring-foreground/15 ring-offset-2 ring-offset-background",
+                  TILE[step.state],
                 )}
+                style={{ animationDelay: `${i * 120}ms` }}
               >
-                <Icon className={cn("h-5 w-5", ICON[step.tone])} />
+                {step.state === "active" ? (
+                  <span className="absolute inset-0 rounded-xl ring-2 ring-blue-500/25 motion-safe:animate-pulse" />
+                ) : null}
+                <Icon className="relative h-5 w-5" />
               </span>
-              <span className={cn("rounded-md px-2.5 py-1 text-xs font-semibold", PILL[step.tone])}>
+
+              <span
+                className={cn(
+                  "rounded-md px-2.5 py-1 text-xs font-semibold duration-500 ease-out motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1",
+                  PILL[step.state],
+                )}
+                style={{ animationDelay: `${i * 120 + 90}ms` }}
+              >
                 {step.label}
               </span>
-              <span className="text-xs text-muted-foreground">{step.subtitle}</span>
-            </div>
+              <span
+                className="text-xs text-muted-foreground duration-500 ease-out motion-safe:animate-in motion-safe:fade-in"
+                style={{ animationDelay: `${i * 120 + 160}ms` }}
+              >
+                {step.subtitle}
+              </span>
+            </button>
           );
         })}
       </div>
+
+      {/* Detail for the selected step — expands under the row, animated. */}
+      {openStep !== null && steps[openStep] ? (
+        <div
+          key={openStep}
+          className="mt-6 flex items-start gap-2.5 rounded-lg border bg-background/70 p-3.5 text-sm text-muted-foreground duration-200 ease-out animate-in fade-in slide-in-from-top-1"
+        >
+          <span
+            className={cn(
+              "mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full",
+              steps[openStep]!.state === "done"
+                ? "bg-emerald-500"
+                : steps[openStep]!.state === "active"
+                  ? "bg-blue-500"
+                  : "bg-muted-foreground/40",
+            )}
+          />
+          <p>
+            <span className="font-medium text-foreground">{steps[openStep]!.label}.</span>{" "}
+            {steps[openStep]!.detail}
+          </p>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/dashboard/features/capabilities/verification-timeline.tsx
+++ b/apps/dashboard/features/capabilities/verification-timeline.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import type { ComponentType } from "react";
-import { Rocket, ScanEye, ShieldCheck } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { ComponentType, PointerEvent as ReactPointerEvent } from "react";
+import { RotateCcw, Rocket, ScanEye, ShieldCheck } from "lucide-react";
 import type { LucideProps } from "lucide-react";
 import { cn } from "@tael/ui";
 
@@ -27,13 +27,33 @@ const PILL: Record<State, string> = {
   todo: "bg-muted text-muted-foreground",
 };
 
+/** A node's position: x as a fraction of the canvas width (stays responsive),
+ *  y in pixels. The tile is 48px; its centre is (fx·width, y + 24). */
+interface Pos {
+  fx: number;
+  y: number;
+}
+
+const CANVAS_H = 236; // px — room to drag the nodes around
+const TILE_HALF = 24;
+const clamp = (n: number, lo: number, hi: number) => Math.min(Math.max(n, lo), hi);
+
+/** Evenly spread n nodes across the canvas at a comfortable resting height. */
+function defaultPositions(n: number): Pos[] {
+  return Array.from({ length: n }, (_, i) => ({
+    fx: n > 1 ? 0.14 + (i / (n - 1)) * 0.72 : 0.5,
+    y: 72,
+  }));
+}
+
 /**
- * The capability's real publish → verify journey, tied to its actual status
- * (`pending` | `verified`), not fabricated stages. Published is always reached;
- * "Under review" is the manual Tael review; "Verified" turns green only once
- * Tael grants the badge. Animations follow Emil Kowalski's rules: transform +
- * opacity only, ease-out, a mount-triggered line draw and a staggered entrance,
- * a gentle pulse on the in-flight step — all disabled under reduced motion.
+ * The capability's real publish → verify journey (Published → Under review →
+ * Verified), tied to its actual status — not fabricated always-done stages.
+ * The nodes are draggable: grab a tile and move it, and the connectors follow.
+ * Tap a node (without dragging) to read what that stage means. Animations follow
+ * Emil Kowalski's rules — transform/opacity only, ease-out, a mount-triggered
+ * line fade + staggered entrance, a soft pulse on the in-flight step — all
+ * disabled under reduced motion.
  */
 export function VerificationTimeline({
   status,
@@ -43,12 +63,14 @@ export function VerificationTimeline({
   publishedLabel: string;
 }) {
   const verified = status === "verified";
+  const canvasRef = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(false);
-  // Which step's detail is open. Defaults to the current stage (the active one,
-  // else the last done one) so there's something to read without a click.
   const [openStep, setOpenStep] = useState<number | null>(verified ? 2 : 1);
-  // Flip on the next frame so the line fill + entrances animate from their
-  // initial state instead of rendering already-complete.
+  const [pos, setPos] = useState<Pos[]>(() => defaultPositions(3));
+  const [moved, setMoved] = useState(false);
+  // Tracks the in-flight pointer drag without re-rendering on every check.
+  const drag = useRef<{ i: number; sx: number; sy: number; moved: boolean } | null>(null);
+
   useEffect(() => {
     const raf = requestAnimationFrame(() => setMounted(true));
     return () => cancelAnimationFrame(raf);
@@ -82,50 +104,93 @@ export function VerificationTimeline({
     },
   ];
 
+  function onPointerDown(e: ReactPointerEvent, i: number) {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    drag.current = { i, sx: e.clientX, sy: e.clientY, moved: false };
+  }
+
+  function onPointerMove(e: ReactPointerEvent) {
+    const d = drag.current;
+    const canvas = canvasRef.current;
+    if (!d || !canvas) return;
+    // Ignore sub-pixel jitter so a tap doesn't count as a drag.
+    if (!d.moved && Math.hypot(e.clientX - d.sx, e.clientY - d.sy) < 4) return;
+    d.moved = true;
+    if (!moved) setMoved(true);
+    const rect = canvas.getBoundingClientRect();
+    const fx = clamp((e.clientX - rect.left) / rect.width, 0.07, 0.93);
+    const y = clamp(e.clientY - rect.top - TILE_HALF, 8, rect.height - 104);
+    setPos((prev) => prev.map((p, idx) => (idx === d.i ? { fx, y } : p)));
+  }
+
+  function onPointerUp(i: number) {
+    const wasDrag = drag.current?.moved;
+    drag.current = null;
+    // A tap (no drag) toggles the step's detail.
+    if (!wasDrag) setOpenStep((cur) => (cur === i ? null : i));
+  }
+
+  function reset() {
+    setPos(defaultPositions(steps.length));
+    setMoved(false);
+  }
+
   return (
-    <div
-      className="rounded-xl border p-8"
-      style={{
-        backgroundImage: "radial-gradient(currentColor 1px, transparent 1px)",
-        backgroundSize: "14px 14px",
-        color: "rgb(120 120 120 / 0.14)",
-      }}
-    >
-      <div className="grid grid-cols-3 items-start gap-2 text-foreground">
+    <div>
+      <div
+        ref={canvasRef}
+        className="relative touch-none overflow-hidden rounded-xl border"
+        style={{
+          height: CANVAS_H,
+          backgroundImage: "radial-gradient(currentColor 1px, transparent 1px)",
+          backgroundSize: "14px 14px",
+          color: "rgb(120 120 120 / 0.14)",
+        }}
+      >
+        {/* Connectors — SVG lines between node centres; they follow on drag. */}
+        <svg
+          className="pointer-events-none absolute inset-0 h-full w-full transition-opacity duration-500 ease-out"
+          style={{ opacity: mounted ? 1 : 0 }}
+        >
+          {steps.slice(0, -1).map((step, i) => {
+            const a = pos[i]!;
+            const b = pos[i + 1]!;
+            const filled = step.state === "done" && steps[i + 1]!.state !== "todo";
+            return (
+              <line
+                key={i}
+                x1={`${a.fx * 100}%`}
+                y1={a.y + TILE_HALF}
+                x2={`${b.fx * 100}%`}
+                y2={b.y + TILE_HALF}
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                className={filled ? "stroke-emerald-500/40" : "stroke-border"}
+              />
+            );
+          })}
+        </svg>
+
+        {/* Nodes — absolutely positioned, draggable, centred on their point. */}
         {steps.map((step, i) => {
           const Icon = step.icon;
-          const next = steps[i + 1];
-          // The connector to the next node fills once this node is done and the
-          // next one has been reached (done or active).
-          const filled = step.state === "done" && next && next.state !== "todo";
-          const isOpen = openStep === i;
+          const p = pos[i]!;
+          const open = openStep === i;
           return (
-            <button
+            <div
               key={step.label}
-              type="button"
-              onClick={() => setOpenStep(isOpen ? null : i)}
-              className="group relative flex flex-col items-center gap-2.5 text-center outline-none"
+              className="absolute flex w-32 -translate-x-1/2 flex-col items-center gap-2.5 text-center"
+              style={{ left: `${p.fx * 100}%`, top: p.y }}
             >
-              {/* Connector: a grey track with an emerald fill that draws in. */}
-              {next ? (
-                <span className="absolute left-1/2 top-6 -z-0 h-px w-full overflow-hidden bg-border">
-                  <span
-                    className="block h-full w-full origin-left bg-emerald-500/40 transition-transform duration-700 ease-out motion-reduce:transition-none"
-                    style={{
-                      transform: mounted && filled ? "scaleX(1)" : "scaleX(0)",
-                      transitionDelay: `${i * 180 + 260}ms`,
-                    }}
-                  />
-                </span>
-              ) : null}
-
-              {/* Icon tile — staggered entrance; hover/press feedback; selected ring. */}
               <span
+                onPointerDown={(e) => onPointerDown(e, i)}
+                onPointerMove={onPointerMove}
+                onPointerUp={() => onPointerUp(i)}
                 className={cn(
-                  "relative z-10 flex h-12 w-12 items-center justify-center rounded-xl border bg-background shadow-sm",
-                  "transition-transform duration-150 ease-out group-hover:scale-105 group-active:scale-95",
+                  "relative z-10 flex h-12 w-12 cursor-grab touch-none select-none items-center justify-center rounded-xl border bg-background shadow-sm active:cursor-grabbing",
+                  "transition-transform duration-150 ease-out hover:scale-105 active:scale-95",
                   "motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-90",
-                  isOpen && "ring-2 ring-foreground/15 ring-offset-2 ring-offset-background",
+                  open && "ring-2 ring-foreground/15 ring-offset-2 ring-offset-background",
                   TILE[step.state],
                 )}
                 style={{ animationDelay: `${i * 120}ms` }}
@@ -138,7 +203,7 @@ export function VerificationTimeline({
 
               <span
                 className={cn(
-                  "rounded-md px-2.5 py-1 text-xs font-semibold duration-500 ease-out motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1",
+                  "pointer-events-none rounded-md px-2.5 py-1 text-xs font-semibold duration-500 ease-out motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1",
                   PILL[step.state],
                 )}
                 style={{ animationDelay: `${i * 120 + 90}ms` }}
@@ -146,21 +211,35 @@ export function VerificationTimeline({
                 {step.label}
               </span>
               <span
-                className="text-xs text-muted-foreground duration-500 ease-out motion-safe:animate-in motion-safe:fade-in"
+                className="pointer-events-none text-xs text-muted-foreground duration-500 ease-out motion-safe:animate-in motion-safe:fade-in"
                 style={{ animationDelay: `${i * 120 + 160}ms` }}
               >
                 {step.subtitle}
               </span>
-            </button>
+            </div>
           );
         })}
+
+        {/* Affordance + reset — subtle, bottom corners. */}
+        <span className="pointer-events-none absolute bottom-3 left-3 text-[11px] text-muted-foreground/70">
+          Drag the steps · tap to read
+        </span>
+        {moved ? (
+          <button
+            type="button"
+            onClick={reset}
+            className="absolute bottom-2.5 right-3 inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <RotateCcw className="h-3 w-3" /> Reset
+          </button>
+        ) : null}
       </div>
 
-      {/* Detail for the selected step — expands under the row, animated. */}
+      {/* Detail for the selected step — expands under the canvas, animated. */}
       {openStep !== null && steps[openStep] ? (
         <div
           key={openStep}
-          className="mt-6 flex items-start gap-2.5 rounded-lg border bg-background/70 p-3.5 text-sm text-muted-foreground duration-200 ease-out animate-in fade-in slide-in-from-top-1"
+          className="mt-3 flex items-start gap-2.5 rounded-lg border bg-background/70 p-3.5 text-sm text-muted-foreground duration-200 ease-out animate-in fade-in slide-in-from-top-1"
         >
           <span
             className={cn(

--- a/apps/dashboard/features/capabilities/verify-toggle.tsx
+++ b/apps/dashboard/features/capabilities/verify-toggle.tsx
@@ -3,14 +3,24 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { BadgeCheck, ShieldCheck } from "lucide-react";
-import { Button } from "@tael/ui";
+import { Button, cn } from "@tael/ui";
 import { setCapabilityVerified } from "./actions";
 
 /**
  * Admin-only control to grant or revoke the Verified badge on a capability.
  * Rendered on the marketplace detail page only when the viewer is a Tael admin.
+ * `compact` renders a header-sized status pill + toggle; the default renders the
+ * full dashed panel.
  */
-export function VerifyToggle({ id, verified }: { id: string; verified: boolean }) {
+export function VerifyToggle({
+  id,
+  verified,
+  variant = "full",
+}: {
+  id: string;
+  verified: boolean;
+  variant?: "full" | "compact";
+}) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -22,6 +32,36 @@ export function VerifyToggle({ id, verified }: { id: string; verified: boolean }
       if (res.ok) router.refresh();
       else setError(res.error ?? "Could not update.");
     });
+  }
+
+  // Header variant: a live status pill next to a single Verify/Unverify action.
+  if (variant === "compact") {
+    return (
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium",
+            verified ? "bg-emerald-500/10 text-emerald-700" : "bg-amber-500/10 text-amber-700",
+          )}
+        >
+          <span
+            className={cn("h-1.5 w-1.5 rounded-full", verified ? "bg-emerald-500" : "bg-amber-500")}
+          />
+          {verified ? "Verified" : "Pending"}
+        </span>
+        <Button
+          variant={verified ? "outline" : "default"}
+          size="sm"
+          onClick={toggle}
+          disabled={pending}
+          className="transition-transform duration-100 ease-out active:scale-[0.97]"
+          title={error ?? undefined}
+        >
+          {verified ? null : <BadgeCheck className="h-4 w-4" />}
+          {pending ? "…" : verified ? "Unverify" : "Verify"}
+        </Button>
+      </div>
+    );
   }
 
   return (

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -30,6 +30,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "server-only": "^0.0.1",
+    "sonner": "^1.7.4",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,7 +240,7 @@ importers:
     dependencies:
       '@creit.tech/stellar-wallets-kit':
         specifier: 'catalog:'
-        version: 2.5.0(@trezor/connect@9.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(near-api-js@5.1.1)(react@19.2.7)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(utf-8-validate@6.0.6)(zod@3.25.76)
+        version: 2.5.0(@trezor/connect@9.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)))(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(near-api-js@5.1.1)(react@19.2.7)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))
       '@stellar/stellar-sdk':
         specifier: 'catalog:'
         version: 13.3.0
@@ -344,6 +344,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      sonner:
+        specifier: ^1.7.4
+        version: 1.7.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -5550,6 +5553,12 @@ packages:
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
+  sonner@1.7.4:
+    resolution: {integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -6188,6 +6197,30 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
+  '@base-org/account@2.4.0(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))':
+    dependencies:
+      '@coinbase/cdp-sdk': 1.51.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)
+      preact: 10.24.2
+      viem: 2.54.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+      zustand: 5.0.3(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.2.0(react@19.2.7))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - debug
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+    optional: true
+
   '@base-org/account@2.4.0(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@coinbase/cdp-sdk': 1.51.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -6379,6 +6412,27 @@ snapshots:
       - utf-8-validate
     optional: true
 
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)
+      preact: 10.24.2
+      viem: 2.54.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+      zustand: 5.0.3(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.2.0(react@19.2.7))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+    optional: true
+
   '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -6419,6 +6473,64 @@ snapshots:
       '@twind/preset-autoprefix': 1.0.7(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
       '@twind/preset-tailwind': 1.1.4(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
       '@walletconnect/sign-client': 2.23.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/types': 2.23.9
+      htm: 3.1.1
+      preact: 10.29.4
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@trezor/connect'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - near-api-js
+      - react
+      - supports-color
+      - tslib
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
+  '@creit.tech/stellar-wallets-kit@2.5.0(@trezor/connect@9.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)))(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(near-api-js@5.1.1)(react@19.2.7)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))':
+    dependencies:
+      '@albedo-link/intent': 0.12.0
+      '@creit.tech/xbull-wallet-connect': 0.4.0
+      '@hot-wallet/sdk': 1.0.11(bufferutil@4.1.0)(near-api-js@5.1.1)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@ledgerhq/hw-app-str': 7.2.8
+      '@ledgerhq/hw-transport': 6.31.12
+      '@ledgerhq/hw-transport-webusb': 6.29.12
+      '@lobstrco/signer-extension-api': 2.0.0
+      '@preact/signals': 2.9.0(preact@10.29.4)
+      '@reown/appkit': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))
+      '@stellar/freighter-api': 6.0.0
+      '@stellar/stellar-sdk': 16.0.1
+      '@trezor/connect-plugin-stellar': 10.0.0-alpha.1(@stellar/stellar-sdk@16.0.1)(@trezor/connect@9.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)))(tslib@2.8.1)
+      '@trezor/connect-web': 10.0.0-alpha.1(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
+      '@twind/core': 1.1.3(typescript@5.9.3)
+      '@twind/preset-autoprefix': 1.0.7(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
+      '@twind/preset-tailwind': 1.1.4(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
+      '@walletconnect/sign-client': 2.23.0(bufferutil@4.1.0)(typescript@5.9.3)
       '@walletconnect/types': 2.23.9
       htm: 3.1.1
       preact: 10.29.4
@@ -7661,6 +7773,41 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@reown/appkit-controllers@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)
+      valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
+      viem: 2.54.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@reown/appkit-controllers@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -7693,6 +7840,46 @@ snapshots:
       - react
       - typescript
       - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-pay@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)
+      '@reown/appkit-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)
+      '@reown/appkit-utils': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))
+      lit: 3.3.0
+      valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - use-sync-external-store
       - utf-8-validate
       - zod
 
@@ -7782,6 +7969,84 @@ snapshots:
       - valtio
       - zod
 
+  '@reown/appkit-scaffold-ui@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)
+      '@reown/appkit-pay': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))
+      '@reown/appkit-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)
+      '@reown/appkit-utils': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      lit: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - valtio
+      - zod
+
+  '@reown/appkit-ui@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)':
+    dependencies:
+      '@phosphor-icons/webcomponents': 2.1.5
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      lit: 3.3.0
+      qrcode: 1.5.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@reown/appkit-ui@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@phosphor-icons/webcomponents': 2.1.5
@@ -7866,6 +8131,54 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@reown/appkit-utils@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)
+      '@reown/appkit-polyfills': 1.8.21
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@wallet-standard/wallet': 1.1.0
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)
+      valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
+      viem: 2.54.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+    optionalDependencies:
+      '@base-org/account': 2.4.0(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
   '@reown/appkit-wallet@1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
@@ -7876,6 +8189,55 @@ snapshots:
       - bufferutil
       - typescript
       - utf-8-validate
+
+  '@reown/appkit@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))':
+    dependencies:
+      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)
+      '@reown/appkit-pay': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))
+      '@reown/appkit-polyfills': 1.8.21
+      '@reown/appkit-scaffold-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))
+      '@reown/appkit-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)
+      '@reown/appkit-utils': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))
+      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)
+      bs58: 6.0.0
+      semver: 7.7.2
+      valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
+      viem: 2.54.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
+    optionalDependencies:
+      '@lit/react': 1.0.8(@types/react@19.2.17)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
 
   '@reown/appkit@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.2.0(react@19.2.7))(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
@@ -8001,10 +8363,32 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)':
+    dependencies:
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    optional: true
+
   '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       events: 3.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)':
+    dependencies:
+      '@safe-global/safe-gateway-typescript-sdk': 3.23.1
+      viem: 2.54.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -9494,6 +9878,50 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.1
 
+  '@walletconnect/core@2.23.0(bufferutil@4.1.0)(typescript@5.9.3)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.0
+      '@walletconnect/utils': 2.23.0(typescript@5.9.3)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.39.3
+      events: 3.3.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/core@2.23.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
@@ -9511,6 +9939,50 @@ snapshots:
       '@walletconnect/utils': 2.23.0(typescript@5.9.3)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.39.3
+      events: 3.3.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/core@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.7
+      '@walletconnect/utils': 2.23.7(typescript@5.9.3)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.44.0
       events: 3.3.0
       uint8arrays: 3.1.1
     transitivePeerDependencies:
@@ -9684,6 +10156,42 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
+  '@walletconnect/sign-client@2.23.0(bufferutil@4.1.0)(typescript@5.9.3)':
+    dependencies:
+      '@walletconnect/core': 2.23.0(bufferutil@4.1.0)(typescript@5.9.3)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.0
+      '@walletconnect/utils': 2.23.0(typescript@5.9.3)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/sign-client@2.23.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@walletconnect/core': 2.23.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
@@ -9694,6 +10202,42 @@ snapshots:
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.0
       '@walletconnect/utils': 2.23.0(typescript@5.9.3)(zod@3.25.76)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/sign-client@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)':
+    dependencies:
+      '@walletconnect/core': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.7
+      '@walletconnect/utils': 2.23.7(typescript@5.9.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -9847,6 +10391,46 @@ snapshots:
       - ioredis
       - uploadthing
 
+  '@walletconnect/universal-provider@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/sign-client': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)
+      '@walletconnect/types': 2.23.7
+      '@walletconnect/utils': 2.23.7(typescript@5.9.3)
+      es-toolkit: 1.44.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/universal-provider@2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
@@ -9887,6 +10471,51 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/utils@2.23.0(typescript@5.9.3)':
+    dependencies:
+      '@msgpack/msgpack': 3.1.2
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.0
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.0
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      blakejs: 1.2.1
+      bs58: 6.0.0
+      detect-browser: 5.3.0
+      ox: 0.9.3(typescript@5.9.3)
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - zod
+
   '@walletconnect/utils@2.23.0(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@msgpack/msgpack': 3.1.2
@@ -9908,6 +10537,50 @@ snapshots:
       bs58: 6.0.0
       detect-browser: 5.3.0
       ox: 0.9.3(typescript@5.9.3)(zod@3.25.76)
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - zod
+
+  '@walletconnect/utils@2.23.7(typescript@5.9.3)':
+    dependencies:
+      '@msgpack/msgpack': 3.1.3
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.7
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      blakejs: 1.2.1
+      detect-browser: 5.3.0
+      ox: 0.9.3(typescript@5.9.3)
       uint8arrays: 3.1.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -11473,6 +12146,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.6.9(typescript@5.9.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@3.22.4)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+    optional: true
+
   ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -11487,6 +12175,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
     optional: true
+
+  ox@0.9.3(typescript@5.9.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@3.22.4)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
 
   ox@0.9.3(typescript@5.9.3)(zod@3.25.76):
     dependencies:
@@ -12002,6 +12705,11 @@ snapshots:
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
+
+  sonner@1.7.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
Redesigns the capability detail page's operations section per the UI feedback: the stacked "Requests" cards + per-op **modal** are replaced by an **expandable table** with **inline run** and a **live result panel on the right**.

### What changed
- **Expandable table** — click a row (chevron rotates) to open its params + sample inline. Clean table look, built on the existing `@tael/ui` (no second UI library, matches the app's black/white style).
- **Inline run** — edit the request, hit Run/Pay & run, the **live result renders on the right**, pretty-printed + scrollable (fixes the overflowing single-line JSON).
- **Shared card picker** above the table; a row's Run is disabled with a reason when the selected card can't cover a paid call.
- **Toasts** (`sonner`) on success/failure.
- Motion per the design rules: ease-out expand, chevron rotate, press feedback (`active:scale`), spinner while paying, `tabular-nums`.

### Under the hood
- New `OperationsExplorer` client component; reuses the existing `runCapability` server action (query params for GET, body otherwise) — the paid **402 → sign → settle** flow is unchanged.
- `sonner` added (+ `<Toaster/>` in Providers); **lockfile committed** with the dep.
- Removes the now-unused `CodeBlock` helper and the per-op run modal on this page.

Verified: dashboard typecheck ✓, build ✓, prettier ✓.

Note: the header **Run with card** modal is left as-is (capability-level quick action) — happy to remove it too now that inline run exists, if you prefer.