### PR TITLE
feat(dashboard,web): payout guide + Mainnet signage

### DIFF
--- a/apps/capabilities/src/capabilities/stellar/capability.ts
+++ b/apps/capabilities/src/capabilities/stellar/capability.ts
@@ -13,7 +13,8 @@ export const meta: CapabilityMeta = {
   faqs: [
     {
       question: "Which network does this read from?",
-      answer: "The Stellar network Tael is running on (testnet today).",
+      answer:
+        "The Stellar network this listing targets. Tael is live on mainnet, with a testnet build for development.",
     },
     {
       question: "Which operations cost money?",

--- a/apps/dashboard/components/app-shell/payout-guide-link.tsx
+++ b/apps/dashboard/components/app-shell/payout-guide-link.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Wallet } from "lucide-react";
+import { Button } from "@tael/ui";
+
+/** Where the publisher-facing payout guide lives (marketing site docs). */
+const PAYOUT_DOCS_URL = "https://taelprotocol.xyz/docs/payouts";
+
+/**
+ * A quiet link to the payout guide, shown on the capabilities pages, where a
+ * publisher is most likely to wonder how earnings reach their wallet. Sits just
+ * left of the theme toggle in the topbar.
+ */
+export function PayoutGuideLink() {
+  const pathname = usePathname();
+  if (!pathname?.includes("/capabilities")) return null;
+
+  return (
+    <Button asChild variant="ghost" size="sm" className="text-muted-foreground">
+      <a href={PAYOUT_DOCS_URL} target="_blank" rel="noopener noreferrer">
+        <Wallet />
+        Payout setup
+      </a>
+    </Button>
+  );
+}

--- a/apps/dashboard/components/app-shell/sidebar.tsx
+++ b/apps/dashboard/components/app-shell/sidebar.tsx
@@ -22,6 +22,10 @@ import {
 import { navGroups } from "../../features/navigation/nav.config";
 import { TaelLogo } from "../logo";
 
+/** Which Stellar network this dashboard runs against (build-time env). */
+const IS_MAINNET = process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet";
+const NETWORK_LABEL = IS_MAINNET ? "Mainnet" : "Testnet";
+
 function isActive(pathname: string, href: string): boolean {
   return href === "/" ? pathname === "/" : pathname.startsWith(href);
 }
@@ -36,6 +40,21 @@ function BetaBadge({ className }: { className?: string }) {
       )}
     >
       Beta
+    </span>
+  );
+}
+
+/** Mainnet pill next to the wordmark. Only shown on mainnet, where it signals
+ *  that calls move real USDC. */
+function MainnetBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-600 dark:bg-emerald-400/15 dark:text-emerald-400",
+        className,
+      )}
+    >
+      Mainnet
     </span>
   );
 }
