### PR TITLE
feat: Pay action — agents send USDC from their card (the moat)

### DIFF
--- a/apps/capabilities/src/capabilities/stellar/capability.ts
+++ b/apps/capabilities/src/capabilities/stellar/capability.ts
@@ -9,7 +9,7 @@ export const meta: CapabilityMeta = {
   name: "Stellar",
   kind: "api",
   description:
-    "Stellar lookups for AI agents: account balances, account details, settled transactions, asset info, network status, DEX orderbook, recent trades, and account payments (all free), plus quote (best-price swaps), explain (plain-English transactions), and portfolio (USDC valuation) — priced per call.",
+    "Stellar for AI agents: account balances, account details, settled transactions, asset info, network status, DEX orderbook, recent trades, and account payments (all free), plus quote (best-price swaps), explain (plain-English transactions), and portfolio (USDC valuation) priced per call — and pay, an action that sends USDC from the agent's own card.",
   faqs: [
     {
       question: "Which network does this read from?",

--- a/apps/capabilities/src/capabilities/stellar/operations/pay.ts
+++ b/apps/capabilities/src/capabilities/stellar/operations/pay.ts
@@ -1,0 +1,40 @@
+import type { Operation } from "../../../types";
+import { isStellarAddress } from "../horizon";
+import { buildPayIntent } from "../pay";
+
+/**
+ * GET /stellar/pay?to=G…&amount=1.5 — an ACTION. It returns an intent for the
+ * caller's Tael Card to sign and submit (send USDC to `to`), not data. Free to
+ * call; the money moves when the Card signs. The response is safe to fetch — it
+ * only validates and describes the payment, it never signs or submits.
+ */
+export const operation: Operation = {
+  name: "Pay",
+  path: "/stellar/pay",
+  method: "GET",
+  price: "0",
+  sampleRequest: "to=<stellar-account-address>&amount=1.5",
+  sampleResponse: `{ "tael_action": "pay", "asset": "USDC", "to": "G…", "amount": "1.5", "summary": "Pay 1.5 USDC to G…" }`,
+  handler: async (c) => {
+    const to = c.req.query("to") ?? "";
+    const amount = c.req.query("amount") ?? "";
+    const memo = c.req.query("memo") || undefined;
+    if (!isStellarAddress(to)) {
+      return c.json({ error: "Provide a valid destination address" }, 400);
+    }
+    if (!(Number(amount) > 0)) {
+      return c.json({ error: "Provide a positive amount" }, 400);
+    }
+    if (memo && memo.length > 28) {
+      return c.json({ error: "Memo must be at most 28 characters" }, 400);
+    }
+    try {
+      return c.json(await buildPayIntent(to, amount, memo));
+    } catch (err) {
+      return c.json(
+        { error: err instanceof Error ? err.message : "Could not prepare the payment" },
+        422,
+      );
+    }
+  },
+};

--- a/apps/capabilities/src/capabilities/stellar/pay.ts
+++ b/apps/capabilities/src/capabilities/stellar/pay.ts
@@ -1,0 +1,61 @@
+// The Pay action: validate a USDC payment against Horizon and return an "action
+// intent" for the caller's Card to sign + submit. This endpoint NEVER holds a
+// key and never moves money — it only checks the payment can succeed (the
+// destination exists and trusts USDC) and describes what to sign. The buy-side
+// (a funded Tael Card) builds the transaction from these validated params, adds
+// Tael's fee, signs once, and submits. See the dashboard runCapability action
+// branch.
+
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+const NETWORK = process.env.STELLAR_NETWORK === "mainnet" ? "stellar" : "stellar-testnet";
+const USDC_ISSUER =
+  process.env.USDC_ISSUER ?? "GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+
+export interface PayIntent {
+  /** Discriminator the buy-side uses to switch into sign-and-submit mode. */
+  tael_action: "pay";
+  network: string;
+  asset: "USDC";
+  to: string;
+  amount: string;
+  memo?: string;
+  summary: string;
+}
+
+interface HorizonBalance {
+  asset_code?: string;
+  asset_issuer?: string;
+}
+
+function short(a: string): string {
+  return `${a.slice(0, 4)}…${a.slice(-4)}`;
+}
+
+/**
+ * Validate a USDC payment and return the intent to sign. Throws with a caller-
+ * facing message if the payment could not succeed on-chain.
+ */
+export async function buildPayIntent(
+  to: string,
+  amount: string,
+  memo?: string,
+): Promise<PayIntent> {
+  const res = await fetch(`${HORIZON_URL}/accounts/${to}`, {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) throw new Error("Destination account not found or not funded");
+  const account = (await res.json()) as { balances?: HorizonBalance[] };
+  const trustsUsdc = (account.balances ?? []).some(
+    (b) => b.asset_code === "USDC" && b.asset_issuer === USDC_ISSUER,
+  );
+  if (!trustsUsdc) throw new Error("Destination has no USDC trustline");
+  return {
+    tael_action: "pay",
+    network: NETWORK,
+    asset: "USDC",
+    to,
+    amount,
+    ...(memo ? { memo } : {}),
+    summary: `Pay ${amount} USDC to ${short(to)}`,
+  };
+}

--- a/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/marketplace/[slug]/page.tsx
@@ -193,6 +193,9 @@ export default async function CapabilityDetailPage({
             priceRaw: op.price ?? "0",
             sampleRequest: op.sampleRequest ?? "",
             sampleResponse: op.sampleResponse ?? "",
+            // Action ops return a `tael_action` intent to sign, not data — mark
+            // them so they read as "Action", never "Free".
+            isAction: (op.sampleResponse ?? "").includes("tael_action"),
           }))}
         />
       ) : null}

