### PR TITLE
feat(copilot): name the destination + amount on a pay confirm card

### DIFF
--- a/apps/dashboard/app/api/agent/route.ts
+++ b/apps/dashboard/app/api/agent/route.ts
@@ -163,22 +163,25 @@ const ACTION_FEE_BPS = Number(process.env.TAEL_ACTION_FEE_BPS ?? "100");
 const ACTION_FEE_RATE =
   process.env.TAEL_FEE_ADDRESS && ACTION_FEE_BPS > 0 ? ACTION_FEE_BPS / 1e4 : 0;
 
-/** Pull a positive `amount` out of a run's params, whether the model formatted
- *  them as a query string (`to=G…&amount=1`) or JSON (`{"amount":"1"}`). */
-function amountFromParams(params: string | undefined): number | null {
+/** Read one param out of a run's params, whether the model formatted them as a
+ *  query string (`to=G…&amount=1`) or JSON (`{"to":"G…","amount":"1"}`). */
+function paramValue(params: string | undefined, key: string): string | null {
   const s = params?.trim();
   if (!s) return null;
-  let raw: string | null | undefined;
   if (s.startsWith("{")) {
     try {
-      raw = String((JSON.parse(s) as Record<string, unknown>).amount ?? "");
+      const v = (JSON.parse(s) as Record<string, unknown>)[key];
+      return v == null ? null : String(v);
     } catch {
-      raw = undefined;
+      return null;
     }
-  } else {
-    raw = new URLSearchParams(s.replace(/^\?/, "")).get("amount");
   }
-  const n = Number(raw);
+  return new URLSearchParams(s.replace(/^\?/, "")).get(key);
+}
+
+/** The positive `amount` a run sends, or null if absent/invalid. */
+function amountFromParams(params: string | undefined): number | null {
+  const n = Number(paramValue(params, "amount"));
   return Number.isFinite(n) && n > 0 ? n : null;
 }
 
@@ -285,6 +288,10 @@ async function proposeRun(
       // Show the true per-call cost on the confirm button (the amount + fee for
       // an action), not the op's free call price.
       price: sendAmount != null ? trimNum(spend) : price,
+      // For a pay/swap, tell the confirm card what it sends + where, so it can
+      // read "Send $1 USDC to G…" instead of just a bare amount.
+      ...(sendAmount != null ? { sendAmount: trimNum(sendAmount) } : {}),
+      ...(isAction && paramValue(params, "to") ? { sendTo: paramValue(params, "to")! } : {}),
     },
   };
 }

--- a/apps/dashboard/features/agent/message-bubble.tsx
+++ b/apps/dashboard/features/agent/message-bubble.tsx
@@ -5,6 +5,11 @@ import { motion } from "framer-motion";
 import type { AgentMessage, ProposedAction } from "./types";
 import { DiscordIcon } from "./icons";
 
+/** Truncate a Stellar address for display, e.g. GC62IXD4…LBRK. */
+function shortAddr(a: string): string {
+  return a.length > 12 ? `${a.slice(0, 6)}…${a.slice(-4)}` : a;
+}
+
 /** The confirm card for a proposed action; the label + button follow its kind. */
 function ActionCard({ action, onRun }: { action: ProposedAction; onRun: () => void }) {
   let label: string;
@@ -12,18 +17,36 @@ function ActionCard({ action, onRun }: { action: ProposedAction; onRun: () => vo
   let sub: ReactNode = null;
   let button: string;
   if (action.kind === "run") {
-    label = "Run capability";
+    // A pay/swap carries a send amount (and a pay, a destination): show what it
+    // does, e.g. "Sends $1 USDC to GC62…LBRK", not just the op name.
+    const sending = action.sendAmount != null;
+    label = sending ? "Send payment" : "Run capability";
     title = (
       <>
         {action.operationName} <span className="text-white/50">· {action.capabilityName}</span>
       </>
     );
-    sub = (
+    sub = sending ? (
+      <>
+        Sends <span className="text-white/70">${action.sendAmount} USDC</span>
+        {action.sendTo ? (
+          <>
+            {" "}
+            to <span className="text-white/70">{shortAddr(action.sendTo)}</span>
+          </>
+        ) : null}{" "}
+        · from your <span className="text-white/70">{action.cardName}</span> card
+      </>
+    ) : (
       <>
         Pays from your <span className="text-white/70">{action.cardName}</span> card
       </>
     );
-    button = Number(action.price) > 0 ? `Run · $${action.price} USDC` : "Run · free";
+    button = sending
+      ? `Send · $${action.sendAmount} USDC`
+      : Number(action.price) > 0
+        ? `Run · $${action.price} USDC`
+        : "Run · free";
   } else if (action.kind === "create_card") {
     label = "Create card";
     title = action.name;

--- a/apps/dashboard/features/agent/types.ts
+++ b/apps/dashboard/features/agent/types.ts
@@ -14,6 +14,11 @@ export interface RunAction {
   operationName: string;
   /** USDC price shown on the confirm button. */
   price: string;
+  /** For an on-chain action (pay/swap): the USDC amount being sent, so the
+   *  confirm card can say what it does (e.g. "Send $1 USDC to G…"). */
+  sendAmount?: string;
+  /** For a pay: the destination address, shown (truncated) on the confirm card. */
+  sendTo?: string;
 }
 
 /** Create a new Card (agent wallet). */


### PR DESCRIPTION
Follow-up to #155. A pay/swap proposal now carries the send amount (and, for a pay, the destination), so the confirm card reads what it does instead of a bare op name:

- **Before:** Run capability · Pay · Stellar · 'Pays from your Research card' · button 'Run · $1.01 USDC'
- **After:** Send payment · Pay · Stellar · 'Sends $1 USDC to GC62…LBRK · from your Research card' · button 'Send · $1 USDC'

Both keys are parsed from the run params (query string or JSON) via a shared paramValue helper; falls back to the plain 'Run capability' card for non-action ops.

Verify: typecheck, prettier --check, eslint all clean.