### PR TITLE
fix(copilot): make Stellar pay/swap work, align earnings, add on-chain proof

### DIFF
--- a/apps/dashboard/app/api/agent/route.ts
+++ b/apps/dashboard/app/api/agent/route.ts
@@ -56,7 +56,11 @@ const TOOLS = [
     {
       slug: { type: "string", description: "The capability's URL slug." },
       operation: { type: "string", description: "The operation to run (its slug or name)." },
-      params: { type: "string", description: "Optional query string or JSON body for the op." },
+      params: {
+        type: "string",
+        description:
+          "The op's parameters, formatted exactly like its `sample` field. For action ops (e.g. Stellar 'pay' or 'swap') this is required — pass every key the sample shows, e.g. `to=G…&amount=1.5`. Ask the user for any value you don't have (like the destination address or amount) before proposing the run.",
+      },
     },
   ),
   fn(
@@ -114,6 +118,10 @@ function compactCap(c: Awaited<ReturnType<typeof listPublicCapabilities>>[number
       name: o.name,
       slug: o.slug ?? kebab(o.name),
       price: o.price,
+      method: o.method ?? "GET",
+      // How params are shaped for this op (e.g. `to=G…&amount=1.5`) so the model
+      // fills them correctly when it proposes a run.
+      sample: o.sampleRequest,
     })),
     description: c.description ? c.description.slice(0, 140) : undefined,
   };

--- a/apps/dashboard/features/agent/knowledge.ts
+++ b/apps/dashboard/features/agent/knowledge.ts
@@ -50,6 +50,12 @@ Each message includes the page the user is currently on. Use it to answer "what 
 ## Network
 The "This dashboard" note tells you which Stellar network you're on (testnet or mainnet). Capabilities named "… (Mainnet)" are mainnet-only; the plain ones (e.g. "Stellar", "FX Rates") are testnet. ONLY run capabilities that match the current network — never propose a "(Mainnet)" capability on testnet, or a testnet one on mainnet, running the wrong one fails. When listing capabilities, prefer the ones for the current network.
 
+## Running an on-chain action (Stellar pay / swap)
+Some operations are on-chain ACTIONS, not data lookups — e.g. Stellar "pay" (send USDC) and "swap". They read their inputs from the op's \`sample\` (e.g. \`to=G…&amount=1.5\`). Before proposing one:
+- Make sure you have EVERY value the sample shows. For "pay" that's the destination address ("to") and the "amount". If the user hasn't given one, ASK for it first — never invent an address or amount.
+- Pass them in \`params\` exactly like the sample (e.g. \`to=GC62…&amount=1\`).
+The operation itself is free to CALL, but the action moves real USDC from the card (plus a small network fee) once the user confirms — so say what it will send, e.g. "send 1 USDC to GC62…", not just "it's free". The destination must already exist and hold a USDC trustline, or the call is rejected.
+
 ## Funding a Card
 A new Card needs a little XLM to exist and hold a USDC trustline, then USDC to spend. On testnet it's auto-funded on creation. On mainnet, walk the user through: (1) send ~1.5 XLM to the Card's address, (2) it can then hold a USDC trustline, (3) send USDC to fund it. A wallet that RECEIVES payouts also needs a USDC trustline (Circle's issuer on mainnet).
 

--- a/apps/dashboard/features/agent/message-bubble.tsx
+++ b/apps/dashboard/features/agent/message-bubble.tsx
@@ -86,10 +86,10 @@ function SecretBox({ value }: { value: string }) {
   );
 }
 
-/** Inline markdown: **bold** and `code`. */
+/** Inline markdown: **bold**, `code`, and [label](url) links. */
 function renderInline(s: string): ReactNode[] {
   const out: ReactNode[] = [];
-  const re = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+  const re = /(\*\*[^*]+\*\*|`[^`]+`|\[[^\]]+\]\([^)\s]+\))/g;
   let last = 0;
   let k = 0;
   let m: RegExpExecArray | null;
@@ -98,11 +98,28 @@ function renderInline(s: string): ReactNode[] {
     const tok = m[0];
     if (tok.startsWith("**")) {
       out.push(<strong key={k++}>{tok.slice(2, -2)}</strong>);
-    } else {
+    } else if (tok.startsWith("`")) {
       out.push(
         <code key={k++} className="break-all rounded bg-white/10 px-1 py-0.5 font-mono text-[12px]">
           {tok.slice(1, -1)}
         </code>,
+      );
+    } else {
+      const link = tok.match(/^\[([^\]]+)\]\(([^)\s]+)\)$/);
+      out.push(
+        link ? (
+          <a
+            key={k++}
+            href={link[2]}
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium text-sky-400 underline decoration-sky-400/40 underline-offset-2 transition-colors hover:text-sky-300"
+          >
+            {link[1]}
+          </a>
+        ) : (
+          tok
+        ),
       );
     }
     last = m.index + tok.length;