--- a/apps/dashboard/features/agents/operations-explorer.tsx
+++ b/apps/dashboard/features/agents/operations-explorer.tsx
@@ -35,6 +35,9 @@ export interface ExplorerOperation {
   priceRaw: string;
   sampleRequest: string;
   sampleResponse: string;
+  /** An on-chain action (signs + sends from the card) rather than a data read.
+   *  The call itself is free, but it moves funds — so it must not read "Free". */
+  isAction?: boolean;
 }
 
 /**
@@ -172,6 +175,7 @@ function OperationRow({
   const isGet = method === "GET" || method === "HEAD";
   const priceNum = Number(op.priceRaw);
   const paid = priceNum > 0;
+  const action = op.isAction ?? false;
 
   const [input, setInput] = useState(op.sampleRequest);
   const [result, setResult] = useState<RunResult | null>(null);
@@ -241,7 +245,11 @@ function OperationRow({
         </span>
 
         <span className="text-right text-sm tabular-nums">
-          {paid ? (
+          {action ? (
+            <span className="rounded-md bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
+              Action
+            </span>
+          ) : paid ? (
             <>
               <span className="font-semibold">${op.price}</span>
               <span className="text-xs font-normal text-muted-foreground"> USDC</span>
@@ -278,7 +286,7 @@ function OperationRow({
             <span className="h-3 w-3 animate-spin rounded-full border-2 border-background/40 border-t-background" />
           ) : (
             <>
-              <Play className="h-3 w-3" /> {paid ? "Pay" : "Run"}
+              <Play className="h-3 w-3" /> {action ? "Send" : paid ? "Pay" : "Run"}
             </>
           )}
         </span>
@@ -303,7 +311,12 @@ function OperationRow({
               />
             </label>
             <p className="text-xs text-muted-foreground">
-              {paid ? (
+              {action ? (
+                <>
+                  Moves funds from your card. It signs and sends on-chain — use{" "}
+                  <span className="font-medium text-foreground">Send</span> above.
+                </>
+              ) : paid ? (
                 <>
                   Costs{" "}
                   <span className="font-medium tabular-nums text-foreground">${op.price} USDC</span>

--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -11,7 +11,7 @@ import {
   wallets,
 } from "@tael/database";
 import { Money } from "@tael/types";
-import { buildSignedPayment, TAEL_MEMO } from "@tael/stellar";
+import { buildSignedPayment, createStellarSettlement, TAEL_MEMO } from "@tael/stellar";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "../capabilities/current-user";
 import { fetchUsdcBalance } from "./balance";
@@ -23,6 +23,11 @@ const STELLAR_NETWORK = process.env.STELLAR_NETWORK === "mainnet" ? "mainnet" : 
 // balance check below then behaves exactly as it did before this change.
 const TRUSTLINE_API = process.env.TRUSTLINE_API;
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+// Action settlement config (the Pay action and future on-chain actions).
+const USDC_ISSUER =
+  process.env.USDC_ISSUER ?? "GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+const FEE_ADDRESS = process.env.TAEL_FEE_ADDRESS ?? "";
+const ACTION_FEE = process.env.TAEL_ACTION_FEE ?? "0.001";
 
 interface Requirement {
   network: string;
@@ -151,6 +156,11 @@ export async function runCapability(input: {
       if (!direct.ok) {
         return { ok: false, status: direct.status, body, error: friendlyError(direct.status) };
       }
+      // Action ops return a `tael_action` intent to SIGN, not data. If we get
+      // one, the agent's card signs it and submits it on-chain (with Tael's fee
+      // baked into the same transaction), after enforcing the spending policy.
+      const intent = parsePayIntent(body);
+      if (intent) return runPayAction(intent, agent.address, agent.policy, secretEnc);
       return { ok: true, status: direct.status, body, paid: "0" };
     }
     const body = (await res.json()) as { accepts: Requirement[] };
@@ -261,4 +271,99 @@ function friendlyError(status: number): string {
   if (status === 404) return "This capability is no longer available.";
   if (status >= 500) return "The agent couldn't pay, or the upstream API is down. Try again.";
   return `The call failed (${status}).`;
+}
+
+/** The validated Pay intent an action capability returns to be signed. */
+interface PayIntent {
+  to: string;
+  amount: string;
+  memo?: string;
+}
+
+/** Parse a capability response into a Pay intent, or null if it isn't an action. */
+function parsePayIntent(body: string): PayIntent | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const p = parsed as Record<string, unknown>;
+  if (p.tael_action !== "pay") return null;
+  if (typeof p.to !== "string" || typeof p.amount !== "string") return null;
+  return { to: p.to, amount: p.amount, memo: typeof p.memo === "string" ? p.memo : undefined };
+}
+
+/**
+ * Execute a Pay action: enforce the spending policy, build ONE USDC transaction
+ * (the payment + Tael's fee), sign it with the agent's card, and submit it. The
+ * action and the fee settle atomically — the fee is another leg in the same tx.
+ */
+async function runPayAction(
+  intent: PayIntent,
+  address: string,
+  policy: { maxPerCall: string; dailyLimit: string } | null,
+  secretEnc: string,
+): Promise<RunResult> {
+  const amount = Money.parse(intent.amount);
+  const fee = FEE_ADDRESS ? Money.parse(ACTION_FEE) : Money.parse("0");
+  const total = amount.add(fee);
+
+  // Enforce the spending policy BEFORE signing — same gates as a paid call.
+  if (policy) {
+    if (total.isGreaterThan(Money.parse(policy.maxPerCall))) {
+      return {
+        ok: false,
+        error: `Over the per-call cap ($${total.toDecimalString()} > $${policy.maxPerCall}).`,
+      };
+    }
+    const projected = (await spentLast24h(address)).add(total);
+    if (projected.isGreaterThan(Money.parse(policy.dailyLimit))) {
+      return { ok: false, error: `Would exceed the daily limit of $${policy.dailyLimit}.` };
+    }
+  }
+
+  // Must actually hold enough USDC to cover the payment + fee.
+  const { usdc } = await fetchUsdcBalance(address);
+  if (total.isGreaterThan(Money.parse(usdc))) {
+    return {
+      ok: false,
+      error: `Not enough USDC. This card has $${usdc}, the payment needs $${total.toDecimalString()}. Fund it first.`,
+    };
+  }
+
+  try {
+    const legs = [{ to: intent.to, amount: intent.amount }];
+    if (FEE_ADDRESS) legs.push({ to: FEE_ADDRESS, amount: ACTION_FEE });
+    const xdr = await buildSignedPayment({
+      secret: decryptSecret(secretEnc),
+      network: STELLAR_NETWORK,
+      horizonUrl: HORIZON_URL,
+      usdcIssuer: USDC_ISSUER,
+      legs,
+      memo: TAEL_MEMO,
+    });
+    const receipt = await createStellarSettlement({
+      network: STELLAR_NETWORK,
+      horizonUrl: HORIZON_URL,
+      usdcIssuer: USDC_ISSUER,
+    }).submitSignedTransaction(xdr);
+    const result = {
+      action: "pay",
+      to: intent.to,
+      amount: intent.amount,
+      fee: FEE_ADDRESS ? ACTION_FEE : "0",
+      asset: "USDC",
+      txHash: receipt.txHash,
+    };
+    return { ok: true, status: 200, body: JSON.stringify(result), paid: total.toDecimalString() };
+  } catch (error) {
+    console.error("[run] pay action failed:", error);
+    return {
+      ok: false,
+      error:
+        "The payment couldn't be submitted. Check the card is funded and the destination trusts USDC.",
+    };
+  }
 }


