### PR TITLE
feat(dashboard): copilot L3 (run capability) + clear-chat + open-on-click

### DIFF
--- a/apps/dashboard/app/api/agent/route.ts
+++ b/apps/dashboard/app/api/agent/route.ts
@@ -1,4 +1,5 @@
 import { DASHBOARD_SYSTEM_PROMPT } from "../../../features/agent/knowledge";
+import type { ProposedAction } from "../../../features/agent/types";
 import { listAgentWallets } from "../../../features/agents/queries";
 import {
   getPublicCapabilityBySlug,
@@ -8,11 +9,12 @@ import {
 import { getPaymentsData } from "../../../features/payments/queries";
 import { getWalletOverview } from "../../../features/wallet/queries";
 
-// The dashboard's Tael copilot. Unlike the marketing widget, it runs a tool
-// loop: it can call the same server queries the pages use (scoped to the signed
-// in user's session), so it answers with the account's real, live data. Talks to
-// OpenRouter (OpenAI-compatible) so the model is swappable — default Gemini 2.5
-// Flash. Node runtime: reads a server-only key and touches server-only queries.
+// The dashboard's Tael copilot. It runs a tool loop over the same server queries
+// the pages use (scoped to the signed-in user's session), so it answers with the
+// account's real, live data. It can also PROPOSE running a capability — that
+// never runs on its own; it returns a confirmation the user approves before a
+// card pays. Talks to OpenRouter (default Gemini 2.5 Flash, swappable). Node
+// runtime: reads a server-only key and touches server-only queries.
 export const runtime = "nodejs";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
@@ -36,18 +38,24 @@ interface OpenRouterResponse {
   choices?: { message?: ChatMessage }[];
 }
 
-/** Read-only tools the copilot can call. Each returns live data for the signed
- *  in user (the queries resolve the session themselves), as a compact JSON
- *  string. Read-only on purpose: the assistant can look, not spend or mutate. */
 const TOOLS = [
   fn("get_wallet_overview", "The user's wallet balance, total spend, and revenue."),
   fn("list_cards", "The user's Cards (agent wallets) with their live USDC balances and caps."),
   fn("list_my_capabilities", "Capabilities the user has published: name, slug, price, status."),
   fn("browse_marketplace", "Capabilities available to buy in the marketplace."),
   fn("get_recent_payments", "The user's recent settled payments (incoming and outgoing)."),
-  fn("get_capability", "Details of one capability by its slug.", {
+  fn("get_capability", "Details of one capability by its slug (name, operations, prices).", {
     slug: { type: "string", description: "The capability's URL slug." },
   }),
+  fn(
+    "run_capability",
+    "Propose running ONE operation of a capability for the user. This does NOT run immediately: it returns a confirmation the user must approve before their card pays. Call it only once you know the capability slug and which operation to run.",
+    {
+      slug: { type: "string", description: "The capability's URL slug." },
+      operation: { type: "string", description: "The operation to run (its slug or name)." },
+      params: { type: "string", description: "Optional query string or JSON body for the op." },
+    },
+  ),
 ];
 
 function fn(name: string, description: string, properties?: Record<string, unknown>) {
@@ -69,6 +77,15 @@ function clip(s: string, n = 4000): string {
   return s.length > n ? `${s.slice(0, n)}… (truncated)` : s;
 }
 
+function kebab(s: string): string {
+  return s
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Read-only tools return live data for the signed-in user, as compact JSON. */
 async function runTool(name: string, args: Record<string, unknown>): Promise<string> {
   try {
     switch (name) {
@@ -98,6 +115,64 @@ async function runTool(name: string, args: Record<string, unknown>): Promise<str
   }
 }
 
+/**
+ * Resolve a proposed run: look up the REAL operation price (never trust the
+ * model) and a card that can actually afford it, then return a confirm proposal.
+ * Running is still enforced by the card's on-chain caps + the gateway price when
+ * the user approves, so this only needs to be a good-faith preview.
+ */
+async function proposeRun(
+  args: Record<string, unknown>,
+): Promise<{ reply: string; action: ProposedAction | null }> {
+  const slug = String(args.slug ?? "").trim();
+  const opRef = String(args.operation ?? "").trim();
+  const params = args.params ? String(args.params) : undefined;
+  if (!slug) return { reply: "I need the capability's slug to run it.", action: null };
+
+  const cap = await getPublicCapabilityBySlug(slug);
+  if (!cap) return { reply: `I couldn't find a capability with slug "${slug}".`, action: null };
+
+  const ops = cap.spec?.operations ?? [];
+  const op =
+    ops.find(
+      (o) => (o.slug ?? kebab(o.name)) === opRef || o.name.toLowerCase() === opRef.toLowerCase(),
+    ) ?? ops[0];
+  if (!op) return { reply: `${cap.name} has no runnable operations.`, action: null };
+
+  const price = op.price ?? "0";
+  const total = Number(price);
+
+  const cards = await listAgentWallets();
+  const card = cards.find(
+    (c) => Number(c.usdc) >= total && (!c.policy || total <= Number(c.policy.maxPerCall)),
+  );
+  if (!card) {
+    return {
+      reply:
+        total > 0
+          ? `Running ${op.name} costs $${price} USDC, but none of your cards can pay that right now. Fund a card first.`
+          : `You don't have a card set up yet — create one under Cards first.`,
+      action: null,
+    };
+  }
+
+  const cost = total > 0 ? `pays $${price} USDC from your "${card.name}" card` : "is free";
+  return {
+    reply: `I can run **${op.name}** on ${cap.name} — it ${cost}. Confirm below to run it.`,
+    action: {
+      slug,
+      operation: op.slug ?? kebab(op.name),
+      method: op.method ?? "GET",
+      params,
+      cardId: card.agentId,
+      cardName: card.name,
+      capabilityName: cap.name,
+      operationName: op.name,
+      price,
+    },
+  };
+}
+
 function safeParseArgs(raw: string | undefined): Record<string, unknown> {
   if (!raw) return {};
   try {
@@ -108,10 +183,10 @@ function safeParseArgs(raw: string | undefined): Record<string, unknown> {
   }
 }
 
-function textResponse(body: string, status = 200): Response {
-  return new Response(body, {
-    status,
-    headers: { "content-type": "text/plain; charset=utf-8", "cache-control": "no-store" },
+function reply(text: string, action: ProposedAction | null = null): Response {
+  return new Response(JSON.stringify({ reply: text, action }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
   });
 }
 
@@ -142,7 +217,6 @@ export async function POST(request: Request) {
   const system =
     DASHBOARD_SYSTEM_PROMPT + (page ? `\n\n## Current page\nThe user is on: ${page}` : "");
 
-  // Last 20 turns keeps context and cost predictable.
   const convo: ChatMessage[] = [
     { role: "system", content: system },
     ...messages.slice(-20).map((m) => ({ role: m.role, content: m.content })),
@@ -174,34 +248,35 @@ export async function POST(request: Request) {
           resp.status,
           await resp.text().catch(() => ""),
         );
-        return textResponse("Sorry, the copilot is unavailable right now. Please try again.");
+        return reply("Sorry, the copilot is unavailable right now. Please try again.");
       }
       data = (await resp.json()) as OpenRouterResponse;
     } catch (error) {
       console.error("[copilot] openrouter request failed:", error);
-      return textResponse("Sorry, something went wrong on my end. Please try again.");
+      return reply("Sorry, something went wrong on my end. Please try again.");
     }
 
     const message = data.choices?.[0]?.message;
-    if (!message) return textResponse("Sorry, I didn't get a response. Please try again.");
+    if (!message) return reply("Sorry, I didn't get a response. Please try again.");
 
-    // The model wants live data → run each tool, feed results back, loop.
     if (message.tool_calls?.length) {
+      // A run proposal is terminal: resolve it and return the confirm card.
+      const run = message.tool_calls.find((c) => c.function.name === "run_capability");
+      if (run) {
+        const { reply: text, action } = await proposeRun(safeParseArgs(run.function.arguments));
+        return reply(text, action);
+      }
+      // Otherwise run the read tools and loop with their results.
       convo.push(message);
       for (const call of message.tool_calls) {
         const out = await runTool(call.function.name, safeParseArgs(call.function.arguments));
-        convo.push({
-          role: "tool",
-          tool_call_id: call.id,
-          name: call.function.name,
-          content: out,
-        });
+        convo.push({ role: "tool", tool_call_id: call.id, name: call.function.name, content: out });
       }
       continue;
     }
 
-    return textResponse(message.content ?? "");
+    return reply(message.content ?? "");
   }
 
-  return textResponse("I couldn't quite finish that — try rephrasing?");
+  return reply("I couldn't quite finish that — try rephrasing?");
 }

--- a/apps/dashboard/features/agent/knowledge.ts
+++ b/apps/dashboard/features/agent/knowledge.ts
@@ -38,6 +38,7 @@ You have read tools that return the user's real, live data. USE them, do not gue
 - browse_marketplace: capabilities available to buy.
 - get_capability: details of one capability by slug.
 - get_recent_payments: the user's recent settled payments.
+- run_capability: PROPOSE running one operation of a capability. It never runs on its own, it shows the user a confirm button, and only when they click it does their card pay. Use it when the user asks you to run/call/try a capability. Look the capability up first (browse_marketplace or get_capability) so you pass the right slug and operation.
 
 When a question is about the user's account ("my balance", "my capabilities", "did that payment go through"), call the matching tool and answer from the result. When it's conceptual ("what is a Card", "how do payouts work"), answer directly from the knowledge above.
 
@@ -46,6 +47,6 @@ Each message includes the page the user is currently on. Use it to answer "what 
 
 ## How to answer
 - Be concise, friendly, and practical. Short paragraphs.
-- To DO things (publish, run a capability, provision a card), guide them to the right button/page, you can read data but you cannot yet perform actions on their behalf.
+- You CAN run a capability via run_capability, but it always requires the user's one-click confirm before their card pays. For publishing or provisioning a Card, guide them to the right page, you can't do those yet.
 - If a tool returns nothing or errors, say so plainly rather than inventing an answer.
 - Never reveal secrets, private keys, or raw internal IDs.`;

--- a/apps/dashboard/features/agent/message-bubble.tsx
+++ b/apps/dashboard/features/agent/message-bubble.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import type { AgentMessage } from "./types";
+import type { AgentMessage, ProposedAction } from "./types";
 import { DiscordIcon } from "./icons";
 
 /** A blinking three-dot indicator shown while the first token is in flight. */
@@ -44,9 +44,12 @@ const DISCORD_RE = /(?:https?:\/\/)?discord\.(?:gg|com\/invite)\/[A-Za-z0-9-]+/i
 export function MessageBubble({
   message,
   showMeta,
+  onRunAction,
 }: {
   message: AgentMessage;
   showMeta?: boolean;
+  /** Called when the user confirms a proposed capability run. */
+  onRunAction?: (messageId: string, action: ProposedAction) => void;
 }) {
   const isUser = message.role === "user";
   const empty = message.content.length === 0;
@@ -100,6 +103,28 @@ export function MessageBubble({
         >
           <DiscordIcon className="h-4 w-4" /> Join our Discord
         </a>
+      ) : null}
+
+      {message.action && !message.actionDone ? (
+        <div className="w-full max-w-[85%] rounded-2xl border border-white/10 bg-[#1c1d21] p-3">
+          <p className="text-[11px] uppercase tracking-wide text-white/40">Run capability</p>
+          <p className="mt-0.5 text-[13.5px] font-medium text-zinc-100">
+            {message.action.operationName}{" "}
+            <span className="text-white/50">· {message.action.capabilityName}</span>
+          </p>
+          <p className="mt-0.5 text-[12px] text-white/50">
+            Pays from your <span className="text-white/70">{message.action.cardName}</span> card
+          </p>
+          <button
+            type="button"
+            onClick={() => onRunAction?.(message.id, message.action!)}
+            className="mt-2.5 w-full rounded-lg bg-white px-3 py-1.5 text-[13px] font-medium text-[#14161a] transition-all duration-150 ease-out hover:bg-white/90 active:scale-[0.98]"
+          >
+            {Number(message.action.price) > 0
+              ? `Run · $${message.action.price} USDC`
+              : "Run · free"}
+          </button>
+        </div>
       ) : null}
 
       {!isUser && showMeta && !empty ? (

--- a/apps/dashboard/features/agent/message-bubble.tsx
+++ b/apps/dashboard/features/agent/message-bubble.tsx
@@ -1,8 +1,82 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { motion } from "framer-motion";
 import type { AgentMessage, ProposedAction } from "./types";
 import { DiscordIcon } from "./icons";
+
+/** Inline markdown: **bold** and `code`. */
+function renderInline(s: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  const re = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+  let last = 0;
+  let k = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(s)) !== null) {
+    if (m.index > last) out.push(s.slice(last, m.index));
+    const tok = m[0];
+    if (tok.startsWith("**")) {
+      out.push(<strong key={k++}>{tok.slice(2, -2)}</strong>);
+    } else {
+      out.push(
+        <code key={k++} className="rounded bg-white/10 px-1 py-0.5 font-mono text-[12px]">
+          {tok.slice(1, -1)}
+        </code>,
+      );
+    }
+    last = m.index + tok.length;
+  }
+  if (last < s.length) out.push(s.slice(last));
+  return out;
+}
+
+/**
+ * A small, tasteful markdown renderer for the assistant's replies: paragraphs,
+ * bullet + numbered lists, bold, and inline code. Enough for chat, no deps.
+ */
+function Markdown({ text }: { text: string }) {
+  const blocks: ReactNode[] = [];
+  let list: { ordered: boolean; items: string[] } | null = null;
+
+  const flush = (key: string) => {
+    if (!list) return;
+    const items = list.items.map((it, i) => <li key={i}>{renderInline(it)}</li>);
+    blocks.push(
+      list.ordered ? (
+        <ol key={`o${key}`} className="list-decimal space-y-1 pl-5">
+          {items}
+        </ol>
+      ) : (
+        <ul key={`u${key}`} className="list-disc space-y-1 pl-5 marker:text-white/40">
+          {items}
+        </ul>
+      ),
+    );
+    list = null;
+  };
+
+  text.split("\n").forEach((line, i) => {
+    const bullet = line.match(/^\s*[*-]\s+(.*)/);
+    const number = line.match(/^\s*\d+\.\s+(.*)/);
+    if (bullet) {
+      if (!list || list.ordered) flush(`${i}`);
+      list ??= { ordered: false, items: [] };
+      list.items.push(bullet[1]!);
+      return;
+    }
+    if (number) {
+      if (!list || !list.ordered) flush(`${i}`);
+      list ??= { ordered: true, items: [] };
+      list.items.push(number[1]!);
+      return;
+    }
+    flush(`${i}`);
+    if (line.trim()) blocks.push(<p key={i}>{renderInline(line)}</p>);
+  });
+  flush("end");
+
+  return <div className="space-y-2 leading-relaxed">{blocks}</div>;
+}
 
 /** A blinking three-dot indicator shown while the first token is in flight. */
 export function TypingDots() {
@@ -81,15 +155,16 @@ export function MessageBubble({
         >
           {empty ? (
             <TypingDots />
+          ) : isUser ? (
+            <p className="whitespace-pre-wrap">{text}</p>
           ) : (
-            <motion.p
+            <motion.div
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 0.25, ease: "easeOut" }}
-              className="whitespace-pre-wrap"
             >
-              {text}
-            </motion.p>
+              <Markdown text={text} />
+            </motion.div>
           )}
         </div>
       ) : null}

--- a/apps/dashboard/features/agent/tael-agent.tsx
+++ b/apps/dashboard/features/agent/tael-agent.tsx
@@ -2,14 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import {
-  AGENT_NAME,
-  AGENT_TAGLINE,
-  GREETING,
-  INTRO_BODY,
-  INTRO_MESSAGE,
-  SUGGESTED_QUESTIONS,
-} from "./knowledge";
+import { Trash2 } from "lucide-react";
+import { AGENT_NAME, AGENT_TAGLINE, INTRO_MESSAGE, SUGGESTED_QUESTIONS } from "./knowledge";
 import { useAgentChat } from "./use-agent-chat";
 import { MessageBubble } from "./message-bubble";
 import { ChatSmileIcon, ChevronDownIcon, CloseIcon, SendIcon, TaelLogoMark } from "./icons";
@@ -22,9 +16,8 @@ const CHIP_CLASS =
 
 /**
  * The Tael Agent: a floating, self-contained support widget. Drop `<TaelAgent />`
- * anywhere (it renders its own fixed launcher, proactive teaser, and panel) and
- * it answers questions about Tael, streamed from /api/agent. No app-specific UI
- * deps, so it's reusable across surfaces — pass props to retheme or repoint it.
+ * anywhere (it renders its own fixed launcher and panel) and it answers questions
+ * about Tael from /api/agent. It only opens on click — no proactive pop-up.
  */
 export function TaelAgent({
   endpoint = "/api/agent",
@@ -34,70 +27,25 @@ export function TaelAgent({
   suggestions = SUGGESTED_QUESTIONS,
 }: TaelAgentProps) {
   const [open, setOpen] = useState(false);
-  const [teaser, setTeaser] = useState(false);
   const [draft, setDraft] = useState("");
   const [unread, setUnread] = useState(0);
-  const { messages, streaming, send, runAction } = useAgentChat(endpoint);
+  const { messages, streaming, send, runAction, clear } = useAgentChat(endpoint);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const wasStreaming = useRef(false);
   const askedPermission = useRef(false);
-  // Once the teaser has been shown or dismissed, never auto-pop it again.
-  const teaserDone = useRef(false);
-  // The teaser's tick can be autoplay-blocked on a fresh load; flush it on the
-  // visitor's first gesture instead.
-  const teaserSoundPending = useRef(false);
-
-  // Proactive greeting: two seconds after load, nudge with the teaser card
-  // (unless the visitor already opened the panel).
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (teaserDone.current || open) return;
-      teaserDone.current = true;
-      setTeaser(true);
-      setUnread(1);
-      void playChime().then((ok) => {
-        if (!ok) teaserSoundPending.current = true;
-      });
-    }, 2000);
-    return () => clearTimeout(timer);
-  }, [open]);
-
-  // Browsers block audio before the first interaction, so the teaser tick above
-  // may be silenced on a fresh load. Play it on the visitor's first gesture.
-  useEffect(() => {
-    const flush = () => {
-      if (teaserSoundPending.current) {
-        teaserSoundPending.current = false;
-        void playChime();
-      }
-      window.removeEventListener("pointerdown", flush);
-      window.removeEventListener("keydown", flush);
-      window.removeEventListener("scroll", flush);
-    };
-    window.addEventListener("pointerdown", flush);
-    window.addEventListener("keydown", flush);
-    window.addEventListener("scroll", flush, { passive: true });
-    return () => {
-      window.removeEventListener("pointerdown", flush);
-      window.removeEventListener("keydown", flush);
-      window.removeEventListener("scroll", flush);
-    };
-  }, []);
 
   // Keep the transcript pinned to the latest message as it streams in.
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
   }, [messages, open]);
 
-  // On open: focus the input, clear the teaser + unread dot, and ask once for
-  // permission to send browser notifications (to nudge when the panel is closed).
+  // On open: focus the input, clear the unread dot, and ask once for permission
+  // to send browser notifications (to nudge when the panel is closed).
   useEffect(() => {
     if (!open) return;
     inputRef.current?.focus();
     setUnread(0);
-    setTeaser(false);
-    teaserDone.current = true;
     if (!askedPermission.current) {
       askedPermission.current = true;
       void ensureNotifyPermission();
@@ -128,65 +76,8 @@ export function TaelAgent({
     setDraft("");
   }
 
-  /** From the teaser: open the panel and send the tapped suggestion. */
-  function ask(question: string) {
-    setTeaser(false);
-    setOpen(true);
-    submit(question);
-  }
-
   return (
     <>
-      {/* Proactive teaser: greeting card + suggestions, above the launcher. */}
-      <AnimatePresence>
-        {teaser && !open && (
-          <motion.div
-            initial={{ opacity: 0, y: 16 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 16 }}
-            transition={{ duration: 0.25, ease: "easeOut" }}
-            className="fixed bottom-24 right-5 z-[60] flex w-[calc(100vw-2.5rem)] flex-col items-end gap-2 sm:w-[404px]"
-          >
-            <div className="group relative w-full rounded-[20px] border border-white/10 bg-[#14161a] p-4 text-white shadow-[0_24px_70px_-20px_rgba(0,0,0,0.7)]">
-              <button
-                type="button"
-                onClick={() => {
-                  setTeaser(false);
-                  setUnread(0);
-                }}
-                aria-label="Dismiss"
-                className="absolute -right-2.5 -top-2.5 flex h-7 w-7 items-center justify-center rounded-full border border-white/15 bg-[#1c1c1f] text-white/70 opacity-0 shadow transition-opacity duration-150 hover:text-white group-hover:opacity-100"
-              >
-                <CloseIcon className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                onClick={() => setOpen(true)}
-                className="flex w-full items-start gap-3 text-left"
-              >
-                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white">
-                  <TaelLogoMark className="text-[20px]" />
-                </span>
-                <span className="min-w-0">
-                  <span className="block text-[15px] font-semibold">{GREETING}</span>
-                  <span className="mt-1 block text-[14px] leading-relaxed text-white/90">
-                    {INTRO_BODY}
-                  </span>
-                  <span className="mt-1.5 block text-xs text-white/40">{name} • Just now</span>
-                </span>
-              </button>
-            </div>
-            <div className="flex flex-wrap justify-end gap-2">
-              {suggestions.map((q) => (
-                <button key={q} type="button" onClick={() => ask(q)} className={CHIP_CLASS}>
-                  {q}
-                </button>
-              ))}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
       {/* Launcher */}
       <motion.button
         type="button"
@@ -233,6 +124,17 @@ export function TaelAgent({
                 <p className="text-sm font-semibold leading-tight">{name}</p>
                 <p className="truncate text-xs text-white/50">{tagline}</p>
               </div>
+              {messages.length > 0 ? (
+                <button
+                  type="button"
+                  onClick={clear}
+                  aria-label="Clear chat"
+                  title="Clear chat"
+                  className="rounded-md p-1 text-white/50 transition-colors hover:bg-white/10 hover:text-white"
+                >
+                  <Trash2 className="h-[18px] w-[18px]" />
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={() => setOpen(false)}

--- a/apps/dashboard/features/agent/tael-agent.tsx
+++ b/apps/dashboard/features/agent/tael-agent.tsx
@@ -37,7 +37,7 @@ export function TaelAgent({
   const [teaser, setTeaser] = useState(false);
   const [draft, setDraft] = useState("");
   const [unread, setUnread] = useState(0);
-  const { messages, streaming, send } = useAgentChat(endpoint);
+  const { messages, streaming, send, runAction } = useAgentChat(endpoint);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const wasStreaming = useRef(false);
@@ -262,6 +262,7 @@ export function TaelAgent({
                 <MessageBubble
                   key={m.id}
                   message={m}
+                  onRunAction={runAction}
                   showMeta={
                     i === messages.length - 1 && m.role === "assistant" && m.content.length > 0
                   }

--- a/apps/dashboard/features/agent/types.ts
+++ b/apps/dashboard/features/agent/types.ts
@@ -1,9 +1,30 @@
+/** A capability run the copilot proposes. It never runs on its own — the user
+ *  confirms first, then the card pays. Resolved server-side (card + price). */
+export interface ProposedAction {
+  slug: string;
+  operation?: string;
+  method?: string;
+  /** Query string or JSON body the op will receive. */
+  params?: string;
+  /** The card that would pay, chosen server-side (an affordable one). */
+  cardId: string;
+  cardName: string;
+  capabilityName: string;
+  operationName: string;
+  /** USDC price shown on the confirm button. */
+  price: string;
+}
+
 export interface AgentMessage {
   id: string;
   role: "user" | "assistant";
   content: string;
   /** When the message was created (ms epoch), for the "· time" meta line. */
   createdAt?: number;
+  /** A capability run the copilot is proposing; renders as a confirm card. */
+  action?: ProposedAction;
+  /** True once the proposed action has been run, so the confirm card collapses. */
+  actionDone?: boolean;
 }
 
 /** Props for the reusable widget, all optional so `<TaelAgent />` just works. */

--- a/apps/dashboard/features/agent/use-agent-chat.ts
+++ b/apps/dashboard/features/agent/use-agent-chat.ts
@@ -154,5 +154,15 @@ export function useAgentChat(endpoint: string) {
     }
   }, []);
 
-  return { messages, streaming, send, runAction };
+  /** Clear the conversation and its saved copy. */
+  const clear = useCallback(() => {
+    setMessages([]);
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore — private mode / quota
+    }
+  }, []);
+
+  return { messages, streaming, send, runAction, clear };
 }

--- a/apps/dashboard/features/agent/use-agent-chat.ts
+++ b/apps/dashboard/features/agent/use-agent-chat.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
-import type { AgentMessage } from "./types";
+import { runCapability } from "../agents/run-capability";
+import type { AgentMessage, ProposedAction } from "./types";
 
 let counter = 0;
 function nextId(): string {
@@ -10,8 +11,8 @@ function nextId(): string {
   return `m${counter}-${Date.now()}`;
 }
 
-/** Persist the conversation so the visitor's context survives a reload or leaving. */
-const STORAGE_KEY = "tael-agent-chat";
+/** Persist the conversation so context survives a reload or navigating away. */
+const STORAGE_KEY = "tael-copilot-chat";
 
 function loadMessages(): AgentMessage[] {
   if (typeof window === "undefined") return [];
@@ -23,21 +24,34 @@ function loadMessages(): AgentMessage[] {
   }
 }
 
+/** Trim a capability's response body for display; pretty-print if it's JSON. */
+function formatBody(body: string | undefined): string {
+  if (!body) return "";
+  let out = body;
+  try {
+    out = JSON.stringify(JSON.parse(body), null, 2);
+  } catch {
+    // not JSON — leave as-is
+  }
+  return out.length > 1200 ? `${out.slice(0, 1200)}…` : out;
+}
+
 /**
- * Owns the conversation and the streaming fetch. `send` optimistically appends
- * the user's message plus an empty assistant message, then fills that assistant
- * message token-by-token as the stream arrives, so the UI feels instant.
+ * Owns the conversation and the copilot fetch. `send` posts the history + the
+ * current page and gets back `{ reply, action }`: the reply is shown, and an
+ * action (a proposed capability run) renders as a confirm card. `runAction`
+ * executes a confirmed run through the normal server action, so the card's caps
+ * still bound the spend, and appends the result.
  */
 export function useAgentChat(endpoint: string) {
   const [messages, setMessages] = useState<AgentMessage[]>(loadMessages);
   const [streaming, setStreaming] = useState(false);
-  // The route the user is currently on, so the assistant can answer about the
-  // page they're looking at and scope its tools to their session.
+  // The route the user is on, so the copilot can answer about the current page
+  // and scope its tools to their session.
   const pathname = usePathname();
-  // Guards against overlapping sends (double-enter, clicking a suggestion mid-stream).
+  // Guards against overlapping sends (double-enter, clicking a suggestion mid-run).
   const busy = useRef(false);
 
-  // Save the conversation on every change (survives reload / the visitor leaving).
   useEffect(() => {
     try {
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
@@ -71,28 +85,20 @@ export function useAgentChat(endpoint: string) {
             pageContext: { path: pathname },
           }),
         });
+        const data = (await res.json().catch(() => null)) as {
+          reply?: string;
+          action?: ProposedAction | null;
+          error?: string;
+        } | null;
+        if (!res.ok || !data) throw new Error(data?.error ?? "request failed");
 
-        if (!res.ok || !res.body) {
-          const detail = await res
-            .json()
-            .then((j: { error?: string }) => j.error)
-            .catch(() => null);
-          throw new Error(detail ?? "request failed");
-        }
-
-        // Buffer the whole reply as it streams in, but don't paint it token by
-        // token. The visitor sees the typing indicator while it generates, then
-        // the complete message is revealed at once (with a fade, in the bubble).
-        const reader = res.body.getReader();
-        const decoder = new TextDecoder();
-        let acc = "";
-        for (;;) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          acc += decoder.decode(value, { stream: true });
-        }
-        acc += decoder.decode();
-        setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, content: acc } : m)));
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, content: data.reply ?? "", action: data.action ?? undefined }
+              : m,
+          ),
+        );
       } catch (error) {
         const message =
           error instanceof Error && error.message !== "request failed"
@@ -109,5 +115,44 @@ export function useAgentChat(endpoint: string) {
     [endpoint, messages, pathname],
   );
 
-  return { messages, streaming, send };
+  /** Run a proposed capability the user just confirmed, then append the result. */
+  const runAction = useCallback(async (messageId: string, action: ProposedAction) => {
+    if (busy.current) return;
+    busy.current = true;
+    setStreaming(true);
+    // Collapse the confirm card on the proposing message.
+    setMessages((prev) => prev.map((m) => (m.id === messageId ? { ...m, actionDone: true } : m)));
+    const resultId = nextId();
+    setMessages((prev) => [
+      ...prev,
+      { id: resultId, role: "assistant", content: "Running…", createdAt: Date.now() },
+    ]);
+
+    const isGet = (action.method ?? "GET").toUpperCase() === "GET";
+    try {
+      const r = await runCapability({
+        agentId: action.cardId,
+        slug: action.slug,
+        operation: action.operation,
+        method: action.method,
+        body: isGet ? undefined : action.params,
+        query: isGet ? action.params : undefined,
+      });
+      const text = r.ok
+        ? `Ran ${action.operationName}${Number(r.paid) > 0 ? ` · paid $${r.paid} USDC` : " · free"}.` +
+          (r.borrowed ? ` Borrowed $${r.borrowed} from TrustLine.` : "") +
+          `\n\n${formatBody(r.body)}`
+        : `Couldn't run it: ${r.error ?? "something went wrong"}`;
+      setMessages((prev) => prev.map((m) => (m.id === resultId ? { ...m, content: text } : m)));
+    } catch {
+      setMessages((prev) =>
+        prev.map((m) => (m.id === resultId ? { ...m, content: "Sorry, that didn't run." } : m)),
+      );
+    } finally {
+      busy.current = false;
+      setStreaming(false);
+    }
+  }, []);
+
+  return { messages, streaming, send, runAction };
 }


### PR DESCRIPTION
Follow-up to #150 — that PR merged at **L1+L2 only** (the L3 commit landed after the merge), so this brings the rest plus polish.

## L3 — run a capability, gated by a confirm
- New `run_capability` tool: the model proposes a run; the route resolves the **real** op price + an affordable card **server-side** (never trusts the model) and returns a confirm proposal — it does not run on its own.
- The widget shows a **`Run · $X USDC`** confirm card; on click it calls the existing `runCapability` server action, so the card's on-chain caps still bound the spend, and shows the result (paid, response, any TrustLine borrow) inline.

## Polish
- **Clear chat** button in the header (resets the conversation + saved copy).
- **Opens only on click** — removed the proactive auto-teaser + chime on load.

`typecheck` · `lint` · `format` green.