### PR TITLE
chore: declare web app env vars in turbo.json globalEnv

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,16 @@
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
   "globalDependencies": ["**/.env", "tsconfig.json"],
-  "globalEnv": ["NODE_ENV"],
+  "globalEnv": [
+    "NODE_ENV",
+    "OPENROUTER_API_KEY",
+    "OPENROUTER_MODEL",
+    "RESEND_API_KEY",
+    "WAITLIST_NOTIFY_EMAIL",
+    "WAITLIST_FROM_EMAIL",
+    "AGENT_NOTIFY_EMAIL",
+    "NEXT_PUBLIC_TAEL_BOOKING_URL"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Declares the web app's env vars in `turbo.json` `globalEnv` so Turbo tracks them as build inputs.

## Why
Vercel warned these project env vars are set but missing from `turbo.json`:
`OPENROUTER_API_KEY`, `RESEND_API_KEY`, `WAITLIST_NOTIFY_EMAIL`, `WAITLIST_FROM_EMAIL`. Undeclared env vars aren't part of Turbo's cache key, so a build can be served from a stale cache that doesn't reflect them — which is what dropped `/api/agent` from a production build (the widget UI deployed, the route 404'd). Declaring them silences the warning and keeps the cache honest.

## Change
`globalEnv`: adds `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `RESEND_API_KEY`, `WAITLIST_NOTIFY_EMAIL`, `WAITLIST_FROM_EMAIL`, `AGENT_NOTIFY_EMAIL`, `NEXT_PUBLIC_TAEL_BOOKING_URL`.

Config-only, no code change.