### PR TITLE
feat(copilot): capture a page block and attach it to the copilot

### DIFF
--- a/apps/dashboard/app/api/agent/route.ts
+++ b/apps/dashboard/app/api/agent/route.ts
@@ -30,9 +30,12 @@ interface ToolCall {
   id: string;
   function: { name: string; arguments: string };
 }
+/** A multimodal content part (text or an image data URL), for attached blocks. */
+type ContentPart =
+  { type: "text"; text: string } | { type: "image_url"; image_url: { url: string } };
 interface ChatMessage {
   role: string;
-  content: string | null;
+  content: string | ContentPart[] | null;
   tool_calls?: ToolCall[];
   tool_call_id?: string;
   name?: string;
@@ -357,7 +360,7 @@ function jsonError(message: string, status: number): Response {
 }
 
 interface AgentRequestBody {
-  messages?: { role: "user" | "assistant"; content: string }[];
+  messages?: { role: "user" | "assistant"; content: string; attachments?: string[] }[];
   pageContext?: { path?: string };
 }
 
@@ -377,11 +380,22 @@ export async function POST(request: Request) {
   const system =
     DASHBOARD_SYSTEM_PROMPT +
     `\n\n## This dashboard\nThis dashboard is running on Stellar **${network}**.` +
-    (page ? ` The user is on: ${page}` : "");
+    (page ? ` The user is on: ${page}` : "") +
+    `\n\nThe user can attach a screenshot of a block on this page. When one is attached, read it and answer about exactly what's shown.`;
 
   const convo: ChatMessage[] = [
     { role: "system", content: system },
-    ...messages.slice(-20).map((m) => ({ role: m.role, content: m.content })),
+    ...messages.slice(-20).map((m) => ({
+      role: m.role,
+      // A message with attached block screenshots becomes multimodal content so
+      // the (vision) model can actually see what's on the user's screen.
+      content: m.attachments?.length
+        ? ([
+            { type: "text", text: m.content || "(screenshot of a page block)" },
+            ...m.attachments.map((url) => ({ type: "image_url" as const, image_url: { url } })),
+          ] as ContentPart[])
+        : m.content,
+    })),
   ];
 
   for (let hop = 0; hop < MAX_TOOL_HOPS; hop += 1) {
@@ -449,7 +463,7 @@ export async function POST(request: Request) {
       continue;
     }
 
-    return reply(message.content ?? "");
+    return reply(typeof message.content === "string" ? message.content : "");
   }
 
   return reply("I couldn't quite finish that — try rephrasing?");

--- a/apps/dashboard/features/agent/element-picker.tsx
+++ b/apps/dashboard/features/agent/element-picker.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** What we show in the little inspector tooltip while hovering a block. */
+interface BlockMeta {
+  tag: string;
+  size: string;
+  color: string;
+  font: string;
+}
+
+interface Hover {
+  rect: DOMRect;
+  el: HTMLElement;
+  meta: BlockMeta;
+}
+
+/** "rgb(255, 255, 255)" → "#FFFFFF" (best-effort; passes other formats through). */
+function rgbToHex(rgb: string): string {
+  const m = rgb.match(/\d+/g);
+  if (!m || m.length < 3) return rgb;
+  return (
+    "#" +
+    m
+      .slice(0, 3)
+      .map((n) => Number(n).toString(16).padStart(2, "0"))
+      .join("")
+      .toUpperCase()
+  );
+}
+
+function metaFor(el: HTMLElement, rect: DOMRect): BlockMeta {
+  const cs = getComputedStyle(el);
+  const family = cs.fontFamily.split(",")[0]?.replace(/["']/g, "").trim() ?? "";
+  return {
+    tag: el.tagName.toLowerCase(),
+    size: `${Math.round(rect.width)}x${Math.round(rect.height)}`,
+    color: rgbToHex(cs.color),
+    font: `${cs.fontSize} ${family}`,
+  };
+}
+
+/** Shrink a capture to a sane size (cap width, JPEG) so the attachment stays
+ *  small enough to persist and to send to the model. */
+function downscale(dataUrl: string, maxW = 1400, quality = 0.85): Promise<string> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      const scale = Math.min(1, maxW / img.width);
+      const w = Math.max(1, Math.round(img.width * scale));
+      const h = Math.max(1, Math.round(img.height * scale));
+      const canvas = document.createElement("canvas");
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return resolve(dataUrl);
+      ctx.drawImage(img, 0, 0, w, h);
+      resolve(canvas.toDataURL("image/jpeg", quality));
+    };
+    img.onerror = () => resolve(dataUrl);
+    img.src = dataUrl;
+  });
+}
+
+/**
+ * A full-screen "inspect and capture" overlay. While active, it highlights the
+ * block under the cursor (with a tag/size/color/font tooltip, like a browser
+ * inspector), and a click screenshots just that block and hands back a data URL.
+ * The overlay's own chrome is pointer-events:none so `elementFromPoint` sees the
+ * real page; the click is caught in the capture phase so it never activates the
+ * underlying element.
+ */
+export function ElementPicker({
+  onCapture,
+  onCancel,
+}: {
+  onCapture: (dataUrl: string) => void;
+  onCancel: () => void;
+}) {
+  const [hover, setHover] = useState<Hover | null>(null);
+  const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
+
+  // Resolve the block under a point, ignoring the copilot's own UI.
+  const resolve = useCallback((x: number, y: number): Hover | null => {
+    const el = document.elementFromPoint(x, y) as HTMLElement | null;
+    if (!el || el.closest("[data-tael-agent]")) return null;
+    if (el === document.body || el === document.documentElement) return null;
+    const rect = el.getBoundingClientRect();
+    if (rect.width < 4 || rect.height < 4) return null;
+    return { el, rect, meta: metaFor(el, rect) };
+  }, []);
+
+  const capture = useCallback(
+    async (el: HTMLElement) => {
+      if (busyRef.current) return;
+      busyRef.current = true;
+      setBusy(true);
+      try {
+        const { toPng } = await import("html-to-image");
+        const png = await toPng(el, { pixelRatio: 2, cacheBust: true });
+        const shrunk = await downscale(png);
+        onCapture(shrunk);
+      } catch (error) {
+        console.error("[picker] capture failed:", error);
+        onCancel();
+      } finally {
+        busyRef.current = false;
+        setBusy(false);
+      }
+    },
+    [onCapture, onCancel],
+  );
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (busyRef.current) return;
+      setHover(resolve(e.clientX, e.clientY));
+    };
+    // Capture phase so we win before the underlying element's own handler.
+    const onClick = (e: MouseEvent) => {
+      if (busyRef.current) return;
+      const target = resolve(e.clientX, e.clientY);
+      if (!target) return;
+      e.preventDefault();
+      e.stopPropagation();
+      void capture(target.el);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener("mousemove", onMove, true);
+    window.addEventListener("click", onClick, true);
+    window.addEventListener("keydown", onKey, true);
+    const prevCursor = document.body.style.cursor;
+    document.body.style.cursor = "crosshair";
+    return () => {
+      window.removeEventListener("mousemove", onMove, true);
+      window.removeEventListener("click", onClick, true);
+      window.removeEventListener("keydown", onKey, true);
+      document.body.style.cursor = prevCursor;
+    };
+  }, [resolve, capture, onCancel]);
+
+  const box = hover?.rect;
+  // Prefer the tooltip above the block; drop below if there isn't room.
+  const tipTop = box ? (box.top > 88 ? box.top - 80 : box.bottom + 8) : 0;
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-[70]" aria-hidden>
+      {/* Faint tint so it's obvious we're in pick mode. */}
+      <div className="absolute inset-0 bg-black/20" />
+
+      {/* Hint bar. */}
+      <div className="absolute inset-x-0 top-4 flex justify-center">
+        <div className="rounded-full bg-[#14161a] px-3.5 py-1.5 text-[12px] font-medium text-white shadow-lg ring-1 ring-white/10">
+          {busy ? "Capturing…" : "Click a block to capture · Esc to cancel"}
+        </div>
+      </div>
+
+      {/* Highlight box + inspector tooltip. */}
+      {box && !busy ? (
+        <>
+          <div
+            className="absolute rounded-[3px] bg-sky-400/10 ring-2 ring-sky-400"
+            style={{ left: box.left, top: box.top, width: box.width, height: box.height }}
+          />
+          <div
+            className="absolute min-w-[180px] rounded-lg bg-[#14161a] px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-white/90 shadow-lg ring-1 ring-white/10"
+            style={{ left: Math.max(8, box.left), top: tipTop }}
+          >
+            <Row label={hover!.meta.tag} value={hover!.meta.size} />
+            <Row label="color" value={hover!.meta.color} />
+            <Row label="font" value={hover!.meta.font} />
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-6">
+      <span className="text-white/40">{label}</span>
+      <span className="max-w-[220px] truncate">{value}</span>
+    </div>
+  );
+}

