### PR TITLE
fix(ui): one clean network badge next to the wordmark

### DIFF
--- a/apps/dashboard/components/app-shell/sidebar.tsx
+++ b/apps/dashboard/components/app-shell/sidebar.tsx
@@ -30,8 +30,9 @@ function isActive(pathname: string, href: string): boolean {
   return href === "/" ? pathname === "/" : pathname.startsWith(href);
 }
 
-/** Small BETA pill next to the wordmark. */
-function BetaBadge({ className }: { className?: string }) {
+/** The pill next to the wordmark: the network name on mainnet (where calls move
+ *  real USDC), otherwise "Beta". One badge, so the header stays clean. */
+function StatusBadge({ className }: { className?: string }) {
   return (
     <span
       className={cn(
@@ -39,22 +40,7 @@ function BetaBadge({ className }: { className?: string }) {
         className,
       )}
     >
-      Beta
-    </span>
-  );
-}
-
-/** Mainnet pill next to the wordmark. Only shown on mainnet, where it signals
- *  that calls move real USDC. */
-function MainnetBadge({ className }: { className?: string }) {
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-600 dark:bg-emerald-400/15 dark:text-emerald-400",
-        className,
-      )}
-    >
-      Mainnet
+      {IS_MAINNET ? "Mainnet" : "Beta"}
     </span>
   );
 }
@@ -103,8 +89,7 @@ export function AppSidebar({ address }: { address: string | null }) {
           >
             t
           </span>
-          <BetaBadge className="group-data-[collapsible=icon]:hidden" />
-          {IS_MAINNET ? <MainnetBadge className="group-data-[collapsible=icon]:hidden" /> : null}
+          <StatusBadge className="group-data-[collapsible=icon]:hidden" />
         </Link>
       </SidebarHeader>
 

--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -38,7 +38,7 @@ export default function DocsLayout({ children }: { children: ReactNode }) {
                 tael
               </span>
             </a>
-            <span className="inline-flex items-center rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-600 dark:bg-emerald-400/15 dark:text-emerald-400">
+            <span className="inline-flex items-center rounded-full bg-gradient-to-r from-[#156DFC] to-indigo-500 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white shadow-sm">
               Mainnet
             </span>
           </div>


### PR DESCRIPTION
The dashboard was showing two pills side by side (blue **Beta** + green **Mainnet**), which looked cluttered.

Now there's a **single blue pill** that reads the network: it says **Mainnet** on mainnet (where calls move real USDC) and **Beta** otherwise. The docs header badge matches the same blue style (was green).

- `sidebar.tsx`: merged BetaBadge + MainnetBadge into one `StatusBadge`.
- `docs/layout.tsx`: recolored the badge blue.

`typecheck` + `format` green.