### PR TITLE
fix(testnet): align on GBBD47IF USDC + bump TrustLine SDK to 0.2.1

### DIFF
--- a/apps/api/src/scripts/testnet-swap.ts
+++ b/apps/api/src/scripts/testnet-swap.ts
@@ -38,7 +38,7 @@ import {
 const CAP_URL = process.env.CAP_URL ?? "http://localhost:3004";
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
 const USDC_ISSUER =
-  process.env.USDC_ISSUER ?? "GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+  process.env.USDC_ISSUER ?? "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 const FRIENDBOT = "https://friendbot.stellar.org";
 const server = new Horizon.Server(HORIZON_URL);
 

--- a/apps/capabilities/src/capabilities/stellar/horizon.ts
+++ b/apps/capabilities/src/capabilities/stellar/horizon.ts
@@ -404,7 +404,7 @@ export async function explainTransaction(hash: string): Promise<TxExplanation> {
 
 /** The USDC asset portfolio values are quoted in. Overridable per deployment. */
 const USDC_ASSET =
-  process.env.USDC_ASSET ?? "USDC:GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+  process.env.USDC_ASSET ?? "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
 export interface Holding {
   asset: string;

--- a/apps/capabilities/src/capabilities/stellar/pay.ts
+++ b/apps/capabilities/src/capabilities/stellar/pay.ts
@@ -9,7 +9,7 @@
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
 const NETWORK = process.env.STELLAR_NETWORK === "mainnet" ? "stellar" : "stellar-testnet";
 const USDC_ISSUER =
-  process.env.USDC_ISSUER ?? "GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+  process.env.USDC_ISSUER ?? "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
 export interface PayIntent {
   /** Discriminator the buy-side uses to switch into sign-and-submit mode. */

--- a/apps/capabilities/src/capabilities/stellar/swap.ts
+++ b/apps/capabilities/src/capabilities/stellar/swap.ts
@@ -8,7 +8,7 @@
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
 const NETWORK = process.env.STELLAR_NETWORK === "mainnet" ? "stellar" : "stellar-testnet";
 const USDC_ISSUER =
-  process.env.USDC_ISSUER ?? "GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+  process.env.USDC_ISSUER ?? "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
 /** The two assets v1 swaps between. Kept small on purpose — both have deep testnet liquidity. */
 export type SwapSymbol = "XLM" | "USDC";

--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -31,7 +31,7 @@ const TRUSTLINE_API = process.env.TRUSTLINE_API;
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
 // Action settlement config (the Pay action and future on-chain actions).
 const USDC_ISSUER =
-  process.env.USDC_ISSUER ?? "GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+  process.env.USDC_ISSUER ?? "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 const FEE_ADDRESS = process.env.TAEL_FEE_ADDRESS ?? "";
 // Tael's cut of an action, in basis points of the amount sent (100 = 1%).
 const ACTION_FEE_BPS = Number(process.env.TAEL_ACTION_FEE_BPS ?? "100");

--- a/apps/dashboard/features/capabilities/publish-wizard.tsx
+++ b/apps/dashboard/features/capabilities/publish-wizard.tsx
@@ -34,7 +34,7 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 // this issuer, or Stellar rejects the payment (op_no_trust). Shown to publishers
 // so they set it up before listing.
 const USDC_ISSUER =
-  process.env.NEXT_PUBLIC_USDC_ISSUER ?? "GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA";
+  process.env.NEXT_PUBLIC_USDC_ISSUER ?? "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
 type Step = "describe" | "test" | "verify" | "done";
 type Answer = { question: string; answer: string };

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -23,7 +23,7 @@
     "@tael/stellar": "workspace:*",
     "@tael/types": "workspace:*",
     "@tael/ui": "workspace:*",
-    "@trustline-agents/agent-sdk": "^0.2.0",
+    "@trustline-agents/agent-sdk": "^0.2.1",
     "lucide-react": "catalog:",
     "next": "catalog:",
     "next-themes": "catalog:",

--- a/apps/web/app/docs/payouts/page.tsx
+++ b/apps/web/app/docs/payouts/page.tsx
@@ -39,8 +39,8 @@ export default function PayoutsPage() {
         code={`# Mainnet  (Circle USDC)
 USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
 
-# Testnet  (Tael test USDC)
-USDC:GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA`}
+# Testnet  (SDF testnet USDC)
+USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5`}
       />
       <P>
         Most wallets make this one click. In Freighter, open <Code>Manage assets</Code>, choose{" "}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,8 +342,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@trustline-agents/agent-sdk':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       lucide-react:
         specifier: 'catalog:'
         version: 0.469.0(react@19.2.7)
@@ -4712,8 +4712,8 @@ packages:
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@trustline-agents/agent-sdk@0.2.0':
-    resolution: {integrity: sha512-Rtvq6NZM1s88VS4cXkV1tAXHzSP7n4ycDBHzjTin2a2D5E9e0WSPtDBx9urACSX3H4/HIc38mGX/6lmrlmfrXg==}
+  '@trustline-agents/agent-sdk@0.2.1':
+    resolution: {integrity: sha512-rJeYrwC/FKQL5+z8VjaF8BRuuCk/XWT1/2A43Ju3B2YzDlP03LIeMfH8JbqE6XwRijMm6Kd4RXXuiYybFXWPew==}
 
   '@turbo/darwin-64@2.10.2':
     resolution: {integrity: sha512-wBM3ObqOWnKUDmg7QfUFDkDHPFUAJmrYlYqmEM8jMPAPA/I6wRJIbWimeQUqhOiQ8xPKhzyWM+xaiUP0wz8FEQ==}
@@ -13293,7 +13293,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@trustline-agents/agent-sdk@0.2.0':
+  '@trustline-agents/agent-sdk@0.2.1':
     dependencies:
       '@stellar/stellar-sdk': 16.0.1
       '@x402/fetch': 2.18.0


### PR DESCRIPTION
Unblocks TrustLine credit (borrow/repay) on testnet. Two root causes, both environmental:

## 1. Testnet USDC issuer split

Our own code disagreed on the testnet dollar:
- **Gateway** (`apps/api`) + **every test** use `GBBD47IF…` (SDF canonical testnet USDC) — same as TrustLine.
- **Dashboard buy-side** (`run-capability.ts`, the publish wizard's trustline warning) + the **capabilities service** (`pay.ts`, `swap.ts`, `horizon.ts`) defaulted to `GBCDXWBEN…` (Tael test USDC).

An agent that borrowed/held one and paid in the other never lined up. This standardizes **all** testnet defaults on `GBBD47IF…` so everything is on the same dollar. Notably the **publish wizard now shows publishers the correct issuer to trustline**.

## 2. Stale TrustLine SDK

`@trustline-agents/agent-sdk@0.2.0` shipped without the treasury auto-seed in `borrow()`, so draws hit an empty vault (`InsufficientLiquidity`). Bumped to **0.2.1** (the maintainer verified a real testnet borrow against it).

## Also needed (env, your side)
Set on the deployed **dashboard** + **capabilities** services:
```
USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
NEXT_PUBLIC_USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
```
Existing testnet cards may need re-funding with GBBD47IF USDC.

Mainnet (Circle `GA5ZSEJY…`) is untouched. `typecheck` + `format` green across dashboard, capabilities, web.