@@ -85,6 +104,7 @@ export function AppSidebar({ address }: { address: string | null }) {
             t
           </span>
           <BetaBadge className="group-data-[collapsible=icon]:hidden" />
+          {IS_MAINNET ? <MainnetBadge className="group-data-[collapsible=icon]:hidden" /> : null}
         </Link>
       </SidebarHeader>
 
@@ -130,7 +150,7 @@ export function AppSidebar({ address }: { address: string | null }) {
                   <span className="truncate font-mono text-sm font-medium">
                     {address ? truncateAddress(address) : "Not connected"}
                   </span>
-                  <span className="truncate text-xs text-sidebar-foreground/70">Testnet</span>
+                  <span className="truncate text-xs text-sidebar-foreground/70">{NETWORK_LABEL}</span>
                 </span>
               </Link>
             </SidebarMenuButton>

--- a/apps/dashboard/components/app-shell/sidebar.tsx
+++ b/apps/dashboard/components/app-shell/sidebar.tsx
@@ -150,7 +150,9 @@ export function AppSidebar({ address }: { address: string | null }) {
                   <span className="truncate font-mono text-sm font-medium">
                     {address ? truncateAddress(address) : "Not connected"}
                   </span>
-                  <span className="truncate text-xs text-sidebar-foreground/70">{NETWORK_LABEL}</span>
+                  <span className="truncate text-xs text-sidebar-foreground/70">
+                    {NETWORK_LABEL}
+                  </span>
                 </span>
               </Link>
             </SidebarMenuButton>

--- a/apps/dashboard/components/app-shell/topbar.tsx
+++ b/apps/dashboard/components/app-shell/topbar.tsx
@@ -1,11 +1,15 @@
 import { SidebarTrigger } from "@tael/ui";
 import { ThemeToggle } from "./theme-toggle";
+import { PayoutGuideLink } from "./payout-guide-link";
 
 export function Topbar() {
   return (
     <header className="sticky top-0 z-20 flex h-14 items-center justify-between gap-3 border-b bg-background/80 px-4 backdrop-blur sm:px-6">
       <SidebarTrigger />
-      <ThemeToggle />
+      <div className="flex items-center gap-1">
+        <PayoutGuideLink />
+        <ThemeToggle />
+      </div>
     </header>
   );
 }

--- a/apps/web/app/docs/_components/docs-sidebar.tsx
+++ b/apps/web/app/docs/_components/docs-sidebar.tsx
@@ -21,7 +21,10 @@ export const SECTIONS = [
   },
   {
     title: "Partners",
-    items: [{ label: "Become a capability", href: "/docs/become-a-capability" }],
+    items: [
+      { label: "Become a capability", href: "/docs/become-a-capability" },
+      { label: "Get paid", href: "/docs/payouts" },
+    ],
   },
   {
     title: "SDKs",

--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -31,12 +31,17 @@ export default function DocsLayout({ children }: { children: ReactNode }) {
       {/* Top nav */}
       <header className="sticky top-0 z-40 border-b border-line bg-white/90 backdrop-blur dark:border-white/10 dark:bg-[#0a0a0a]/90">
         <div className="flex h-14 items-center gap-8 px-6">
-          <a href="/" className="flex items-center gap-1">
-            <span className="font-display text-[20px] leading-none text-accent">t</span>
-            <span className="text-[20px] font-medium tracking-[0.01em] text-black dark:text-white">
-              tael
+          <div className="flex items-center gap-2">
+            <a href="/" className="flex items-center gap-1">
+              <span className="font-display text-[20px] leading-none text-accent">t</span>
+              <span className="text-[20px] font-medium tracking-[0.01em] text-black dark:text-white">
+                tael
+              </span>
+            </a>
+            <span className="inline-flex items-center rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-600 dark:bg-emerald-400/15 dark:text-emerald-400">
+              Mainnet
             </span>
-          </a>
+          </div>
 
           <nav className="hidden items-center gap-6 md:flex">
             {TABS.map((tab) => (

--- a/apps/web/app/docs/payouts/page.tsx
+++ b/apps/web/app/docs/payouts/page.tsx
@@ -17,13 +17,13 @@ export default function PayoutsPage() {
     >
       <H2 id="how">How you get paid</H2>
       <P>
-        When an agent pays for your capability, Tael settles the USDC to your payout wallet in the same
-        request. The builder share and the Tael fee move on-chain atomically: either both land or
-        neither does. There are no invoices, no monthly payouts, and no waiting.
+        When an agent pays for your capability, Tael settles the USDC to your payout wallet in the
+        same request. The builder share and the Tael fee move on-chain atomically: either both land
+        or neither does. There are no invoices, no monthly payouts, and no waiting.
       </P>
       <P>
-        Your payout wallet is just a Stellar address you control. You set it as <Code>payTo</Code> when
-        you publish, and you can reuse one wallet across every capability you sell.
+        Your payout wallet is just a Stellar address you control. You set it as <Code>payTo</Code>{" "}
+        when you publish, and you can reuse one wallet across every capability you sell.
       </P>
 
       <H2 id="trustline">Add a USDC trustline</H2>
@@ -32,9 +32,7 @@ export default function PayoutsPage() {
         Stellar rule, not a Tael setting: an account cannot hold an asset without first trusting its
         issuer. Without the trustline, a payout cannot settle and the paid call fails.
       </Callout>
-      <P>
-        Add a trustline to the USDC issuer for the network you are getting paid on:
-      </P>
+      <P>Add a trustline to the USDC issuer for the network you are getting paid on:</P>
       <CodeBlock
         title="USDC issuers"
         lang="bash"
@@ -61,8 +59,8 @@ USDC:GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA`}
       <H2 id="xlm">Fund the wallet with XLM</H2>
       <P>
         A Stellar account needs a small XLM balance to exist and to hold a trustline: about{" "}
-        <Code>1 XLM</Code> base reserve plus <Code>0.5 XLM</Code> per trustline. This XLM is a reserve,
-        not a fee, it stays in your account.
+        <Code>1 XLM</Code> base reserve plus <Code>0.5 XLM</Code> per trustline. This XLM is a
+        reserve, not a fee, it stays in your account.
       </P>
       <Ul>
         <li>
@@ -76,13 +74,14 @@ USDC:GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA`}
 
       <H2 id="payto">Use it as your payout wallet</H2>
       <P>
-        When you publish a capability, set this wallet as <Code>payTo</Code>. Every settled call then
-        pays you there instantly. See <A href="/docs/become-a-capability">Become a capability</A> for
-        the full publish flow.
+        When you publish a capability, set this wallet as <Code>payTo</Code>. Every settled call
+        then pays you there instantly. See{" "}
+        <A href="/docs/become-a-capability">Become a capability</A> for the full publish flow.
       </P>
       <Callout>
-        On mainnet, <Code>payTo</Code> must be the mainnet wallet that holds the Circle USDC trustline.
-        A wallet without the trustline will reject payouts, so set this up before you go live.
+        On mainnet, <Code>payTo</Code> must be the mainnet wallet that holds the Circle USDC
+        trustline. A wallet without the trustline will reject payouts, so set this up before you go
+        live.
       </Callout>
     </DocPage>
   );

--- a/apps/web/app/docs/payouts/page.tsx
+++ b/apps/web/app/docs/payouts/page.tsx
@@ -1,0 +1,89 @@
+import { A, Callout, Code, CodeBlock, DocPage, H2, P, Ul } from "../_components/doc-page";
+
+const TOC = [
+  { label: "How you get paid", href: "#how" },
+  { label: "Add a USDC trustline", href: "#trustline" },
+  { label: "Fund the wallet with XLM", href: "#xlm" },
+  { label: "Use it as your payout wallet", href: "#payto" },
+];
+
+export default function PayoutsPage() {
+  return (
+    <DocPage
+      eyebrow="Partners"
+      title="Get paid"
+      lead="Every paid call settles USDC straight to your Stellar wallet. Here is the one-time setup so it can arrive."
+      toc={TOC}
+    >
+      <H2 id="how">How you get paid</H2>
+      <P>
+        When an agent pays for your capability, Tael settles the USDC to your payout wallet in the same
+        request. The builder share and the Tael fee move on-chain atomically: either both land or
+        neither does. There are no invoices, no monthly payouts, and no waiting.
+      </P>
+      <P>
+        Your payout wallet is just a Stellar address you control. You set it as <Code>payTo</Code> when
+        you publish, and you can reuse one wallet across every capability you sell.
+      </P>
+
+      <H2 id="trustline">Add a USDC trustline</H2>
+      <Callout>
+        To receive USDC, your payout wallet must hold a <strong>USDC trustline</strong>. This is a
+        Stellar rule, not a Tael setting: an account cannot hold an asset without first trusting its
+        issuer. Without the trustline, a payout cannot settle and the paid call fails.
+      </Callout>
+      <P>
+        Add a trustline to the USDC issuer for the network you are getting paid on:
+      </P>
+      <CodeBlock
+        title="USDC issuers"
+        lang="bash"
+        code={`# Mainnet  (Circle USDC)
+USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+
+# Testnet  (Tael test USDC)
+USDC:GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA`}
+      />
+      <P>
+        Most wallets make this one click. In Freighter, open <Code>Manage assets</Code>, choose{" "}
+        <Code>Add an asset</Code>, and paste the issuer above. You can also do it from the{" "}
+        <A href="https://developers.stellar.org/docs/tools/cli">Stellar CLI</A>:
+      </P>
+      <CodeBlock
+        title="Add a mainnet USDC trustline"
+        lang="bash"
+        code={`stellar tx new change-trust \\
+  --source YOUR_WALLET \\
+  --line USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN \\
+  --network mainnet`}
+      />
+
+      <H2 id="xlm">Fund the wallet with XLM</H2>
+      <P>
+        A Stellar account needs a small XLM balance to exist and to hold a trustline: about{" "}
+        <Code>1 XLM</Code> base reserve plus <Code>0.5 XLM</Code> per trustline. This XLM is a reserve,
+        not a fee, it stays in your account.
+      </P>
+      <Ul>
+        <li>
+          <strong>Testnet:</strong> fund from the friendbot (free), then add the trustline above.
+        </li>
+        <li>
+          <strong>Mainnet:</strong> there is no friendbot, so send the account a couple of XLM
+          yourself before adding the Circle trustline.
+        </li>
+      </Ul>
+
+      <H2 id="payto">Use it as your payout wallet</H2>
+      <P>
+        When you publish a capability, set this wallet as <Code>payTo</Code>. Every settled call then
+        pays you there instantly. See <A href="/docs/become-a-capability">Become a capability</A> for
+        the full publish flow.
+      </P>
+      <Callout>
+        On mainnet, <Code>payTo</Code> must be the mainnet wallet that holds the Circle USDC trustline.
+        A wallet without the trustline will reject payouts, so set this up before you go live.
+      </Callout>
+    </DocPage>
+  );
+}


### PR DESCRIPTION
## What

Two related bits of mainnet go-live polish:

### Payout guide
- New **Get paid** docs page at `/docs/payouts` explaining the one-time **USDC trustline** a publisher's payout wallet needs before earnings can settle (mainnet Circle + testnet issuers, how to add it via Freighter / Stellar CLI, XLM reserves, setting `payTo`). Added to the docs sidebar under **Partners**.
- A quiet **Payout setup** button in the dashboard topbar (just left of the theme toggle), shown on the **capabilities** pages, linking to the guide.

### Mainnet signage
- The dashboard shows a green **Mainnet** pill next to the wordmark when `NEXT_PUBLIC_STELLAR_NETWORK=mainnet`, and the wallet footer now reads the **real network** instead of a hardcoded `Testnet`.
- The docs header carries the same **Mainnet** badge.
- The Stellar capability FAQ no longer claims Tael is "testnet today".

## Note

I left the **runnable dev examples** (quickstart, SDK reference) on `stellar-testnet` on purpose: the quickstart uses `createMockVerifier()` with a "swap for prod" note, so those are development examples and testnet is the safe default. The docs no longer *claim* testnet-only. Happy to flip those example values to `stellar-mainnet` too if preferred.

`typecheck` green across web, dashboard, and capabilities.