### PR DESCRIPTION
The first on-chain **action** (not a read), and the reusable **signing pipeline** Swap/Trustline will build on.

### Flow
1. `/stellar/pay?to=G…&amount=1.5` (capabilities) validates against Horizon (destination exists + trusts USDC) and returns a **`tael_action` intent** to sign. It never holds a key or moves money.
2. Buy-side (`runCapability`): a `tael_action` response → the agent's **card signs ONE USDC tx** (the payment + Tael's fee as a 2nd leg) and **submits** it — action + fee **atomic**. Spending caps enforced **before** signing.
3. UI: action ops read **"Action"** (not "Free"), the button says **"Send"**, and the panel notes it moves funds on-chain.

### Verified
- Endpoint locally: valid pay → `200` intent; bad addr → `400`; zero amount → `400`; no USDC trustline → `422`.
- Both apps typecheck ✓.

### To test the full on-chain send (after merge)
1. Merge → Render redeploys capabilities with `/stellar/pay`.
2. Republish so the Stellar manifest includes the `pay` op (gateway routes `/c/stellar/pay`).
3. Dashboard → Stellar → **Pay** → enter `to` + `amount` → **Send** → card signs + sends real testnet USDC, returns the tx hash.

### Notes
- USDC-only for v1 (caps are USDC-denominated). Any-asset + Swap next.
- Env: `TAEL_FEE_ADDRESS` (fee leg; if unset, payment sends with no fee), `USDC_ISSUER` + `TAEL_ACTION_FEE` have safe defaults.