### PR TITLE
fix(copilot): vertically center the composer's pick button

### DIFF
--- a/apps/dashboard/features/agent/tael-agent.tsx
+++ b/apps/dashboard/features/agent/tael-agent.tsx
@@ -236,7 +236,7 @@ export function TaelAgent({
                   ))}
                 </div>
               ) : null}
-              <div className="flex items-end gap-1.5 rounded-xl border border-white/10 bg-white/[0.04] px-2.5 py-2 focus-within:border-white/25">
+              <div className="flex items-center gap-1.5 rounded-xl border border-white/10 bg-white/[0.04] px-2.5 py-2 focus-within:border-white/25">
                 <button
                   type="button"
                   onClick={startPicking}


### PR DESCRIPTION
Follow-up to #157. The crosshair pick button pushed the composer row to `items-end`, so on a single line the icon sat slightly above the text's center. Back to `items-center` so the crosshair, input, and send button align.

One-line CSS change; prettier/typecheck unaffected.