--- a/apps/dashboard/features/agent/knowledge.ts
+++ b/apps/dashboard/features/agent/knowledge.ts
@@ -63,5 +63,6 @@ A new Card needs a little XLM to exist and hold a USDC trustline, then USDC to s
 - Be concise, friendly, and practical. Short paragraphs.
 - You CAN run a capability, create a Card, and create an API key via the tools above — each one asks the user for a single-click confirm first, and any spending stays within the Card's caps. For publishing a capability, guide them to the right page.
 - "Earnings" / "revenue" = the revenue field from get_wallet_overview (USDC received). Never report a balance (usdc / agentsUsdc) as earnings — those are current holdings, not what was earned.
+- The user can capture a block of the current page (via the crosshair button) and attach it as a screenshot. When one is attached, look at it and answer about exactly what's shown.
 - If a tool returns nothing or errors, say so plainly rather than inventing an answer.
 - Never reveal secrets, private keys, or raw internal IDs (the API key tool handles showing the key securely).`;

--- a/apps/dashboard/features/agent/message-bubble.tsx
+++ b/apps/dashboard/features/agent/message-bubble.tsx
@@ -295,6 +295,19 @@ export function MessageBubble({
       transition={{ duration: 0.2, ease: "easeOut" }}
       className={`flex flex-col gap-1.5 ${isUser ? "items-end" : "items-start"}`}
     >
+      {message.attachments?.length ? (
+        <div className="flex flex-wrap justify-end gap-1.5">
+          {message.attachments.map((src, i) => (
+            // eslint-disable-next-line @next/next/no-img-element -- user-captured data URL, dynamic size
+            <img
+              key={i}
+              src={src}
+              alt="Captured page block"
+              className="max-h-40 w-auto max-w-[85%] rounded-xl border border-white/10 object-contain"
+            />
+          ))}
+        </div>
+      ) : null}
       {showBubble ? (
         <div
           className={`max-w-[85%] rounded-2xl px-3.5 py-2.5 text-[13.5px] leading-relaxed ${

--- a/apps/dashboard/features/agent/tael-agent.tsx
+++ b/apps/dashboard/features/agent/tael-agent.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Trash2 } from "lucide-react";
+import { Crosshair, Trash2, X } from "lucide-react";
 import { AGENT_NAME, AGENT_TAGLINE, INTRO_MESSAGE, SUGGESTED_QUESTIONS } from "./knowledge";
 import { useAgentChat } from "./use-agent-chat";
 import { MessageBubble } from "./message-bubble";
