### PR TITLE
feat(agent): rename to autonomous agent + scheduled payments

### DIFF
--- a/apps/dashboard/app/api/agent/route.ts
+++ b/apps/dashboard/app/api/agent/route.ts
@@ -64,7 +64,13 @@ const TOOLS = [
         description:
           "The op's parameters, formatted exactly like its `sample` field. For action ops (e.g. Stellar 'pay' or 'swap') this is required — pass every key the sample shows, e.g. `to=G…&amount=1.5`. Ask the user for any value you don't have (like the destination address or amount) before proposing the run.",
       },
+      delaySeconds: {
+        type: "string",
+        description:
+          "Optional. To SCHEDULE the run for later (e.g. 'pay ... in 2 minutes'), the number of seconds to wait before it runs. Max 300 (5 minutes). Omit to run now.",
+      },
     },
+    ["slug", "operation"],
   ),
   fn(
     "create_card",
@@ -81,7 +87,12 @@ const TOOLS = [
   ),
 ];
 
-function fn(name: string, description: string, properties?: Record<string, unknown>) {
+function fn(
+  name: string,
+  description: string,
+  properties?: Record<string, unknown>,
+  required?: string[],
+) {
   return {
     type: "function" as const,
     function: {
@@ -90,7 +101,7 @@ function fn(name: string, description: string, properties?: Record<string, unkno
       parameters: {
         type: "object",
         properties: properties ?? {},
-        required: properties ? Object.keys(properties) : [],
+        required: required ?? (properties ? Object.keys(properties) : []),
       },
     },
   };
@@ -218,6 +229,17 @@ async function proposeRun(
     ) ?? ops[0];
   if (!op) return { reply: `${cap.name} has no runnable operations.`, action: null };
 
+  // Optional schedule: run this many seconds from confirmation (client-side, so
+  // capped at 5 minutes and only while the tab stays open).
+  const delaySeconds = Math.max(0, Math.round(Number(args.delaySeconds ?? 0)) || 0);
+  if (delaySeconds > 300) {
+    return {
+      reply:
+        "I can only schedule a payment up to 5 minutes out for now (it runs while this tab stays open). Want it within 5 minutes, or should I send it now?",
+      action: null,
+    };
+  }
+
   const price = op.price ?? "0";
   // On-chain ACTION ops (Stellar pay/swap) move the amount the user names plus
   // Tael's fee — not the op's (free) call price. Detect them by their
@@ -276,8 +298,15 @@ async function proposeRun(
       : Number(price) > 0
         ? `pays **$${price} USDC** from your "${card.name}" card`
         : "is free";
+  const when =
+    delaySeconds > 0
+      ? ` in ~${delaySeconds >= 60 ? `${Math.round(delaySeconds / 60)} min` : `${delaySeconds}s`}`
+      : "";
   return {
-    reply: `I can run **${op.name}** on ${cap.name} — it ${cost}. Confirm below to run it.`,
+    reply:
+      delaySeconds > 0
+        ? `I'll schedule **${op.name}** on ${cap.name}${when} — it ${cost}. Confirm below to schedule it.`
+        : `I can run **${op.name}** on ${cap.name} — it ${cost}. Confirm below to run it.`,
     action: {
       kind: "run",
       slug,
@@ -295,6 +324,7 @@ async function proposeRun(
       // read "Send $1 USDC to G…" instead of just a bare amount.
       ...(sendAmount != null ? { sendAmount: trimNum(sendAmount) } : {}),
       ...(isAction && paramValue(params, "to") ? { sendTo: paramValue(params, "to")! } : {}),
+      ...(delaySeconds > 0 ? { delaySeconds } : {}),
     },
   };
 }
@@ -367,7 +397,7 @@ interface AgentRequestBody {
 export async function POST(request: Request) {
   const apiKey = process.env.OPENROUTER_API_KEY;
   if (!apiKey)
-    return jsonError("The copilot isn't configured yet (missing OPENROUTER_API_KEY).", 503);
+    return jsonError("The agent isn't configured yet (missing OPENROUTER_API_KEY).", 503);
 
   const body = (await request.json().catch(() => null)) as AgentRequestBody | null;
   const messages = body?.messages;
@@ -407,7 +437,7 @@ export async function POST(request: Request) {
           authorization: `Bearer ${apiKey}`,
           "content-type": "application/json",
           "HTTP-Referer": "https://taelprotocol.xyz",
-          "X-Title": "Tael Copilot",
+          "X-Title": "Tael Agent",
         },
         body: JSON.stringify({
           model: MODEL,
@@ -424,7 +454,7 @@ export async function POST(request: Request) {
           resp.status,
           await resp.text().catch(() => ""),
         );
-        return reply("Sorry, the copilot is unavailable right now. Please try again.");
+        return reply("Sorry, the agent is unavailable right now. Please try again.");
       }
       data = (await resp.json()) as OpenRouterResponse;
     } catch (error) {

--- a/apps/dashboard/features/agent/knowledge.ts
+++ b/apps/dashboard/features/agent/knowledge.ts
@@ -3,11 +3,11 @@
 // has read tools, so it answers with the account's real, live data.
 
 export const AGENT_NAME = "Tael";
-export const AGENT_TAGLINE = "Your Tael copilot";
+export const AGENT_TAGLINE = "Your autonomous agent";
 
 export const GREETING = "Hi 👋";
 export const INTRO_BODY =
-  "I'm your Tael copilot. Ask me about your account, this page, or how anything in Tael works.";
+  "I'm your autonomous Tael agent. Ask about your account, or tell me to run a capability, pay, or schedule a payment — I'll do it.";
 export const INTRO_MESSAGE = `${GREETING}\n${INTRO_BODY}`;
 
 export const SUGGESTED_QUESTIONS = [
@@ -17,7 +17,7 @@ export const SUGGESTED_QUESTIONS = [
   "What does this page do?",
 ];
 
-export const DASHBOARD_SYSTEM_PROMPT = `You are the Tael copilot, an AI assistant embedded in the Tael dashboard. You are signed in AS the current user and help them understand and operate their Tael account.
+export const DASHBOARD_SYSTEM_PROMPT = `You are the Tael agent, an autonomous agent embedded in the Tael dashboard. You are signed in AS the current user and can understand and operate their Tael account on their behalf — each action they approve with one click.
 
 ## What Tael is
 Tael is the payment layer for autonomous AI agents: an agent pays per call, in USDC on Stellar (via the HTTP 402 / x402 standard), for any API, tool, model, or dataset. No subscriptions, no accounts, no human in the loop.
@@ -55,6 +55,8 @@ Some operations are on-chain ACTIONS, not data lookups — e.g. Stellar "pay" (s
 - Make sure you have EVERY value the sample shows. For "pay" that's the destination address ("to") and the "amount". If the user hasn't given one, ASK for it first — never invent an address or amount.
 - Pass them in \`params\` exactly like the sample (e.g. \`to=GC62…&amount=1\`).
 The operation itself is free to CALL, but the action moves real USDC from the card (plus a small network fee) once the user confirms — so say what it will send, e.g. "send 1 USDC to GC62…", not just "it's free". The destination must already exist and hold a USDC trustline, or the call is rejected.
+
+You can also SCHEDULE a pay for later: if the user says "pay … in 2 minutes" or "… after 90 seconds", set \`delaySeconds\` on run_capability (e.g. 120). Scheduling only supports up to 300 seconds (5 minutes) and runs while the dashboard tab stays open — if they ask for longer, tell them scheduling is limited to 5 minutes for now.
 
 ## Funding a Card
 A new Card needs a little XLM to exist and hold a USDC trustline, then USDC to spend. On testnet it's auto-funded on creation. On mainnet, walk the user through: (1) send ~1.5 XLM to the Card's address, (2) it can then hold a USDC trustline, (3) send USDC to fund it. A wallet that RECEIVES payouts also needs a USDC trustline (Circle's issuer on mainnet).

--- a/apps/dashboard/features/agent/message-bubble.tsx
+++ b/apps/dashboard/features/agent/message-bubble.tsx
@@ -18,35 +18,54 @@ function ActionCard({ action, onRun }: { action: ProposedAction; onRun: () => vo
   let button: string;
   if (action.kind === "run") {
     // A pay/swap carries a send amount (and a pay, a destination): show what it
-    // does, e.g. "Sends $1 USDC to GC62…LBRK", not just the op name.
+    // does, e.g. "Sends $1 USDC to GC62…LBRK", not just the op name. A delay means
+    // it's scheduled for later.
     const sending = action.sendAmount != null;
-    label = sending ? "Send payment" : "Run capability";
+    const scheduled = !!action.delaySeconds && action.delaySeconds > 0;
+    const whenText = scheduled
+      ? action.delaySeconds! >= 60
+        ? `in ~${Math.round(action.delaySeconds! / 60)} min`
+        : `in ${action.delaySeconds}s`
+      : "";
+    label = scheduled ? "Schedule payment" : sending ? "Send payment" : "Run capability";
     title = (
       <>
         {action.operationName} <span className="text-white/50">· {action.capabilityName}</span>
       </>
     );
-    sub = sending ? (
+    sub = (
       <>
-        Sends <span className="text-white/70">${action.sendAmount} USDC</span>
-        {action.sendTo ? (
+        {sending ? (
+          <>
+            Sends <span className="text-white/70">${action.sendAmount} USDC</span>
+            {action.sendTo ? (
+              <>
+                {" "}
+                to <span className="text-white/70">{shortAddr(action.sendTo)}</span>
+              </>
+            ) : null}{" "}
+            · from your <span className="text-white/70">{action.cardName}</span> card
+          </>
+        ) : (
+          <>
+            Pays from your <span className="text-white/70">{action.cardName}</span> card
+          </>
+        )}
+        {scheduled ? (
           <>
             {" "}
-            to <span className="text-white/70">{shortAddr(action.sendTo)}</span>
+            · <span className="text-white/70">{whenText}</span>
           </>
-        ) : null}{" "}
-        · from your <span className="text-white/70">{action.cardName}</span> card
-      </>
-    ) : (
-      <>
-        Pays from your <span className="text-white/70">{action.cardName}</span> card
+        ) : null}
       </>
     );
-    button = sending
-      ? `Send · $${action.sendAmount} USDC`
-      : Number(action.price) > 0
-        ? `Run · $${action.price} USDC`
-        : "Run · free";
+    button = scheduled
+      ? `Schedule · $${action.sendAmount ?? action.price} USDC`
+      : sending
+        ? `Send · $${action.sendAmount} USDC`
+        : Number(action.price) > 0
+          ? `Run · $${action.price} USDC`
+          : "Run · free";
   } else if (action.kind === "create_card") {
     label = "Create card";
     title = action.name;

--- a/apps/dashboard/features/agent/tael-agent.tsx
+++ b/apps/dashboard/features/agent/tael-agent.tsx
@@ -270,7 +270,7 @@ export function TaelAgent({
                 </button>
               </div>
               <p className="mt-2 text-center text-[10.5px] text-white/30">
-                Tael assistant can make mistakes. Verify important details.
+                The Tael agent can make mistakes. Verify important details.
               </p>
             </form>
           </motion.div>

--- a/apps/dashboard/features/agent/types.ts
+++ b/apps/dashboard/features/agent/types.ts
@@ -19,6 +19,9 @@ export interface RunAction {
   sendAmount?: string;
   /** For a pay: the destination address, shown (truncated) on the confirm card. */
   sendTo?: string;
+  /** Schedule the run this many seconds from confirmation instead of running it
+   *  now (client-side, capped at 5 min; only while the tab stays open). */
+  delaySeconds?: number;
 }
 
 /** Create a new Card (agent wallet). */

--- a/apps/dashboard/features/agent/use-agent-chat.ts
+++ b/apps/dashboard/features/agent/use-agent-chat.ts
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { createAgent } from "../agents/actions";
 import { createApiKey } from "../api-keys/actions";
 import { runCapability } from "../agents/run-capability";
-import type { AgentMessage, ProposedAction } from "./types";
+import type { AgentMessage, ProposedAction, RunAction } from "./types";
 
 let counter = 0;
 function nextId(): string {
@@ -77,6 +77,42 @@ function formatBody(body: string | undefined): string {
     // not JSON — leave as-is
   }
   return out.length > 1200 ? `${out.slice(0, 1200)}…` : out;
+}
+
+/** Truncate a Stellar address for a compact display, e.g. GC62IX…LBRK. */
+function shortAddr(a: string): string {
+  return a.length > 12 ? `${a.slice(0, 6)}…${a.slice(-4)}` : a;
+}
+
+/** A human countdown like "2m 5s" / "45s". */
+function fmtCountdown(s: number): string {
+  if (s >= 60) {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return sec ? `${m}m ${sec}s` : `${m}m`;
+  }
+  return `${s}s`;
+}
+
+/** Execute one confirmed run and return the result text (with an on-chain proof
+ *  link when it settled). Shared by immediate and scheduled runs. */
+async function runOne(action: RunAction): Promise<string> {
+  const isGet = (action.method ?? "GET").toUpperCase() === "GET";
+  const params = paramsForMethod(action.params, isGet);
+  const r = await runCapability({
+    agentId: action.cardId,
+    slug: action.slug,
+    operation: action.operation,
+    method: action.method,
+    body: isGet ? undefined : params,
+    query: isGet ? params : undefined,
+  });
+  return r.ok
+    ? `**Ran ${action.operationName}**${Number(r.paid) > 0 ? ` · paid $${r.paid} USDC` : " · free"}` +
+        (r.borrowed ? ` · borrowed $${r.borrowed} from TrustLine` : "") +
+        (r.txHash ? `\n\n[View on-chain proof ↗](${STELLAR_EXPERT_TX}${r.txHash})` : "") +
+        (r.body ? `\n\n\`\`\`json\n${formatBody(r.body)}\n\`\`\`` : "")
+    : `Couldn't run it: ${r.error ?? "something went wrong"}`;
 }
 
 /**
@@ -175,10 +211,50 @@ export function useAgentChat(endpoint: string) {
    *  Card, or create an API key), then append the result. */
   const runAction = useCallback(async (messageId: string, action: ProposedAction) => {
     if (busy.current) return;
-    busy.current = true;
-    setStreaming(true);
     // Collapse the confirm card on the proposing message.
     setMessages((prev) => prev.map((m) => (m.id === messageId ? { ...m, actionDone: true } : m)));
+
+    // Scheduled run: don't block the agent — show a live countdown and fire the
+    // run when it elapses. Client-side, so it only runs while the tab stays open.
+    if (action.kind === "run" && action.delaySeconds && action.delaySeconds > 0) {
+      const delayMs = Math.min(action.delaySeconds, 300) * 1000;
+      const fireAt = Date.now() + delayMs;
+      const id = nextId();
+      const what = action.sendAmount
+        ? `pay **$${action.sendAmount} USDC**${action.sendTo ? ` to ${shortAddr(action.sendTo)}` : ""}`
+        : `run **${action.operationName}**`;
+      const line = (s: number) =>
+        `**Scheduled** ⏱ — I'll ${what} in ${fmtCountdown(s)}. Keep this tab open.`;
+      setMessages((prev) => [
+        ...prev,
+        { id, role: "assistant", content: line(Math.ceil(delayMs / 1000)), createdAt: Date.now() },
+      ]);
+      const set = (content: string) =>
+        setMessages((prev) => prev.map((m) => (m.id === id ? { ...m, content } : m)));
+      const tick = setInterval(() => {
+        const s = Math.ceil((fireAt - Date.now()) / 1000);
+        if (s > 0) set(line(s));
+      }, 1000);
+      setTimeout(() => {
+        clearInterval(tick);
+        // If the user cleared the chat, the scheduled message is gone — cancel,
+        // so we never move money for something no longer on screen.
+        let live = false;
+        setMessages((prev) => {
+          live = prev.some((m) => m.id === id);
+          return live
+            ? prev.map((m) =>
+                m.id === id ? { ...m, content: "Running the scheduled payment…" } : m,
+              )
+            : prev;
+        });
+        if (live) void runOne(action).then(set);
+      }, delayMs);
+      return;
+    }
+
+    busy.current = true;
+    setStreaming(true);
     const resultId = nextId();
     const working =
       action.kind === "run"
@@ -196,24 +272,7 @@ export function useAgentChat(endpoint: string) {
 
     try {
       if (action.kind === "run") {
-        const isGet = (action.method ?? "GET").toUpperCase() === "GET";
-        const params = paramsForMethod(action.params, isGet);
-        const r = await runCapability({
-          agentId: action.cardId,
-          slug: action.slug,
-          operation: action.operation,
-          method: action.method,
-          body: isGet ? undefined : params,
-          query: isGet ? params : undefined,
-        });
-        patch({
-          content: r.ok
-            ? `**Ran ${action.operationName}**${Number(r.paid) > 0 ? ` · paid $${r.paid} USDC` : " · free"}` +
-              (r.borrowed ? ` · borrowed $${r.borrowed} from TrustLine` : "") +
-              (r.txHash ? `\n\n[View on-chain proof ↗](${STELLAR_EXPERT_TX}${r.txHash})` : "") +
-              (r.body ? `\n\n\`\`\`json\n${formatBody(r.body)}\n\`\`\`` : "")
-            : `Couldn't run it: ${r.error ?? "something went wrong"}`,
-        });
+        patch({ content: await runOne(action) });
       } else if (action.kind === "create_card") {
         const r = await createAgent({
           name: action.name,


### PR DESCRIPTION
Two things you asked for.

## 1. It's an autonomous agent, not a copilot
Renamed everywhere it's user-facing:
- Tagline: **"Your autonomous agent"** (was "Your Tael copilot")
- Intro: *"I'm your autonomous Tael agent. Ask about your account, or tell me to run a capability, pay, or schedule a payment."*
- System-prompt self-description → "the Tael agent, an autonomous agent…"
- Composer footer + the config/error strings

## 2. Scheduled payments
Say **"pay 0.5 USDC to G… in 2 minutes"** and the agent proposes a **Schedule payment** card ("in ~2 min"). On confirm it drops a message with a **live countdown** — *"Scheduled ⏱ — I'll pay $0.5 USDC to GC62…LBRK in 1m 58s. Keep this tab open."* — and when it elapses it fires the **real pay**, with the on-chain proof link, exactly like an immediate one.

Scoped as discussed:
- **Client-side, capped at 5 minutes** (runs only while the tab stays open). Longer delays are declined with a clear message.
- If you **clear the chat** before it fires, the payment is cancelled (never moves money for something that's gone).

### How it's built
- `route.ts`: `run_capability` gains an optional `delaySeconds`; `proposeRun` caps it at 300s and threads it into the proposal. Optional params are now truly optional in the tool schema.
- `use-agent-chat.ts`: a shared `runOne()` for immediate + scheduled runs, plus the countdown message that executes on elapse.
- `message-bubble.tsx`: the confirm card shows **Schedule payment** + "in ~Xm" + a **Schedule** button.

Verified: typecheck, eslint, prettier, and `next build` all pass.