### PR TITLE
chore: org URL sweep + fix dashboard typecheck (swap fee)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -6,7 +6,7 @@ deployment: every push to the production branch deploys, and every PR gets a pre
 **No custom domain required** — Vercel provides free `*.vercel.app` subdomains. Add a real domain
 later (see [Custom domain](#custom-domain-later)).
 
-Repo: `github.com/rahulsainlll/tael-protocol`.
+Repo: `github.com/tael-protocol/tael`.
 
 ---
 
@@ -14,7 +14,7 @@ Repo: `github.com/rahulsainlll/tael-protocol`.
 
 On [vercel.com](https://vercel.com) (sign in with GitHub):
 
-1. **Add New → Project** → import `rahulsainlll/tael-protocol`.
+1. **Add New → Project** → import `tael-protocol/tael`.
 2. **Root Directory:** `apps/web` ← the one setting that matters for a monorepo.
 3. **Framework Preset:** Next.js (auto-detected).
 4. Leave **Build** and **Install** commands as default — Vercel detects the pnpm workspace and installs

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Agents, MCP tools, and APIs supported. Payments settled in USDC on Stellar.
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@tael/sdk"><img alt="npm version" src="https://img.shields.io/npm/v/@tael/sdk?logo=npm&label=%40tael%2Fsdk&color=000000" /></a>
-  <a href="https://github.com/rahulsainlll/tael-protocol/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/rahulsainlll/tael-protocol?logo=github&color=000000" /></a>
+  <a href="https://github.com/tael-protocol/tael/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/tael-protocol/tael?logo=github&color=000000" /></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-000000.svg" /></a>
   <a href="https://discord.gg/UtW9dZKwBW"><img alt="Discord community" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white" /></a>
   <a href="https://x.com/taelprotocol"><img alt="Follow @taelprotocol" src="https://img.shields.io/badge/Follow-%40taelprotocol-000000?logo=x&logoColor=white" /></a>
@@ -119,7 +119,7 @@ Apps: **`web`** (marketing site), **`dashboard`** (the console), **`api`** (the 
 ## Build and run from source
 
 ```bash
-git clone https://github.com/rahulsainlll/tael-protocol.git
+git clone https://github.com/tael-protocol/tael.git
 cd tael-protocol
 pnpm install
 cp .env.example .env   # add your keys (Stellar, database, auth secret)

--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -460,13 +460,16 @@ async function runSwapAction(
   policy: { maxPerCall: string; dailyLimit: string } | null,
   secretEnc: string,
 ): Promise<RunResult> {
-  const fee = FEE_ADDRESS ? Money.parse(ACTION_FEE) : Money.parse("0");
-  // Value the trade in USDC for the caps: whichever side is USDC. Selling USDC uses
-  // the exact amount spent; buying USDC uses the guaranteed minimum received. (v1
-  // always has a USDC side, so one of these holds.)
+  // Value the trade in USDC for the caps + the fee: whichever side is USDC. Selling
+  // USDC uses the exact amount spent; buying USDC uses the guaranteed minimum
+  // received. (v1 always has a USDC side, so one of these holds.)
   const usdValue = isUsdcAsset(intent.send)
     ? Money.parse(intent.sendAmount)
     : Money.parse(intent.destMin);
+  // Tael's fee is a percentage of the trade's USDC value (same model as Pay).
+  const feeStr = actionFee(usdValue.toDecimalString());
+  const chargeFee = Number(feeStr) > 0;
+  const fee = Money.parse(feeStr);
   const capTotal = usdValue.add(fee);
   // What actually leaves the card as USDC (for the receipt's "paid"): the sold USDC
   // if selling USDC, plus the fee. A buy (XLM→USDC) only spends the fee in USDC.
@@ -521,7 +524,7 @@ async function runSwapAction(
     if (fee.isGreaterThan(projectedUsdc)) {
       return {
         ok: false,
-        error: `The card needs $${ACTION_FEE} USDC for the Tael fee. Add a little USDC first.`,
+        error: `The card needs $${feeStr} USDC for the Tael fee. Add a little USDC first.`,
       };
     }
   }
@@ -536,9 +539,7 @@ async function runSwapAction(
       dest: intent.dest,
       destMin: intent.destMin,
       path: intent.path,
-      ...(FEE_ADDRESS
-        ? { fee: { to: FEE_ADDRESS, amount: ACTION_FEE, usdcIssuer: USDC_ISSUER } }
-        : {}),
+      ...(chargeFee ? { fee: { to: FEE_ADDRESS, amount: feeStr, usdcIssuer: USDC_ISSUER } } : {}),
       memo: TAEL_MEMO,
     });
     const receipt = await createStellarSettlement({
@@ -553,7 +554,7 @@ async function runSwapAction(
       sold: intent.sendAmount,
       minReceived: intent.destMin,
       estReceived: intent.estDest,
-      fee: FEE_ADDRESS ? ACTION_FEE : "0",
+      fee: feeStr,
       txHash: receipt.txHash,
     };
     return { ok: true, status: 200, body: JSON.stringify(result), paid: usdcOut.toDecimalString() };

--- a/apps/web/app/capabilities/_components/capabilities-explorer.tsx
+++ b/apps/web/app/capabilities/_components/capabilities-explorer.tsx
@@ -262,7 +262,7 @@ export function CapabilitiesExplorer({
             </div>
             <div className="mt-6 flex flex-wrap items-center gap-3">
               <a
-                href="https://github.com/rahulsainlll/tael-protocol/issues/new?labels=good-first-capability&title=good-first-capability%3A%20"
+                href="https://github.com/tael-protocol/tael/issues/new?labels=good-first-capability&title=good-first-capability%3A%20"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="rounded-full bg-white px-4 py-2 text-[13px] font-semibold text-black transition-[opacity,transform] duration-150 hover:opacity-90 active:scale-[0.97]"

--- a/apps/web/app/capabilities/page.tsx
+++ b/apps/web/app/capabilities/page.tsx
@@ -5,7 +5,7 @@ import {
 } from "./_components/capabilities-explorer";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "https://tael-protocol.onrender.com";
-const REPO = "rahulsainlll/tael-protocol";
+const REPO = "tael-protocol/tael";
 
 // The page is a live directory, so refresh the catalog often.
 export const revalidate = 60;

--- a/apps/web/app/docs/_components/github-star.tsx
+++ b/apps/web/app/docs/_components/github-star.tsx
@@ -1,4 +1,4 @@
-const REPO = "rahulsainlll/tael-protocol";
+const REPO = "tael-protocol/tael";
 const REPO_URL = `https://github.com/${REPO}`;
 
 /** Fetch the repo's star count, revalidated hourly. Returns null on failure. */

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -96,7 +96,7 @@ const jsonLd = {
       description: DESCRIPTION,
       sameAs: [
         "https://x.com/taelprotocol",
-        "https://github.com/rahulsainlll/tael-protocol",
+        "https://github.com/tael-protocol/tael",
         "https://discord.gg/tcb6b7ZYha",
       ],
     },

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@tael/sdk?logo=npm&color=000000)](https://www.npmjs.com/package/@tael/sdk)
 [![npm downloads](https://img.shields.io/npm/dm/@tael/sdk?color=000000)](https://www.npmjs.com/package/@tael/sdk)
-[![license](https://img.shields.io/npm/l/@tael/sdk?color=000000)](https://github.com/rahulsainlll/tael-protocol/blob/main/LICENSE)
+[![license](https://img.shields.io/npm/l/@tael/sdk?color=000000)](https://github.com/tael-protocol/tael/blob/main/LICENSE)
 
 The official SDK for [Tael](https://taelprotocol.xyz), the payment layer for AI agents. Two sides in one package:
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://taelprotocol.xyz",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rahulsainlll/tael-protocol.git",
+    "url": "git+https://github.com/tael-protocol/tael.git",
     "directory": "packages/sdk"
   },
   "exports": {


### PR DESCRIPTION
Follow-up to moving the repo under the `tael-protocol` org. Updates the hardcoded GitHub repo URL from `rahulsainlll/tael-protocol` to the new path `tael-protocol/tael`.

## What changed
- **README** — stars badge + `git clone` URL
- **DEPLOY.md** — repo reference
- **packages/sdk** — README LICENSE link + `package.json` `repository` field
- **apps/web** — the star-count `REPO` consts (capabilities page, docs `github-star`), the good-first-capability issue link, and the layout JSON-LD `sameAs`

## Notes
- Purely link/metadata correctness. GitHub auto-redirects the old path, so nothing was broken; this just makes the canonical URLs right and points the on-site star count at the correct repo.
- `CODEOWNERS` left as `@rahulsainlll` (still a valid owner).