--- a/apps/dashboard/features/agent/tael-agent.tsx
+++ b/apps/dashboard/features/agent/tael-agent.tsx
@@ -35,6 +35,13 @@ export function TaelAgent({
   const wasStreaming = useRef(false);
   const askedPermission = useRef(false);
 
+  // Pre-warm the gateway on mount so the first paid call in a demo isn't slow
+  // from a cold start. Fire-and-forget and silent — no UI, errors ignored.
+  useEffect(() => {
+    const base = process.env.NEXT_PUBLIC_API_URL;
+    if (base) void fetch(`${base}/health`, { cache: "no-store" }).catch(() => {});
+  }, []);
+
   // Keep the transcript pinned to the latest message as it streams in.
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });

--- a/apps/dashboard/features/agent/use-agent-chat.ts
+++ b/apps/dashboard/features/agent/use-agent-chat.ts
@@ -16,6 +16,11 @@ function nextId(): string {
 /** Persist the conversation so context survives a reload or navigating away. */
 const STORAGE_KEY = "tael-copilot-chat";
 
+/** stellar.expert explorer base for the current network — for on-chain proof links. */
+const STELLAR_EXPERT_TX = `https://stellar.expert/explorer/${
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet" ? "public" : "testnet"
+}/tx/`;
+
 function loadMessages(): AgentMessage[] {
   if (typeof window === "undefined") return [];
   try {
@@ -23,6 +28,42 @@ function loadMessages(): AgentMessage[] {
     return raw ? (JSON.parse(raw) as AgentMessage[]) : [];
   } catch {
     return [];
+  }
+}
+
+/**
+ * The model returns an op's params as one freeform string. Coerce it to the
+ * shape the op's METHOD needs — a query string for GET, a JSON body for POST —
+ * so a Stellar pay works whether the model emitted `to=G…&amount=1` or
+ * `{"to":"G…","amount":"1"}`. Without this, a JSON string handed to a GET op
+ * lands as one junk query key and the op 400s for a missing `to`/`amount`.
+ */
+function paramsForMethod(raw: string | undefined, isGet: boolean): string | undefined {
+  const s = raw?.trim();
+  if (!s) return undefined;
+  const looksJson = s.startsWith("{");
+  if (isGet) {
+    if (!looksJson) return s.replace(/^\?/, "");
+    try {
+      const obj = JSON.parse(s) as Record<string, unknown>;
+      return new URLSearchParams(
+        Object.entries(obj)
+          .filter(([, v]) => v != null && v !== "")
+          .map(([k, v]) => [k, String(v)]),
+      ).toString();
+    } catch {
+      return s;
+    }
+  }
+  if (looksJson) return s;
+  try {
+    const obj: Record<string, string> = {};
+    new URLSearchParams(s.replace(/^\?/, "")).forEach((v, k) => {
+      obj[k] = v;
+    });
+    return JSON.stringify(obj);
+  } catch {
+    return s;
   }
 }
 
@@ -143,18 +184,20 @@ export function useAgentChat(endpoint: string) {
     try {
       if (action.kind === "run") {
         const isGet = (action.method ?? "GET").toUpperCase() === "GET";
+        const params = paramsForMethod(action.params, isGet);
         const r = await runCapability({
           agentId: action.cardId,
           slug: action.slug,
           operation: action.operation,
           method: action.method,
-          body: isGet ? undefined : action.params,
-          query: isGet ? action.params : undefined,
+          body: isGet ? undefined : params,
+          query: isGet ? params : undefined,
         });
         patch({
           content: r.ok
             ? `**Ran ${action.operationName}**${Number(r.paid) > 0 ? ` · paid $${r.paid} USDC` : " · free"}` +
               (r.borrowed ? ` · borrowed $${r.borrowed} from TrustLine` : "") +
+              (r.txHash ? `\n\n[View on-chain proof ↗](${STELLAR_EXPERT_TX}${r.txHash})` : "") +
               (r.body ? `\n\n\`\`\`json\n${formatBody(r.body)}\n\`\`\`` : "")
             : `Couldn't run it: ${r.error ?? "something went wrong"}`,
         });

--- a/apps/dashboard/features/agents/actions.ts
+++ b/apps/dashboard/features/agents/actions.ts
@@ -14,6 +14,17 @@ const USDC_ISSUER = process.env.USDC_ISSUER ?? "";
 const nameSchema = z.string().trim().min(1, "Name is required").max(60);
 const amountSchema = z.string().regex(/^\d+(\.\d+)?$/, "Enter an amount, e.g. 0.10");
 
+/**
+ * Resolve `p`, but give up after `ms` and resolve `onTimeout` instead. Wallet
+ * provisioning does network I/O (friendbot fund + trustline) that can outlast a
+ * serverless function's budget — if the whole action ran that long the transport
+ * call would reject on the client even though the agent row was already written.
+ * Capping the wait keeps createAgent snappy; provisioning stays retryable.
+ */
+function withTimeout<T>(p: Promise<T>, ms: number, onTimeout: T): Promise<T> {
+  return Promise.race([p, new Promise<T>((resolve) => setTimeout(() => resolve(onTimeout), ms))]);
+}
+
 const createAgentSchema = z.object({
   name: nameSchema,
   maxPerCall: amountSchema,
@@ -82,12 +93,16 @@ export async function createAgent(input: {
   // defensively so a provisioning fault can never crash the create action.
   let provision: { ok: boolean; ready: boolean; error?: string };
   try {
-    provision = await provisionHotWallet({
-      secret: keypair.secret,
-      network: STELLAR_NETWORK,
-      horizonUrl: HORIZON_URL,
-      usdcIssuer: USDC_ISSUER,
-    });
+    provision = await withTimeout(
+      provisionHotWallet({
+        secret: keypair.secret,
+        network: STELLAR_NETWORK,
+        horizonUrl: HORIZON_URL,
+        usdcIssuer: USDC_ISSUER,
+      }),
+      12_000,
+      { ok: false, ready: false, error: "Still provisioning — retry from the card in a moment." },
+    );
   } catch (error) {
     console.error("[agents] provision threw:", error);
     provision = { ok: false, ready: false, error: "Provisioning failed. Retry from the agent." };

--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -61,6 +61,8 @@ export interface RunResult {
   paid?: string;
   /** USDC drawn from TrustLine credit to cover a shortfall on this call, if any. */
   borrowed?: string;
+  /** The Stellar settlement tx hash, for an on-chain proof link. */
+  txHash?: string;
   error?: string;
 }
 
@@ -331,7 +333,20 @@ export async function runCapability(input: {
       const buffer = agent.policy?.maxPerCall ?? total.toDecimalString();
       await maybeRepayTrustLineCredit(secretEnc, buffer);
     }
-    return { ok: true, status: res.status, body, paid: total.toDecimalString(), borrowed };
+    // Pull the settlement tx hash out of the gateway's receipt header, for an
+    // on-chain proof link. Best-effort — no link if it can't be decoded.
+    let txHash: string | undefined;
+    const receiptHeader = res.headers.get("x-payment-response");
+    if (receiptHeader) {
+      try {
+        txHash = (
+          JSON.parse(Buffer.from(receiptHeader, "base64").toString("utf8")) as { txHash?: string }
+        ).txHash;
+      } catch {
+        // ignore
+      }
+    }
+    return { ok: true, status: res.status, body, paid: total.toDecimalString(), borrowed, txHash };
   } catch {
     return { ok: false, error: "Couldn't reach the capability. Try again." };
   }
@@ -432,7 +447,13 @@ async function runPayAction(
       asset: "USDC",
       txHash: receipt.txHash,
     };
-    return { ok: true, status: 200, body: JSON.stringify(result), paid: total.toDecimalString() };
+    return {
+      ok: true,
+      status: 200,
+      body: JSON.stringify(result),
+      paid: total.toDecimalString(),
+      txHash: receipt.txHash,
+    };
   } catch (error) {
     console.error("[run] pay action failed:", error);
     return {
@@ -614,7 +635,13 @@ async function runSwapAction(
       fee: feeStr,
       txHash: receipt.txHash,
     };
-    return { ok: true, status: 200, body: JSON.stringify(result), paid: usdcOut.toDecimalString() };
+    return {
+      ok: true,
+      status: 200,
+      body: JSON.stringify(result),
+      paid: usdcOut.toDecimalString(),
+      txHash: receipt.txHash,
+    };
   } catch (error) {
     console.error("[run] swap action failed:", error);
     return {

--- a/apps/dashboard/features/wallet/queries.ts
+++ b/apps/dashboard/features/wallet/queries.ts
@@ -1,9 +1,10 @@
 import "server-only";
-import { agents, eq, inArray, payments, sql, wallets } from "@tael/database";
+import { agents, eq, wallets } from "@tael/database";
 import { Money } from "@tael/types";
 import { db } from "../../lib/db";
 import { getSession } from "../../lib/auth";
 import { getCurrentUser } from "../capabilities/current-user";
+import { getPaymentsData } from "../payments/queries";
 import { fetchUsdcBalance } from "../agents/balance";
 
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
@@ -72,22 +73,12 @@ export async function getWalletOverview(): Promise<WalletOverview> {
     const balances = await Promise.all(rows.map((r) => fetchUsdcBalance(r.address)));
     agentsUsdc = balances.reduce((sum, b) => sum.add(Money.parse(b.usdc)), Money.zero());
 
-    // Earnings vs spend from the ledger: USDC received to, vs paid from, any of
-    // the user's addresses (their connected wallet + every Card). This is real
-    // revenue — not to be confused with the balances above.
-    const addrs = [address, ...rows.map((r) => r.address)].filter((a): a is string => !!a);
-    if (addrs.length) {
-      const [rev] = await db
-        .select({ v: sql<string>`coalesce(sum(${payments.amount}), 0)` })
-        .from(payments)
-        .where(inArray(payments.payee, addrs));
-      const [sp] = await db
-        .select({ v: sql<string>`coalesce(sum(${payments.amount} + ${payments.fee}), 0)` })
-        .from(payments)
-        .where(inArray(payments.payer, addrs));
-      revenue = rev?.v ?? "0";
-      spend = sp?.v ?? "0";
-    }
+    // Use the SAME earned/spent the Payments page shows, so the copilot and the
+    // page never disagree: earned = revenue from the user's published
+    // capabilities, spent = what their Cards paid (incl. fees).
+    const pay = await getPaymentsData();
+    revenue = pay.earned;
+    spend = pay.spent;
   }
 
   return {


### PR DESCRIPTION
## Why

Running **Stellar pay** from the copilot failed with `Couldn't run it: The call failed (400)`, and a few smaller copilot rough edges (earnings mismatch, no on-chain proof, create-card "didn't complete", cold first call). This fixes all of them.

## The pay 400 (root cause)

The Stellar `pay` op is a `GET` that reads `to`/`amount` from the **query string** (`/c/stellar/pay?to=G…&amount=1`) and returns **400** when they're missing/invalid. The copilot:
- exposed operations to the model as only `{name, slug, price}`, so the model never saw the required `to=…&amount=…` format, and
- didn't normalize the freeform `params` string the model produced.

So the model emitted JSON, which — handed to a GET op — became one junk query key. The op saw no valid `to`/`amount` and 400'd **before** it ever reached signing/settlement.

## What changed

- **Normalize params to the op's method** (`use-agent-chat.ts`): a proposed run's params are coerced to a query string for GET and a JSON body for POST, so a pay works whether the model emits `to=G…&amount=1` or `{"to":"G…","amount":"1"}`.
- **Show the model each op's `method` + `sample`** (`route.ts` `compactCap`) and instruct it (tool description + `knowledge.ts`) to gather the destination/amount first, format like the sample, and say *"send 1 USDC to G…"* instead of calling an on-chain action "free".
- **On-chain proof link** (`run-capability.ts` + `message-bubble.tsx` + `use-agent-chat.ts`): surface the settlement `txHash` from the gateway's `X-PAYMENT-RESPONSE` receipt (and from the pay/swap paths) and render a clickable `stellar.expert` link on every successful run. The markdown renderer now supports `[label](url)`.
- **Earnings alignment** (`wallet/queries.ts`): report earnings/spend from the same `getPaymentsData()` the Payments page uses, so they can't disagree.
- **create-card "didn't complete"** (`actions.ts`): bound provisioning with a 12s timeout so `createAgent` returns the address promptly instead of the transport call rejecting after the card was already created (provisioning stays retryable from the card).
- **Pre-warm** (`tael-agent.tsx`): silently hit the gateway `/health` on widget mount so the first paid call isn't cold.

## Notes / caveats

- The pay/prompt changes are server-route + system-prompt, so they only take effect once the dashboard **redeploys**.
- Even with correct params, a pay is still rejected (422) if the destination isn't funded or lacks a **USDC trustline** for the current issuer.

## Verification

`pnpm --filter dashboard typecheck` ✅ · `prettier --check` ✅ · `eslint` ✅ on all changed files.