+import { ElementPicker } from "./element-picker";
 import { ChatSmileIcon, ChevronDownIcon, CloseIcon, SendIcon, TaelLogoMark } from "./icons";
 import { ensureNotifyPermission, playChime, sendBrowserNotification } from "./notify";
 import type { TaelAgentProps } from "./types";
@@ -29,6 +30,9 @@ export function TaelAgent({
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState("");
   const [unread, setUnread] = useState(0);
+  // Element-picker: capture a page block and attach it to the next message.
+  const [picking, setPicking] = useState(false);
+  const [attachments, setAttachments] = useState<string[]>([]);
   const { messages, streaming, send, runAction, clear } = useAgentChat(endpoint);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -90,16 +94,25 @@ export function TaelAgent({
   }, [streaming, open, messages]);
 
   function submit(text: string) {
-    if (streaming || !text.trim()) return;
+    if (streaming || (!text.trim() && attachments.length === 0)) return;
     void playChime();
-    void send(text);
+    void send(text, attachments.length ? attachments : undefined);
     setDraft("");
+    setAttachments([]);
+  }
+
+  // Enter pick mode: hide the panel so the whole page is selectable; restore it
+  // (with the capture attached) when a block is picked or the user cancels.
+  function startPicking() {
+    setPicking(true);
+    setOpen(false);
   }
 
   return (
     <>
       {/* Launcher */}
       <motion.button
+        data-tael-agent
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-label={open ? "Close the Tael assistant" : "Open the Tael assistant"}
@@ -129,6 +142,7 @@ export function TaelAgent({
       <AnimatePresence>
         {open && (
           <motion.div
+            data-tael-agent
             initial={{ opacity: 0, y: 16, scale: 0.98 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 16, scale: 0.98 }}
@@ -200,7 +214,38 @@ export function TaelAgent({
               }}
               className="p-3"
             >
-              <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 focus-within:border-white/25">
+              {attachments.length > 0 ? (
+                <div className="mb-2 flex flex-wrap gap-2">
+                  {attachments.map((src, i) => (
+                    <div key={i} className="relative">
+                      {/* eslint-disable-next-line @next/next/no-img-element -- user-captured data URL, dynamic size */}
+                      <img
+                        src={src}
+                        alt="Captured page block"
+                        className="h-14 w-auto max-w-[120px] rounded-lg border border-white/10 object-cover"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setAttachments((a) => a.filter((_, j) => j !== i))}
+                        aria-label="Remove attachment"
+                        className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-[#14161a] text-white ring-1 ring-white/20 transition-colors hover:bg-black"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              <div className="flex items-end gap-1.5 rounded-xl border border-white/10 bg-white/[0.04] px-2.5 py-2 focus-within:border-white/25">
+                <button
+                  type="button"
+                  onClick={startPicking}
+                  aria-label="Capture a block from the page"
+                  title="Capture a block from the page"
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-white/50 transition-colors hover:bg-white/10 hover:text-white"
+                >
+                  <Crosshair className="h-[18px] w-[18px]" />
+                </button>
                 <textarea
                   ref={inputRef}
                   value={draft}
@@ -217,7 +262,7 @@ export function TaelAgent({
                 />
                 <button
                   type="submit"
-                  disabled={!draft.trim() || streaming}
+                  disabled={(!draft.trim() && attachments.length === 0) || streaming}
                   aria-label="Send"
                   className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[#14161a] transition-all duration-150 ease-out hover:bg-white/90 active:scale-95 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/40"
                 >
@@ -231,6 +276,20 @@ export function TaelAgent({
           </motion.div>
         )}
       </AnimatePresence>
+
+      {picking ? (
+        <ElementPicker
+          onCapture={(url) => {
+            setAttachments((a) => [...a, url]);
+            setPicking(false);
+            setOpen(true);
+          }}
+          onCancel={() => {
+            setPicking(false);
+            setOpen(true);
+          }}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/dashboard/features/agent/types.ts
+++ b/apps/dashboard/features/agent/types.ts
@@ -52,6 +52,9 @@ export interface AgentMessage {
   actionDone?: boolean;
   /** A one-time secret to reveal securely (e.g. a freshly created API key). */
   secret?: string;
+  /** Screenshots of page blocks the user attached (data URLs), shown inline and
+   *  sent to the (multimodal) model so it can reason about what's on screen. */
+  attachments?: string[];
 }
 
 /** Props for the reusable widget, all optional so `<TaelAgent />` just works. */

--- a/apps/dashboard/features/agent/use-agent-chat.ts
+++ b/apps/dashboard/features/agent/use-agent-chat.ts
@@ -97,21 +97,30 @@ export function useAgentChat(endpoint: string) {
 
   useEffect(() => {
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+      // Don't persist attachment data URLs — they're large and would blow the
+      // localStorage quota; the transcript text is what's worth keeping.
+      const slim = messages.map((m) => (m.attachments ? { ...m, attachments: undefined } : m));
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(slim));
     } catch {
       // ignore — private mode / quota; persistence is a nice-to-have
     }
   }, [messages]);
 
   const send = useCallback(
-    async (text: string) => {
+    async (text: string, attachments?: string[]) => {
       const content = text.trim();
-      if (!content || busy.current) return;
+      if ((!content && !attachments?.length) || busy.current) return;
       busy.current = true;
       setStreaming(true);
 
       const now = Date.now();
-      const userMsg: AgentMessage = { id: nextId(), role: "user", content, createdAt: now };
+      const userMsg: AgentMessage = {
+        id: nextId(),
+        role: "user",
+        content,
+        createdAt: now,
+        ...(attachments?.length ? { attachments } : {}),
+      };
       const assistantId = nextId();
       const history = [...messages, userMsg];
       setMessages([
@@ -124,7 +133,11 @@ export function useAgentChat(endpoint: string) {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
-            messages: history.map((m) => ({ role: m.role, content: m.content })),
+            messages: history.map((m) => ({
+              role: m.role,
+              content: m.content,
+              ...(m.attachments?.length ? { attachments: m.attachments } : {}),
+            })),
             pageContext: { path: pathname },
           }),
         });

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -25,6 +25,7 @@
     "@tael/ui": "workspace:*",
     "@trustline-agents/agent-sdk": "^0.2.1",
     "framer-motion": "^12.42.2",
+    "html-to-image": "^1.11.13",
     "lucide-react": "catalog:",
     "next": "catalog:",
     "next-themes": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,7 +319,7 @@ importers:
     dependencies:
       '@creit.tech/stellar-wallets-kit':
         specifier: 'catalog:'
-        version: 2.5.0(@trezor/connect@9.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)))(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(near-api-js@5.1.1)(react@19.2.7)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@3.25.76)
+        version: 2.5.0(@trezor/connect@9.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(near-api-js@5.1.1)(react@19.2.7)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(utf-8-validate@6.0.6)(zod@3.25.76)
       '@stellar/stellar-sdk':
         specifier: 'catalog:'
         version: 13.3.0
@@ -347,6 +347,9 @@ importers:
       framer-motion:
         specifier: ^12.42.2
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       lucide-react:
         specifier: 'catalog:'
         version: 0.469.0(react@19.2.7)
@@ -6070,6 +6073,9 @@ packages:
   htm@3.1.1:
     resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
 
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
+
   http-errors@1.7.2:
     resolution: {integrity: sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==}
     engines: {node: '>= 0.6'}
@@ -8004,64 +8010,6 @@ snapshots:
       '@lobstrco/signer-extension-api': 2.0.0
       '@preact/signals': 2.9.0(preact@10.29.4)
       '@reown/appkit': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@stellar/freighter-api': 6.0.0
-      '@stellar/stellar-sdk': 16.0.1
-      '@trezor/connect-plugin-stellar': 10.0.0-alpha.1(@stellar/stellar-sdk@16.0.1)(@trezor/connect@9.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)))(tslib@2.8.1)
-      '@trezor/connect-web': 10.0.0-alpha.1(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)
-      '@twind/core': 1.1.3(typescript@5.9.3)
-      '@twind/preset-autoprefix': 1.0.7(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
-      '@twind/preset-tailwind': 1.1.4(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
-      '@walletconnect/sign-client': 2.23.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@walletconnect/types': 2.23.9
-      htm: 3.1.1
-      preact: 10.29.4
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@trezor/connect'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - near-api-js
-      - react
-      - supports-color
-      - tslib
-      - typescript
-      - uploadthing
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
-  '@creit.tech/stellar-wallets-kit@2.5.0(@trezor/connect@9.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)))(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(near-api-js@5.1.1)(react@19.2.7)(tslib@2.8.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@3.25.76)':
-    dependencies:
-      '@albedo-link/intent': 0.12.0
-      '@creit.tech/xbull-wallet-connect': 0.4.0
-      '@hot-wallet/sdk': 1.0.11(bufferutil@4.1.0)(near-api-js@5.1.1)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@ledgerhq/hw-app-str': 7.2.8
-      '@ledgerhq/hw-transport': 6.31.12
-      '@ledgerhq/hw-transport-webusb': 6.29.12
-      '@lobstrco/signer-extension-api': 2.0.0
-      '@preact/signals': 2.9.0(preact@10.29.4)
-      '@reown/appkit': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@3.25.76)
       '@stellar/freighter-api': 6.0.0
       '@stellar/stellar-sdk': 16.0.1
       '@trezor/connect-plugin-stellar': 10.0.0-alpha.1(@stellar/stellar-sdk@16.0.1)(@trezor/connect@9.6.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.3)(ws@8.21.0(bufferutil@4.1.0)))(tslib@2.8.1)
@@ -11853,55 +11801,6 @@ snapshots:
       bs58: 6.0.0
       semver: 7.7.2
       valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
-      viem: 2.54.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.22.4)
-    optionalDependencies:
-      '@lit/react': 1.0.8(@types/react@19.2.17)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit@1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(zod@3.25.76)':
-    dependencies:
-      '@reown/appkit-common': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-pay': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-polyfills': 1.8.21
-      '@reown/appkit-scaffold-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))(zod@3.25.76)
-      '@reown/appkit-ui': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      '@reown/appkit-utils': 1.8.21(@types/react@19.2.17)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(utf-8-validate@6.0.6)(valtio@2.1.7(@types/react@19.2.17)(react@19.2.7))(zod@3.25.76)
-      '@reown/appkit-wallet': 1.8.21(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
-      '@walletconnect/universal-provider': 2.23.7(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
-      bs58: 6.0.0
-      semver: 7.7.2
-      valtio: 2.1.7(@types/react@19.2.17)(react@19.2.7)
       viem: 2.54.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
     optionalDependencies:
       '@lit/react': 1.0.8(@types/react@19.2.17)
@@ -15090,6 +14989,8 @@ snapshots:
   hono@4.12.27: {}
 
   htm@3.1.1: {}
+
+  html-to-image@1.11.13: {}
 
   http-errors@1.7.2:
     dependencies:


### PR DESCRIPTION
Adds an inspector-style **element picker** to the Tael copilot, so you can screenshot a block on the page and have the copilot reason about it visually.

## How it works
1. A **crosshair button** in the composer enters pick mode (the panel hides so the whole page is selectable).
2. Hovering highlights the block under the cursor with a **tag / size / color / font** tooltip (browser-inspector style).
3. **Click** screenshots just that block (via `html-to-image`), downscales it, and attaches it as a **removable thumbnail** on your next message. **Esc** cancels.
4. On send, the screenshot goes to the model as **multimodal content**, so Gemini can answer about exactly what's on screen ("what's wrong here?", "explain this card").

## Files
- `element-picker.tsx` (new): hover highlight, inspector tooltip, click-to-capture, Esc-to-cancel. Ignores the copilot's own UI via a `data-tael-agent` attribute; the overlay is `pointer-events:none` so `elementFromPoint` sees the real page, and the click is caught in the capture phase so it never activates the underlying element.
- `use-agent-chat.ts`: `send(text, attachments)`; attachments ride in the request but are stripped from localStorage (data URLs are too large to persist).
- `route.ts`: message content becomes multimodal (`text` + `image_url` data URLs) when attachments are present.
- `message-bubble.tsx`: renders attached block screenshots inline in the user turn.
- `knowledge.ts`: tells the copilot it may receive a screenshot of a page block.
- `package.json`: adds `html-to-image` (dynamically imported on capture).

## Notes
- Capture uses `html-to-image` (no permission prompt). Fidelity is great for the dashboard's own markup; cross-origin images inside a block may not render.
- Verified: `typecheck`, `eslint`, `prettier --check`, and `next build` all pass.