### PR TITLE
fix(copilot): find every capability + scrollable JSON + wrapped addresses + longer timeout

### DIFF
--- a/apps/dashboard/app/api/agent/route.ts
+++ b/apps/dashboard/app/api/agent/route.ts
@@ -16,6 +16,9 @@ import { getWalletOverview } from "../../../features/wallet/queries";
 // card pays. Talks to OpenRouter (default Gemini 2.5 Flash, swappable). Node
 // runtime: reads a server-only key and touches server-only queries.
 export const runtime = "nodejs";
+// The tool loop makes several model calls; give it room so multi-step asks
+// (e.g. "run the TrustLine capability") don't hit the default function timeout.
+export const maxDuration = 60;
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MODEL = process.env.OPENROUTER_MODEL ?? "google/gemini-2.5-flash";
@@ -98,6 +101,24 @@ function kebab(s: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+/** Trim a capability to what the model needs to find + run it, so the whole
+ *  marketplace fits in one tool result instead of being clipped after the first. */
+function compactCap(c: Awaited<ReturnType<typeof listPublicCapabilities>>[number]) {
+  return {
+    name: c.name,
+    slug: c.slug,
+    kind: c.kind,
+    price: c.price,
+    status: c.status,
+    operations: c.spec?.operations?.map((o) => ({
+      name: o.name,
+      slug: o.slug ?? kebab(o.name),
+      price: o.price,
+    })),
+    description: c.description ? c.description.slice(0, 140) : undefined,
+  };
+}
+
 /** Read-only tools return live data for the signed-in user, as compact JSON. */
 async function runTool(name: string, args: Record<string, unknown>): Promise<string> {
   try {
@@ -107,9 +128,9 @@ async function runTool(name: string, args: Record<string, unknown>): Promise<str
       case "list_cards":
         return clip(JSON.stringify(await listAgentWallets()));
       case "list_my_capabilities":
-        return clip(JSON.stringify(await listMyCapabilities()));
+        return clip(JSON.stringify((await listMyCapabilities()).map(compactCap)));
       case "browse_marketplace":
-        return clip(JSON.stringify(await listPublicCapabilities()));
+        return clip(JSON.stringify((await listPublicCapabilities()).map(compactCap)));
       case "get_recent_payments":
         return clip(JSON.stringify(await getPaymentsData()));
       case "get_capability": {

--- a/apps/dashboard/app/api/agent/route.ts
+++ b/apps/dashboard/app/api/agent/route.ts
@@ -284,9 +284,12 @@ export async function POST(request: Request) {
     return jsonError("The last message must be from the user.", 400);
   }
 
+  const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet" ? "mainnet" : "testnet";
   const page = body?.pageContext?.path;
   const system =
-    DASHBOARD_SYSTEM_PROMPT + (page ? `\n\n## Current page\nThe user is on: ${page}` : "");
+    DASHBOARD_SYSTEM_PROMPT +
+    `\n\n## This dashboard\nThis dashboard is running on Stellar **${network}**.` +
+    (page ? ` The user is on: ${page}` : "");
 
   const convo: ChatMessage[] = [
     { role: "system", content: system },

--- a/apps/dashboard/features/agent/knowledge.ts
+++ b/apps/dashboard/features/agent/knowledge.ts
@@ -32,7 +32,7 @@ Key concepts:
 
 ## Your tools
 You have read tools that return the user's real, live data. USE them, do not guess or make up numbers:
-- get_wallet_overview: the user's balance, spend, and revenue.
+- get_wallet_overview: the user's live balances (usdc, agentsUsdc, xlm) PLUS ledger totals — **revenue** (total USDC earned/received) and **spend** (total paid). Earnings = the revenue field, never a balance.
 - list_cards: the user's Cards and their live balances.
 - list_my_capabilities: the capabilities the user has published (name, price, status).
 - browse_marketplace: capabilities available to buy.
@@ -47,11 +47,15 @@ When a question is about the user's account ("my balance", "my capabilities", "d
 ## Page context
 Each message includes the page the user is currently on. Use it to answer "what is this page" or "what can I do here", and to make your help specific to where they are.
 
+## Network
+The "This dashboard" note tells you which Stellar network you're on (testnet or mainnet). Capabilities named "… (Mainnet)" are mainnet-only; the plain ones (e.g. "Stellar", "FX Rates") are testnet. ONLY run capabilities that match the current network — never propose a "(Mainnet)" capability on testnet, or a testnet one on mainnet, running the wrong one fails. When listing capabilities, prefer the ones for the current network.
+
 ## Funding a Card
 A new Card needs a little XLM to exist and hold a USDC trustline, then USDC to spend. On testnet it's auto-funded on creation. On mainnet, walk the user through: (1) send ~1.5 XLM to the Card's address, (2) it can then hold a USDC trustline, (3) send USDC to fund it. A wallet that RECEIVES payouts also needs a USDC trustline (Circle's issuer on mainnet).
 
 ## How to answer
 - Be concise, friendly, and practical. Short paragraphs.
 - You CAN run a capability, create a Card, and create an API key via the tools above — each one asks the user for a single-click confirm first, and any spending stays within the Card's caps. For publishing a capability, guide them to the right page.
+- "Earnings" / "revenue" = the revenue field from get_wallet_overview (USDC received). Never report a balance (usdc / agentsUsdc) as earnings — those are current holdings, not what was earned.
 - If a tool returns nothing or errors, say so plainly rather than inventing an answer.
 - Never reveal secrets, private keys, or raw internal IDs (the API key tool handles showing the key securely).`;

--- a/apps/dashboard/features/agent/message-bubble.tsx
+++ b/apps/dashboard/features/agent/message-bubble.tsx
@@ -100,7 +100,7 @@ function renderInline(s: string): ReactNode[] {
       out.push(<strong key={k++}>{tok.slice(2, -2)}</strong>);
     } else {
       out.push(
-        <code key={k++} className="rounded bg-white/10 px-1 py-0.5 font-mono text-[12px]">
+        <code key={k++} className="break-all rounded bg-white/10 px-1 py-0.5 font-mono text-[12px]">
           {tok.slice(1, -1)}
         </code>,
       );
@@ -118,6 +118,7 @@ function renderInline(s: string): ReactNode[] {
 function Markdown({ text }: { text: string }) {
   const blocks: ReactNode[] = [];
   let list: { ordered: boolean; items: string[] } | null = null;
+  let code: string[] | null = null;
 
   const flush = (key: string) => {
     if (!list) return;
@@ -136,7 +137,34 @@ function Markdown({ text }: { text: string }) {
     list = null;
   };
 
+  const flushCode = (key: string) => {
+    if (code === null) return;
+    blocks.push(
+      <pre
+        key={`c${key}`}
+        className="max-h-64 overflow-auto rounded-lg bg-black/30 p-2.5 font-mono text-[11.5px] leading-relaxed"
+      >
+        <code>{code.join("\n")}</code>
+      </pre>,
+    );
+    code = null;
+  };
+
   text.split("\n").forEach((line, i) => {
+    // ``` fences toggle a scrollable code block (e.g. a JSON result).
+    if (line.trim().startsWith("```")) {
+      if (code === null) {
+        flush(`${i}`);
+        code = [];
+      } else {
+        flushCode(`${i}`);
+      }
+      return;
+    }
+    if (code !== null) {
+      code.push(line);
+      return;
+    }
     const bullet = line.match(/^\s*[*-]\s+(.*)/);
     const number = line.match(/^\s*\d+\.\s+(.*)/);
     if (bullet) {
@@ -155,6 +183,7 @@ function Markdown({ text }: { text: string }) {
     if (line.trim()) blocks.push(<p key={i}>{renderInline(line)}</p>);
   });
   flush("end");
+  flushCode("end");
 
   return <div className="space-y-2 leading-relaxed">{blocks}</div>;
 }

--- a/apps/dashboard/features/agent/use-agent-chat.ts
+++ b/apps/dashboard/features/agent/use-agent-chat.ts
@@ -153,9 +153,9 @@ export function useAgentChat(endpoint: string) {
         });
         patch({
           content: r.ok
-            ? `Ran ${action.operationName}${Number(r.paid) > 0 ? ` · paid $${r.paid} USDC` : " · free"}.` +
-              (r.borrowed ? ` Borrowed $${r.borrowed} from TrustLine.` : "") +
-              `\n\n${formatBody(r.body)}`
+            ? `**Ran ${action.operationName}**${Number(r.paid) > 0 ? ` · paid $${r.paid} USDC` : " · free"}` +
+              (r.borrowed ? ` · borrowed $${r.borrowed} from TrustLine` : "") +
+              (r.body ? `\n\n\`\`\`json\n${formatBody(r.body)}\n\`\`\`` : "")
             : `Couldn't run it: ${r.error ?? "something went wrong"}`,
         });
       } else if (action.kind === "create_card") {
@@ -166,8 +166,9 @@ export function useAgentChat(endpoint: string) {
         });
         if (r.ok) {
           const steps = r.ready
-            ? "It's provisioned and ready. Send **USDC** to its address to fund it:"
-            : `To activate it: send **~1.5 XLM** to the address below, then it can hold a USDC trustline, then send **USDC** to fund it.${r.provisionError ? ` (${r.provisionError})` : ""}`;
+            ? "It's funded with XLM and has a USDC trustline, so it's ready to spend. To top it up, send **USDC** to its address:"
+            : "To activate it:\n\n1. Send **~1.5 XLM** to the address below (covers the account reserve + a USDC trustline).\n2. Then send **USDC** to fund it." +
+              (r.provisionError ? `\n\n(${r.provisionError})` : "");
           patch({ content: `Created your **${action.name}** card. ${steps}\n\n\`${r.address}\`` });
         } else {
           patch({ content: `Couldn't create the card: ${r.error}` });

--- a/apps/dashboard/features/wallet/queries.ts
+++ b/apps/dashboard/features/wallet/queries.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { agents, eq, wallets } from "@tael/database";
+import { agents, eq, inArray, payments, sql, wallets } from "@tael/database";
 import { Money } from "@tael/types";
 import { db } from "../../lib/db";
 import { getSession } from "../../lib/auth";
@@ -16,9 +16,13 @@ export interface WalletOverview {
   xlm: string;
   /** Whether the connected wallet holds a USDC trustline. */
   hasUsdc: boolean;
-  /** Combined USDC held across the user's agent hot wallets. */
+  /** Combined USDC held across the user's agent hot wallets (a BALANCE, not earnings). */
   agentsUsdc: string;
   agentCount: number;
+  /** Total USDC the user has EARNED (received to any of their wallets), from the ledger. */
+  revenue: string;
+  /** Total USDC the user has SPENT (paid from any of their wallets), from the ledger. */
+  spend: string;
 }
 
 async function fetchXlm(address: string): Promise<{ xlm: string; hasUsdc: boolean }> {
@@ -56,6 +60,8 @@ export async function getWalletOverview(): Promise<WalletOverview> {
 
   let agentsUsdc = Money.zero();
   let agentCount = 0;
+  let revenue = "0";
+  let spend = "0";
   if (user) {
     const rows = await db
       .select({ address: wallets.address })
@@ -65,6 +71,23 @@ export async function getWalletOverview(): Promise<WalletOverview> {
     agentCount = rows.length;
     const balances = await Promise.all(rows.map((r) => fetchUsdcBalance(r.address)));
     agentsUsdc = balances.reduce((sum, b) => sum.add(Money.parse(b.usdc)), Money.zero());
+
+    // Earnings vs spend from the ledger: USDC received to, vs paid from, any of
+    // the user's addresses (their connected wallet + every Card). This is real
+    // revenue — not to be confused with the balances above.
+    const addrs = [address, ...rows.map((r) => r.address)].filter((a): a is string => !!a);
+    if (addrs.length) {
+      const [rev] = await db
+        .select({ v: sql<string>`coalesce(sum(${payments.amount}), 0)` })
+        .from(payments)
+        .where(inArray(payments.payee, addrs));
+      const [sp] = await db
+        .select({ v: sql<string>`coalesce(sum(${payments.amount} + ${payments.fee}), 0)` })
+        .from(payments)
+        .where(inArray(payments.payer, addrs));
+      revenue = rev?.v ?? "0";
+      spend = sp?.v ?? "0";
+    }
   }
 
   return {
@@ -74,5 +97,7 @@ export async function getWalletOverview(): Promise<WalletOverview> {
     hasUsdc: xlm.hasUsdc,
     agentsUsdc: agentsUsdc.toDecimalString(),
     agentCount,
+    revenue,
+    spend,
   };
 }


### PR DESCRIPTION
These fixes were pushed **after** #152 was already merged, so they're not on `main` yet.

- **browse_marketplace / list_my_capabilities** now return compact entries so the whole marketplace fits, the copilot was only seeing the first capability and couldn't find TrustLine or run others.
- **maxDuration=60** so multi-step asks don't hit the function timeout ('Failed to fetch').
- Markdown renderer handles fenced **code blocks** (scrollable) and **wraps long inline code** (addresses); run results show JSON in a code block with a friendly summary.
- Clearer network-aware **card funding steps** (XLM reserve then USDC).

`typecheck` · `lint` · `format` green.