### PR TITLE
content(web): honest homepage hero subhead

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -95,7 +95,7 @@ export default function HomePage() {
               For AI agents.
             </h1>
             <p className="max-w-[430px] text-[18px] font-normal leading-[26px] tracking-[-0.035em] text-white">
-              Pay for every API you use. 100 apps and 3000 actions, all in one platform.
+              Pay per call in USDC. No keys, no accounts, no subscriptions.
             </p>
           </div>
 


### PR DESCRIPTION
One-line fix: the hero subhead claimed **"100 apps and 3000 actions"** which is not true. Replaced with the honest differentiator:

> Pay per call in USDC. No keys, no accounts, no subscriptions.

Homepage design otherwise unchanged (orbit, gradient, waitlist, headline all as-is).