### PR TITLE
feat(dashboard): make TrustLine credit visible (borrow notice + owed chip)

### DIFF
--- a/apps/dashboard/app/(dashboard)/agents/[id]/page.tsx
+++ b/apps/dashboard/app/(dashboard)/agents/[id]/page.tsx
@@ -35,15 +35,23 @@ export default async function AgentDetailPage({ params }: { params: Promise<{ id
             <p className="text-sm text-muted-foreground">Card</p>
             <h1 className="text-2xl font-semibold tracking-tight">{agent.name}</h1>
           </div>
-          {agent.ready ? (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-700">
-              <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Ready to spend
-            </span>
-          ) : (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-700">
-              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" /> Needs provisioning
-            </span>
-          )}
+          <div className="flex flex-wrap items-center gap-2">
+            {agent.ready ? (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-700">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Ready to spend
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-700">
+                <span className="h-1.5 w-1.5 rounded-full bg-amber-500" /> Needs provisioning
+              </span>
+            )}
+            {agent.owedTrustLine ? (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-violet-500/10 px-2.5 py-1 text-xs font-medium text-violet-700 dark:text-violet-400">
+                <span className="h-1.5 w-1.5 rounded-full bg-violet-500" /> Owes TrustLine $
+                {agent.owedTrustLine}
+              </span>
+            ) : null}
+          </div>
           <p className="text-sm text-muted-foreground">
             Fund this card and set its limits below. Your agents pay from it per call, and nothing
             exceeds the caps you set.

--- a/apps/dashboard/features/agents/operations-explorer.tsx
+++ b/apps/dashboard/features/agents/operations-explorer.tsx
@@ -214,6 +214,9 @@ function OperationRow({
         toast.success(
           Number(r.paid) > 0 ? `Ran ${op.name} · paid $${r.paid} USDC` : `Ran ${op.name}`,
         );
+        if (r.borrowed) {
+          toast.info(`Borrowed $${r.borrowed} from TrustLine to cover the shortfall`);
+        }
       } else {
         toast.error(r.error ?? "The call failed.");
       }
@@ -377,10 +380,18 @@ function ResultPanel({ result, sample }: { result: RunResult | null; sample: str
       )}
     >
       {live ? (
-        <div className="flex items-center gap-1.5 border-b bg-emerald-500/5 px-3 py-1.5 text-xs font-medium text-emerald-600">
-          <Sparkles className="h-3.5 w-3.5" />
-          {Number(result?.paid) > 0 ? `Paid $${result?.paid} USDC` : "Ran free"} · {result?.status}{" "}
-          OK
+        <div className="space-y-1 border-b bg-emerald-500/5 px-3 py-1.5">
+          <div className="flex items-center gap-1.5 text-xs font-medium text-emerald-600">
+            <Sparkles className="h-3.5 w-3.5" />
+            {Number(result?.paid) > 0 ? `Paid $${result?.paid} USDC` : "Ran free"} ·{" "}
+            {result?.status} OK
+          </div>
+          {result?.borrowed ? (
+            <div className="flex items-center gap-1.5 text-xs font-medium text-violet-600 dark:text-violet-400">
+              <span className="h-1.5 w-1.5 rounded-full bg-violet-500" /> Borrowed $
+              {result.borrowed} from TrustLine to cover the shortfall
+            </div>
+          ) : null}
         </div>
       ) : null}
       <pre className="max-h-72 min-w-0 overflow-auto p-3 font-mono text-[11px] leading-relaxed">

--- a/apps/dashboard/features/agents/queries.ts
+++ b/apps/dashboard/features/agents/queries.ts
@@ -4,6 +4,7 @@ import type { SpendingPolicy } from "@tael/types";
 import { db } from "../../lib/db";
 import { getCurrentUser } from "../capabilities/current-user";
 import { fetchUsdcBalance } from "./balance";
+import { fetchTrustLineOwed } from "./trustline";
 
 export interface AgentWallet {
   agentId: string;
@@ -15,6 +16,9 @@ export interface AgentWallet {
   funded: boolean;
   /** Has a USDC trustline, so it can receive USDC. */
   ready: boolean;
+  /** Outstanding TrustLine debt as a decimal USDC string, or null when it owes
+   *  nothing / credit isn't configured. Only populated on the card detail page. */
+  owedTrustLine?: string | null;
   createdAt: Date;
 }
 
@@ -123,6 +127,8 @@ export async function getAgentDetail(agentId: string): Promise<AgentWallet | nul
       name: agents.name,
       policy: agents.policy,
       address: wallets.address,
+      // Server-only: used to read this card's TrustLine debt, never returned.
+      secretEnc: wallets.secretEnc,
       createdAt: agents.createdAt,
     })
     .from(agents)
@@ -132,6 +138,7 @@ export async function getAgentDetail(agentId: string): Promise<AgentWallet | nul
 
   if (!r) return null;
   const { usdc, funded, ready } = await fetchUsdcBalance(r.address);
+  const owedTrustLine = r.secretEnc ? await fetchTrustLineOwed(r.secretEnc) : null;
   return {
     agentId: r.agentId,
     name: r.name,
@@ -140,6 +147,7 @@ export async function getAgentDetail(agentId: string): Promise<AgentWallet | nul
     usdc,
     funded,
     ready,
+    owedTrustLine,
     createdAt: r.createdAt,
   };
 }

--- a/apps/dashboard/features/agents/run-capability-dialog.tsx
+++ b/apps/dashboard/features/agents/run-capability-dialog.tsx
@@ -284,6 +284,13 @@ function ResultView({
         Paid ${result.paid} USDC · {result.status} OK
       </div>
 
+      {result.borrowed ? (
+        <div className="flex items-center gap-1.5 text-sm font-medium text-violet-600 dark:text-violet-400">
+          <span className="h-1.5 w-1.5 rounded-full bg-violet-500" /> Borrowed ${result.borrowed}{" "}
+          from TrustLine to cover the shortfall
+        </div>
+      ) : null}
+
       <div className="min-w-0 overflow-hidden rounded-lg border bg-muted/40">
         <pre className="max-h-64 min-w-0 overflow-auto p-3 text-xs leading-relaxed">
           <code>{pretty}</code>

--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -59,6 +59,8 @@ export interface RunResult {
   body?: string;
   /** Total USDC the agent paid for this call. */
   paid?: string;
+  /** USDC drawn from TrustLine credit to cover a shortfall on this call, if any. */
+  borrowed?: string;
   error?: string;
 }
 
@@ -260,6 +262,7 @@ export async function runCapability(input: {
   // Wallets that opt out, have no credit line, or hit any failure just see the
   // same shortfall and the same error as today — this never blocks a call that
   // would otherwise have failed anyway.
+  let borrowed: string | undefined;
   let { usdc } = await fetchUsdcBalance(agent.address);
   if (
     agent.policy?.allowCreditDraw &&
@@ -268,6 +271,7 @@ export async function runCapability(input: {
     const shortfall = total.subtract(Money.parse(usdc));
     const drew = await tryDrawTrustLineCredit(secretEnc, shortfall.toDecimalString());
     if (drew) {
+      borrowed = shortfall.toDecimalString();
       usdc = (await fetchUsdcBalance(agent.address)).usdc;
     }
   }
@@ -327,7 +331,7 @@ export async function runCapability(input: {
       const buffer = agent.policy?.maxPerCall ?? total.toDecimalString();
       await maybeRepayTrustLineCredit(secretEnc, buffer);
     }
-    return { ok: true, status: res.status, body, paid: total.toDecimalString() };
+    return { ok: true, status: res.status, body, paid: total.toDecimalString(), borrowed };
   } catch {
     return { ok: false, error: "Couldn't reach the capability. Try again." };
   }

--- a/apps/dashboard/features/agents/trustline.ts
+++ b/apps/dashboard/features/agents/trustline.ts
@@ -1,0 +1,25 @@
+import "server-only";
+import { decryptSecret } from "@tael/database";
+
+// TrustLine underwriting API. Unset means no card has a credit line, so there's
+// nothing to owe and this always returns null.
+const TRUSTLINE_API = process.env.TRUSTLINE_API;
+
+/**
+ * How much this card currently owes TrustLine (principal + accrued interest), as
+ * a trimmed decimal string, or `null` when credit isn't configured, it owes
+ * nothing, or anything goes wrong. Best-effort on purpose: it only drives a
+ * display chip, so it must never throw or slow a page into failure.
+ */
+export async function fetchTrustLineOwed(secretEnc: string): Promise<string | null> {
+  if (!TRUSTLINE_API) return null;
+  try {
+    const { TrustLineAgent } = await import("@trustline-agents/agent-sdk");
+    const tl = new TrustLineAgent(decryptSecret(secretEnc), { apiBaseUrl: TRUSTLINE_API });
+    const state = await tl.vaultState();
+    const owed = Number(state.amountOwedUsdc);
+    return owed > 0 ? owed.toString() : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Right now the borrow → repay loop settles **silently**: a card borrows from TrustLine to afford a call, but the UI just says `Paid`, and there's no sign the card owes anything. This makes the credit story **visible** for the demo.

## What you'll see
**1. When a card borrows to cover a shortfall** (in the capability run UI):
- A line in the result: **`Borrowed $0.05 from TrustLine to cover the shortfall`**
- A toast: *Borrowed $0.05 from TrustLine…*

**2. On the card page** — an **`Owes TrustLine $0.05`** chip next to "Ready to spend", so the outstanding debt is visible until `maybeRepayTrustLineCredit` pays it back.

## How it works
- `runCapability` returns `borrowed` (the drawn amount) alongside `paid`; `operations-explorer` + the run dialog render it.
- New server-only `fetchTrustLineOwed(secretEnc)` reads the card's `vaultState().amountOwedUsdc`. `getAgentDetail` populates `owedTrustLine` (detail page only, so the card list isn't slowed).
- **Best-effort + safe:** hidden when the card owes nothing or `TRUSTLINE_API` is unset; any error just returns null and never blocks the page. The card's `secretEnc` is read server-side and never returned to the client.

The money is already real on-chain (TrustLine's vault → the card); this just makes Tael's UI *say* it. `typecheck` + `format` green.

**Review the Vercel preview before merging.**