### PR TITLE
feat(copilot): create Cards + API keys (confirm-gated) + Cmd/Ctrl+K toggle

### DIFF
--- a/apps/dashboard/app/api/agent/route.ts
+++ b/apps/dashboard/app/api/agent/route.ts
@@ -56,6 +56,19 @@ const TOOLS = [
       params: { type: "string", description: "Optional query string or JSON body for the op." },
     },
   ),
+  fn(
+    "create_card",
+    "Propose creating a new Card (an agent's funded Stellar wallet). Does NOT create it immediately: the user confirms first. Use when the user asks to create/make a card or wallet.",
+    { name: { type: "string", description: "A name for the card, e.g. 'Research'." } },
+  ),
+  fn(
+    "create_api_key",
+    "Propose creating an API key, optionally linked to one of the user's Cards so the key can spend. Does NOT create it immediately: the user confirms first, and the key is shown only once. Use when the user asks to create an API key, or 'an api with <card>'.",
+    {
+      name: { type: "string", description: "A name for the key." },
+      card: { type: "string", description: "Optional Card name to link the key to." },
+    },
+  ),
 ];
 
 function fn(name: string, description: string, properties?: Record<string, unknown>) {
@@ -160,6 +173,7 @@ async function proposeRun(
   return {
     reply: `I can run **${op.name}** on ${cap.name} — it ${cost}. Confirm below to run it.`,
     action: {
+      kind: "run",
       slug,
       operation: op.slug ?? kebab(op.name),
       method: op.method ?? "GET",
@@ -170,6 +184,42 @@ async function proposeRun(
       operationName: op.name,
       price,
     },
+  };
+}
+
+/** Propose creating a new Card (with sensible default limits). */
+function proposeCreateCard(args: Record<string, unknown>): {
+  reply: string;
+  action: ProposedAction;
+} {
+  const name = String(args.name ?? "").trim() || "New Card";
+  return {
+    reply: `I'll create a Card called **${name}** with default limits ($0.10 per call, $5.00 daily). Confirm below.`,
+    action: { kind: "create_card", name, maxPerCall: "0.10", dailyLimit: "5.00" },
+  };
+}
+
+/** Propose creating an API key, resolving an optional Card by name. */
+async function proposeCreateKey(
+  args: Record<string, unknown>,
+): Promise<{ reply: string; action: ProposedAction }> {
+  const name = String(args.name ?? "").trim() || "API key";
+  const cardRef = String(args.card ?? "").trim();
+  let cardId: string | undefined;
+  let cardName: string | undefined;
+  if (cardRef) {
+    const card = (await listAgentWallets()).find(
+      (c) => c.name.toLowerCase() === cardRef.toLowerCase(),
+    );
+    if (card) {
+      cardId = card.agentId;
+      cardName = card.name;
+    }
+  }
+  const link = cardName ? ` linked to your "${cardName}" card` : "";
+  return {
+    reply: `I'll create an API key named **${name}**${link}. You'll see the key only once, copy it right away. Confirm below.`,
+    action: { kind: "create_api_key", name, cardId, cardName },
   };
 }
 
@@ -260,10 +310,22 @@ export async function POST(request: Request) {
     if (!message) return reply("Sorry, I didn't get a response. Please try again.");
 
     if (message.tool_calls?.length) {
-      // A run proposal is terminal: resolve it and return the confirm card.
+      // A write proposal is terminal: resolve it and return a confirm card.
       const run = message.tool_calls.find((c) => c.function.name === "run_capability");
       if (run) {
         const { reply: text, action } = await proposeRun(safeParseArgs(run.function.arguments));
+        return reply(text, action);
+      }
+      const cc = message.tool_calls.find((c) => c.function.name === "create_card");
+      if (cc) {
+        const { reply: text, action } = proposeCreateCard(safeParseArgs(cc.function.arguments));
+        return reply(text, action);
+      }
+      const ck = message.tool_calls.find((c) => c.function.name === "create_api_key");
+      if (ck) {
+        const { reply: text, action } = await proposeCreateKey(
+          safeParseArgs(ck.function.arguments),
+        );
         return reply(text, action);
       }
       // Otherwise run the read tools and loop with their results.

--- a/apps/dashboard/features/agent/knowledge.ts
+++ b/apps/dashboard/features/agent/knowledge.ts
@@ -39,14 +39,19 @@ You have read tools that return the user's real, live data. USE them, do not gue
 - get_capability: details of one capability by slug.
 - get_recent_payments: the user's recent settled payments.
 - run_capability: PROPOSE running one operation of a capability. It never runs on its own, it shows the user a confirm button, and only when they click it does their card pay. Use it when the user asks you to run/call/try a capability. Look the capability up first (browse_marketplace or get_capability) so you pass the right slug and operation.
+- create_card: PROPOSE creating a new Card (an agent's wallet). Confirm-gated. Use when the user asks to create/make a card or wallet.
+- create_api_key: PROPOSE creating an API key, optionally linked to a Card (pass the card's name). Confirm-gated; the key is shown only once. Use when the user asks to create an API key or "an api with <card>".
 
 When a question is about the user's account ("my balance", "my capabilities", "did that payment go through"), call the matching tool and answer from the result. When it's conceptual ("what is a Card", "how do payouts work"), answer directly from the knowledge above.
 
 ## Page context
 Each message includes the page the user is currently on. Use it to answer "what is this page" or "what can I do here", and to make your help specific to where they are.
 
+## Funding a Card
+A new Card needs a little XLM to exist and hold a USDC trustline, then USDC to spend. On testnet it's auto-funded on creation. On mainnet, walk the user through: (1) send ~1.5 XLM to the Card's address, (2) it can then hold a USDC trustline, (3) send USDC to fund it. A wallet that RECEIVES payouts also needs a USDC trustline (Circle's issuer on mainnet).
+
 ## How to answer
 - Be concise, friendly, and practical. Short paragraphs.
-- You CAN run a capability via run_capability, but it always requires the user's one-click confirm before their card pays. For publishing or provisioning a Card, guide them to the right page, you can't do those yet.
+- You CAN run a capability, create a Card, and create an API key via the tools above — each one asks the user for a single-click confirm first, and any spending stays within the Card's caps. For publishing a capability, guide them to the right page.
 - If a tool returns nothing or errors, say so plainly rather than inventing an answer.
-- Never reveal secrets, private keys, or raw internal IDs.`;
+- Never reveal secrets, private keys, or raw internal IDs (the API key tool handles showing the key securely).`;

--- a/apps/dashboard/features/agent/message-bubble.tsx
+++ b/apps/dashboard/features/agent/message-bubble.tsx
@@ -1,9 +1,90 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { motion } from "framer-motion";
 import type { AgentMessage, ProposedAction } from "./types";
 import { DiscordIcon } from "./icons";
+
+/** The confirm card for a proposed action; the label + button follow its kind. */
+function ActionCard({ action, onRun }: { action: ProposedAction; onRun: () => void }) {
+  let label: string;
+  let title: ReactNode;
+  let sub: ReactNode = null;
+  let button: string;
+  if (action.kind === "run") {
+    label = "Run capability";
+    title = (
+      <>
+        {action.operationName} <span className="text-white/50">· {action.capabilityName}</span>
+      </>
+    );
+    sub = (
+      <>
+        Pays from your <span className="text-white/70">{action.cardName}</span> card
+      </>
+    );
+    button = Number(action.price) > 0 ? `Run · $${action.price} USDC` : "Run · free";
+  } else if (action.kind === "create_card") {
+    label = "Create card";
+    title = action.name;
+    sub = `Limits: $${action.maxPerCall}/call · $${action.dailyLimit}/day`;
+    button = "Create card";
+  } else {
+    label = "Create API key";
+    title = action.name;
+    sub = action.cardName ? (
+      <>
+        Linked to your <span className="text-white/70">{action.cardName}</span> card · shown once
+      </>
+    ) : (
+      "Shown only once — copy it right away"
+    );
+    button = "Create key";
+  }
+  return (
+    <div className="w-full max-w-[85%] rounded-2xl border border-white/10 bg-[#1c1d21] p-3">
+      <p className="text-[11px] uppercase tracking-wide text-white/40">{label}</p>
+      <p className="mt-0.5 text-[13.5px] font-medium text-zinc-100">{title}</p>
+      {sub ? <p className="mt-0.5 text-[12px] text-white/50">{sub}</p> : null}
+      <button
+        type="button"
+        onClick={onRun}
+        className="mt-2.5 w-full rounded-lg bg-white px-3 py-1.5 text-[13px] font-medium text-[#14161a] transition-all duration-150 ease-out hover:bg-white/90 active:scale-[0.98]"
+      >
+        {button}
+      </button>
+    </div>
+  );
+}
+
+/** A one-time secret (e.g. a freshly created API key): mono value + copy button. */
+function SecretBox({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="w-full max-w-[85%] rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-3">
+      <p className="text-[11px] uppercase tracking-wide text-amber-300/80">
+        Your key — copy it now
+      </p>
+      <div className="mt-1.5 flex items-center gap-2">
+        <code className="min-w-0 flex-1 truncate rounded bg-black/30 px-2 py-1.5 font-mono text-[12px] text-zinc-100">
+          {value}
+        </code>
+        <button
+          type="button"
+          onClick={() => {
+            void navigator.clipboard.writeText(value);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          }}
+          className="shrink-0 rounded-md bg-white/10 px-2.5 py-1.5 text-[12px] font-medium text-white transition-colors hover:bg-white/20"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <p className="mt-1.5 text-[11px] text-white/40">You won&apos;t be able to see this again.</p>
+    </div>
+  );
+}
 
 /** Inline markdown: **bold** and `code`. */
 function renderInline(s: string): ReactNode[] {
@@ -181,26 +262,13 @@ export function MessageBubble({
       ) : null}
 
       {message.action && !message.actionDone ? (
-        <div className="w-full max-w-[85%] rounded-2xl border border-white/10 bg-[#1c1d21] p-3">
-          <p className="text-[11px] uppercase tracking-wide text-white/40">Run capability</p>
-          <p className="mt-0.5 text-[13.5px] font-medium text-zinc-100">
-            {message.action.operationName}{" "}
-            <span className="text-white/50">· {message.action.capabilityName}</span>
-          </p>
-          <p className="mt-0.5 text-[12px] text-white/50">
-            Pays from your <span className="text-white/70">{message.action.cardName}</span> card
-          </p>
-          <button
-            type="button"
-            onClick={() => onRunAction?.(message.id, message.action!)}
-            className="mt-2.5 w-full rounded-lg bg-white px-3 py-1.5 text-[13px] font-medium text-[#14161a] transition-all duration-150 ease-out hover:bg-white/90 active:scale-[0.98]"
-          >
-            {Number(message.action.price) > 0
-              ? `Run · $${message.action.price} USDC`
-              : "Run · free"}
-          </button>
-        </div>
+        <ActionCard
+          action={message.action}
+          onRun={() => onRunAction?.(message.id, message.action!)}
+        />
       ) : null}
+
+      {message.secret ? <SecretBox value={message.secret} /> : null}
 
       {!isUser && showMeta && !empty ? (
         <span className="text-xs text-white/40">

--- a/apps/dashboard/features/agent/tael-agent.tsx
+++ b/apps/dashboard/features/agent/tael-agent.tsx
@@ -40,6 +40,19 @@ export function TaelAgent({
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
   }, [messages, open]);
 
+  // Keyboard shortcut: Cmd/Ctrl + K toggles the copilot. (Cmd+T is the browser's
+  // new-tab shortcut and can't be intercepted, so we use K.)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   // On open: focus the input, clear the unread dot, and ask once for permission
   // to send browser notifications (to nudge when the panel is closed).
   useEffect(() => {

--- a/apps/dashboard/features/agent/types.ts
+++ b/apps/dashboard/features/agent/types.ts
@@ -1,6 +1,7 @@
-/** A capability run the copilot proposes. It never runs on its own — the user
- *  confirms first, then the card pays. Resolved server-side (card + price). */
-export interface ProposedAction {
+/** Run a capability. It never runs on its own — the user confirms first, then
+ *  the card pays. Resolved server-side (card + real price). */
+export interface RunAction {
+  kind: "run";
   slug: string;
   operation?: string;
   method?: string;
@@ -15,6 +16,25 @@ export interface ProposedAction {
   price: string;
 }
 
+/** Create a new Card (agent wallet). */
+export interface CreateCardAction {
+  kind: "create_card";
+  name: string;
+  maxPerCall: string;
+  dailyLimit: string;
+}
+
+/** Create an API key, optionally linked to a Card. */
+export interface CreateKeyAction {
+  kind: "create_api_key";
+  name: string;
+  cardId?: string;
+  cardName?: string;
+}
+
+/** Something the copilot proposes doing; the user confirms before it happens. */
+export type ProposedAction = RunAction | CreateCardAction | CreateKeyAction;
+
 export interface AgentMessage {
   id: string;
   role: "user" | "assistant";
@@ -25,6 +45,8 @@ export interface AgentMessage {
   action?: ProposedAction;
   /** True once the proposed action has been run, so the confirm card collapses. */
   actionDone?: boolean;
+  /** A one-time secret to reveal securely (e.g. a freshly created API key). */
+  secret?: string;
 }
 
 /** Props for the reusable widget, all optional so `<TaelAgent />` just works. */

--- a/apps/dashboard/features/agent/use-agent-chat.ts
+++ b/apps/dashboard/features/agent/use-agent-chat.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
+import { createAgent } from "../agents/actions";
+import { createApiKey } from "../api-keys/actions";
 import { runCapability } from "../agents/run-capability";
 import type { AgentMessage, ProposedAction } from "./types";
 
@@ -115,7 +117,8 @@ export function useAgentChat(endpoint: string) {
     [endpoint, messages, pathname],
   );
 
-  /** Run a proposed capability the user just confirmed, then append the result. */
+  /** Carry out an action the user just confirmed (run a capability, create a
+   *  Card, or create an API key), then append the result. */
   const runAction = useCallback(async (messageId: string, action: ProposedAction) => {
     if (busy.current) return;
     busy.current = true;
@@ -123,31 +126,65 @@ export function useAgentChat(endpoint: string) {
     // Collapse the confirm card on the proposing message.
     setMessages((prev) => prev.map((m) => (m.id === messageId ? { ...m, actionDone: true } : m)));
     const resultId = nextId();
+    const working =
+      action.kind === "run"
+        ? "Running…"
+        : action.kind === "create_card"
+          ? "Creating your card…"
+          : "Creating your key…";
     setMessages((prev) => [
       ...prev,
-      { id: resultId, role: "assistant", content: "Running…", createdAt: Date.now() },
+      { id: resultId, role: "assistant", content: working, createdAt: Date.now() },
     ]);
 
-    const isGet = (action.method ?? "GET").toUpperCase() === "GET";
+    const patch = (fields: Partial<AgentMessage>) =>
+      setMessages((prev) => prev.map((m) => (m.id === resultId ? { ...m, ...fields } : m)));
+
     try {
-      const r = await runCapability({
-        agentId: action.cardId,
-        slug: action.slug,
-        operation: action.operation,
-        method: action.method,
-        body: isGet ? undefined : action.params,
-        query: isGet ? action.params : undefined,
-      });
-      const text = r.ok
-        ? `Ran ${action.operationName}${Number(r.paid) > 0 ? ` · paid $${r.paid} USDC` : " · free"}.` +
-          (r.borrowed ? ` Borrowed $${r.borrowed} from TrustLine.` : "") +
-          `\n\n${formatBody(r.body)}`
-        : `Couldn't run it: ${r.error ?? "something went wrong"}`;
-      setMessages((prev) => prev.map((m) => (m.id === resultId ? { ...m, content: text } : m)));
+      if (action.kind === "run") {
+        const isGet = (action.method ?? "GET").toUpperCase() === "GET";
+        const r = await runCapability({
+          agentId: action.cardId,
+          slug: action.slug,
+          operation: action.operation,
+          method: action.method,
+          body: isGet ? undefined : action.params,
+          query: isGet ? action.params : undefined,
+        });
+        patch({
+          content: r.ok
+            ? `Ran ${action.operationName}${Number(r.paid) > 0 ? ` · paid $${r.paid} USDC` : " · free"}.` +
+              (r.borrowed ? ` Borrowed $${r.borrowed} from TrustLine.` : "") +
+              `\n\n${formatBody(r.body)}`
+            : `Couldn't run it: ${r.error ?? "something went wrong"}`,
+        });
+      } else if (action.kind === "create_card") {
+        const r = await createAgent({
+          name: action.name,
+          maxPerCall: action.maxPerCall,
+          dailyLimit: action.dailyLimit,
+        });
+        if (r.ok) {
+          const steps = r.ready
+            ? "It's provisioned and ready. Send **USDC** to its address to fund it:"
+            : `To activate it: send **~1.5 XLM** to the address below, then it can hold a USDC trustline, then send **USDC** to fund it.${r.provisionError ? ` (${r.provisionError})` : ""}`;
+          patch({ content: `Created your **${action.name}** card. ${steps}\n\n\`${r.address}\`` });
+        } else {
+          patch({ content: `Couldn't create the card: ${r.error}` });
+        }
+      } else {
+        const r = await createApiKey(action.name, action.cardId ?? null);
+        if (r.ok) {
+          patch({
+            content: `Created API key **${action.name}**${action.cardName ? ` linked to your ${action.cardName} card` : ""}. Copy it now — you won't be able to see it again.`,
+            secret: r.key,
+          });
+        } else {
+          patch({ content: `Couldn't create the key: ${r.error}` });
+        }
+      }
     } catch {
-      setMessages((prev) =>
-        prev.map((m) => (m.id === resultId ? { ...m, content: "Sorry, that didn't run." } : m)),
-      );
+      patch({ content: "Sorry, that didn't complete." });
     } finally {
       busy.current = false;
       setStreaming(false);


### PR DESCRIPTION
Builds on #151 (L3 run-capability). Adds the two remaining agentic abilities you asked for, plus the keyboard toggle.

## New copilot abilities (both confirm-gated)
- **Create a card** — *'create a card for me'* → confirm → creates it and shows the **address + funding steps** (testnet auto-funds; mainnet walks **XLM → USDC trustline → USDC**).
- **Create an API key** — *'create an api with my Research card'* → confirm → creates it and reveals the raw key **once**, in a secure copy box (amber warning, one-tap copy, 'you won't see this again').

Both use the same confirm-card pattern as run-capability; `ProposedAction` is now a discriminated union (`run` | `create_card` | `create_api_key`) and `runAction` dispatches by kind. Added funding/provisioning steps to the copilot's knowledge so it walks XLM → trustline → USDC correctly.

## Also
- **Cmd/Ctrl + K** toggles the copilot open/closed. *(Note: Cmd+T is the browser's new-tab shortcut and can't be intercepted, so I used K — easy to change.)*

## Design
Kind-aware confirm cards, a secure one-time key reveal with copy, all in the widget's dark theme. Assistant replies render as markdown (from #151).

`typecheck` · `lint` · `format` green.

> Note: this branch stacks on #151 — merge #151 first (or merge this after and it carries both).