### PR TITLE
feat(web): landing CTAs, footer social icons + links, and a Guide page

### DIFF
--- a/apps/web/app/_components/agent/knowledge.ts
+++ b/apps/web/app/_components/agent/knowledge.ts
@@ -23,8 +23,8 @@ export const INTRO_MESSAGE = `${GREETING}\n${INTRO_BODY}`;
 /** One-tap prompts shown under the intro to get people started. */
 export const SUGGESTED_QUESTIONS = [
   "What is Tael?",
-  "How do I publish a capability?",
-  "How do agents pay for a call?",
+  "How can I publish my capabilities?",
+  "How do I make a card or API key to access capabilities?",
   "Book a meeting",
 ];
 

--- a/apps/web/app/_components/footer-links.tsx
+++ b/apps/web/app/_components/footer-links.tsx
@@ -1,16 +1,24 @@
-import { WaitlistTrigger } from "./waitlist-trigger";
-
 const COLUMNS = [
-  { title: "Product", links: ["Apps", "Guide", "FAQs", "Try now"] },
-  { title: "Connect", links: ["Discord", "X"] },
+  { title: "Product", links: ["Apps", "Guide", "FAQs"] },
+  { title: "Try Tael", links: ["Mainnet", "Testnet"] },
 ];
 
 // Real destinations for links that have one; others fall back to "#".
 const HREFS: Record<string, string> = {
-  Guide: "/docs",
+  Apps: "/capabilities",
+  Guide: "/guide",
   FAQs: "/coming-soon",
-  Discord: "https://discord.gg/tcb6b7ZYha",
-  X: "https://x.com/taelprotocol?s=21",
+  Mainnet: "https://mainnet.taelprotocol.xyz",
+  Testnet: "https://app.taelprotocol.xyz",
+};
+
+// Community + developer accounts, shown as a row of logo icons in the footer.
+const SOCIALS = {
+  github: "https://github.com/tael-protocol",
+  npm: "https://www.npmjs.com/package/@tael/sdk",
+  discord: "https://discord.gg/tcb6b7ZYha",
+  x: "https://x.com/taelprotocol?s=21",
+  youtube: "https://www.youtube.com/playlist?list=PLCa8B7S0sR4g",
 };
 
 const item =
@@ -46,40 +54,49 @@ export function FooterLinks() {
         {COLUMNS.map((col) => (
           <div key={col.title} className="flex flex-col items-start gap-2">
             <span className={`${item} text-[#989898]`}>{col.title}</span>
-            {col.links.map((label) =>
-              label === "Try now" ? (
-                <WaitlistTrigger
+            {col.links.map((label) => {
+              const href = HREFS[label] ?? "#";
+              const external = href.startsWith("http");
+              return (
+                <a
                   key={label}
-                  className={`${item} text-left text-black hover:bg-[#ECECED]`}
+                  href={href}
+                  {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                  className={`${item} text-black hover:bg-[#ECECED]`}
                 >
                   {label}
-                </WaitlistTrigger>
-              ) : (
-                (() => {
-                  const href = HREFS[label] ?? "#";
-                  const external = href.startsWith("http");
-                  return (
-                    <a
-                      key={label}
-                      href={href}
-                      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-                      className={`${item} text-black hover:bg-[#ECECED]`}
-                    >
-                      {label}
-                    </a>
-                  );
-                })()
-              ),
-            )}
+                </a>
+              );
+            })}
           </div>
         ))}
       </div>
 
       {/* Social icons */}
-      <div className="flex gap-6">
-        <SocialIcon label="X (Twitter)" href={HREFS.X}>
+      <div className="flex items-center gap-5">
+        <SocialIcon label="GitHub" href={SOCIALS.github}>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+            <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.438 9.8 8.205 11.387.6.113.82-.26.82-.577 0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.42-1.305.763-1.605-2.665-.303-5.466-1.332-5.466-5.93 0-1.31.468-2.38 1.235-3.22-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.3 1.23a11.5 11.5 0 0 1 3.003-.404c1.02.005 2.047.138 3.006.404 2.29-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.804 5.624-5.476 5.92.43.372.823 1.102.823 2.222 0 1.604-.015 2.897-.015 3.293 0 .32.216.694.825.576C20.565 22.296 24 17.798 24 12.5 24 5.87 18.627.5 12 .5z" />
+          </svg>
+        </SocialIcon>
+        <SocialIcon label="npm" href={SOCIALS.npm}>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+            <path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z" />
+          </svg>
+        </SocialIcon>
+        <SocialIcon label="Discord" href={SOCIALS.discord}>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+            <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
+          </svg>
+        </SocialIcon>
+        <SocialIcon label="X (Twitter)" href={SOCIALS.x}>
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
             <path d="M15.2726 1.58691H18.0838L11.9421 8.60649L19.1673 18.1586H13.51L9.07901 12.3653L4.00894 18.1586H1.19601L7.76518 10.6503L0.833984 1.58691H6.63491L10.6401 6.88219L15.2726 1.58691ZM14.2859 16.4759H15.8436L5.78848 3.18119H4.11687L14.2859 16.4759Z" />
+          </svg>
+        </SocialIcon>
+        <SocialIcon label="YouTube" href={SOCIALS.youtube}>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+            <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
           </svg>
         </SocialIcon>
       </div>

--- a/apps/web/app/guide/page.tsx
+++ b/apps/web/app/guide/page.tsx
@@ -1,0 +1,256 @@
+import type { Metadata } from "next";
+import { SiteHeader } from "../_components/site-header";
+import { FooterLinks } from "../_components/footer-links";
+import { ProviderCards } from "../_components/provider-cards";
+
+export const metadata: Metadata = {
+  title: "Guide — Tael",
+  description:
+    "What Tael is and how it works: price your capabilities, reach every user and agent through one API, and get an autonomous agent that runs your product.",
+};
+
+const MAINNET_URL = "https://mainnet.taelprotocol.xyz";
+const YOUTUBE_URL = "https://www.youtube.com/playlist?list=PLCa8B7S0sR4g";
+
+const WHAT = [
+  {
+    title: "Price your capabilities",
+    body: "Expose your product's best actions and set a per-call price. Every successful call pays you, instantly, in USDC.",
+  },
+  {
+    title: "Accessible to anyone, and any agent",
+    body: "Humans and AI agents can discover, call, and pay for your capabilities over one open standard. No accounts to hand out.",
+  },
+  {
+    title: "A marketplace that grows you",
+    body: "Get listed and get found. Being on Tael raises your product's visibility and credibility across the ecosystem.",
+  },
+];
+
+const AGENT_DOES = [
+  "Runs every function your product offers, with no manual steps.",
+  "Pitches your whole product, so even a first-time visitor knows exactly what to do.",
+  "Handles customer support and explains your product clearly.",
+  "Captures leads and books meetings with your founders.",
+  "Pay, swap, TrustLine, and more, built in.",
+];
+
+const GETS = [
+  {
+    title: "Monetisation",
+    body: "Earn per call on every capability you expose. Real revenue, settled on-chain.",
+  },
+  {
+    title: "Integration in under 5 minutes",
+    body: "That is the benchmark once a product is live on Tael. One API, not ten accounts.",
+  },
+  {
+    title: "An autonomous agent",
+    body: "It handles your product pitch, leads, support, meetings, and runs your product in natural English.",
+  },
+];
+
+const ASK = [
+  "What is Tael?",
+  "How can I publish my capabilities?",
+  "How do I make a card or API key to access capabilities?",
+];
+
+const primaryCta =
+  "inline-flex items-center gap-2 rounded-[14px] bg-accent px-6 py-3.5 text-[15px] font-medium text-white shadow-[0_1px_2px_0_rgba(0,0,0,0.16)] transition-opacity hover:opacity-90";
+const secondaryCtaDark =
+  "inline-flex items-center rounded-[14px] border border-white/25 px-6 py-3.5 text-[15px] font-medium text-white transition-colors hover:bg-white/10";
+
+function ArrowIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <path
+        d="M5 12h14M13 6l6 6-6 6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default function GuidePage() {
+  return (
+    <>
+      <SiteHeader />
+
+      {/* Hero */}
+      <section
+        className="px-6 pb-20 pt-24 text-center"
+        style={{ background: "linear-gradient(180deg, #0A0A0A 0%, #000000 55%, #18181B 100%)" }}
+      >
+        <p className="text-[12px] font-medium uppercase tracking-[0.18em] text-white/50">Guide</p>
+        <h1 className="mx-auto mt-4 max-w-[720px] text-[40px] font-normal leading-[1.1] tracking-[-0.03em] text-white sm:text-[56px]">
+          Tael is the backbone for your product.
+        </h1>
+        <p className="mx-auto mt-5 max-w-[560px] text-[18px] leading-7 tracking-[-0.02em] text-white/65">
+          Connect your best capabilities, put a price on them, and get an autonomous agent that runs
+          your product for your users. One API, live in minutes.
+        </p>
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <a href={MAINNET_URL} target="_blank" rel="noopener noreferrer" className={primaryCta}>
+            Try on Mainnet
+            <ArrowIcon />
+          </a>
+          <a href="/docs" className={secondaryCtaDark}>
+            Read the docs
+          </a>
+        </div>
+      </section>
+
+      <main className="bg-white text-ink">
+        {/* What is Tael */}
+        <section className="mx-auto max-w-[1080px] px-6 py-20">
+          <p className="text-[13px] font-medium uppercase tracking-[0.14em] text-ink-muted">
+            What is Tael
+          </p>
+          <h2 className="mt-3 max-w-[720px] text-[32px] font-semibold leading-tight tracking-[-0.02em] sm:text-[38px]">
+            Think of Tael as a backbone.
+          </h2>
+          <p className="mt-4 max-w-[680px] text-[17px] leading-8 tracking-[-0.01em] text-ink-soft">
+            Tael sits under your product and keeps it strong. You connect your product&apos;s best
+            capabilities and give each one a price. Tael makes them accessible to everyone, and even
+            AI agents can call and pay for them. Its marketplace puts your product in front of new
+            users and builds credibility.
+          </p>
+          <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {WHAT.map((c) => (
+              <div key={c.title} className="rounded-2xl border border-line bg-surface/40 p-6">
+                <p className="text-[16px] font-semibold tracking-[-0.01em]">{c.title}</p>
+                <p className="mt-2 text-[14px] leading-6 tracking-[-0.01em] text-ink-soft">
+                  {c.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Autonomous agent */}
+        <section className="bg-[#0B0B0C] text-white">
+          <div className="mx-auto max-w-[1080px] px-6 py-20">
+            <p className="text-[13px] font-medium uppercase tracking-[0.14em] text-white/45">
+              Autonomous agent
+            </p>
+            <h2 className="mt-3 max-w-[760px] text-[32px] font-semibold leading-tight tracking-[-0.02em] sm:text-[38px]">
+              Your own autonomous agent, built from your product.
+            </h2>
+            <p className="mt-4 max-w-[720px] text-[17px] leading-8 tracking-[-0.01em] text-white/70">
+              From your docs, product information, mission, and capabilities, Tael builds an
+              autonomous agent for your platform. It does not just answer questions. It runs your
+              product. Your users say what they want in plain English, and the agent does it, so
+              they never have to figure out manual steps.
+            </p>
+            <ul className="mt-8 grid max-w-[860px] grid-cols-1 gap-3 sm:grid-cols-2">
+              {AGENT_DOES.map((line) => (
+                <li
+                  key={line}
+                  className="flex gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3.5 text-[15px] leading-6 tracking-[-0.01em] text-white/80"
+                >
+                  <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
+                  {line}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-8 rounded-2xl border border-white/10 bg-white/[0.04] px-6 py-5">
+              <p className="text-[16px] leading-7 tracking-[-0.01em] text-white/85">
+                One API for all of it. No juggling ten different accounts to build on Stellar, Tael
+                gives you every capability through a single API. It is powerful even right now.
+              </p>
+            </div>
+            <div className="mt-8">
+              <a
+                href={YOUTUBE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={secondaryCtaDark}
+              >
+                Watch the demo
+                <span className="ml-2">↗</span>
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* What your product gets */}
+        <section className="mx-auto max-w-[1080px] px-6 py-20">
+          <h2 className="max-w-[720px] text-[32px] font-semibold leading-tight tracking-[-0.02em] sm:text-[38px]">
+            What your product gets.
+          </h2>
+          <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {GETS.map((c) => (
+              <div key={c.title} className="rounded-2xl border border-line bg-surface/40 p-6">
+                <p className="text-[16px] font-semibold tracking-[-0.01em]">{c.title}</p>
+                <p className="mt-2 text-[14px] leading-6 tracking-[-0.01em] text-ink-soft">
+                  {c.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Mission */}
+        <section className="border-y border-line bg-surface/40">
+          <div className="mx-auto max-w-[1080px] px-6 py-16">
+            <p className="text-[13px] font-medium uppercase tracking-[0.14em] text-ink-muted">
+              Mission
+            </p>
+            <h2 className="mt-3 max-w-[760px] text-[28px] font-semibold leading-tight tracking-[-0.02em] sm:text-[34px]">
+              Autonomous agents for every Stellar product.
+            </h2>
+            <p className="mt-4 max-w-[680px] text-[17px] leading-8 tracking-[-0.01em] text-ink-soft">
+              Live on Tael, every product is reachable through the same API. We have already
+              partnered with 6 products in the ecosystem, and we are just getting started.
+            </p>
+          </div>
+        </section>
+
+        {/* Ask the agent */}
+        <section className="mx-auto max-w-[1080px] px-6 py-20">
+          <h2 className="text-[28px] font-semibold leading-tight tracking-[-0.02em] sm:text-[34px]">
+            Have a question? Ask the agent.
+          </h2>
+          <p className="mt-3 max-w-[620px] text-[16px] leading-7 tracking-[-0.01em] text-ink-soft">
+            The Tael agent is on the site, bottom right. Ask it anything while you explore, or try
+            it inside the app. A few good starters:
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2.5">
+            {ASK.map((q) => (
+              <span
+                key={q}
+                className="rounded-full border border-line bg-white px-4 py-2 text-[14px] font-medium tracking-[-0.01em] text-ink"
+              >
+                {q}
+              </span>
+            ))}
+          </div>
+          <div className="mt-10 flex items-center gap-3">
+            <a href={MAINNET_URL} target="_blank" rel="noopener noreferrer" className={primaryCta}>
+              Try on Mainnet
+              <ArrowIcon />
+            </a>
+            <a
+              href="/docs"
+              className="inline-flex items-center rounded-[14px] border border-line px-6 py-3.5 text-[15px] font-medium text-ink transition-colors hover:bg-surface"
+            >
+              Read the docs
+            </a>
+          </div>
+        </section>
+
+        {/* Footer */}
+        <section className="border-t border-line bg-white pb-24 pt-16">
+          <div className="mx-auto flex max-w-[1160px] flex-col gap-16 px-6 lg:flex-row lg:items-start lg:justify-between lg:gap-12">
+            <FooterLinks />
+            <ProviderCards />
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import { Inter, Delicious_Handrawn, DotGothic16 } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
-import { TaelAgent } from "./_components/agent";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -125,7 +124,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
         <Providers>{children}</Providers>
-        <TaelAgent />
       </body>
     </html>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @next/next/no-img-element */
 import { SiteHeader } from "./_components/site-header";
-import { WaitlistForm } from "./_components/waitlist-form";
 import { ProviderCards } from "./_components/provider-cards";
 import { FooterLinks } from "./_components/footer-links";
+import { TaelAgent } from "./_components/agent";
 
 // Pixel-anchored: dark upper region matches the original design, then a long,
 // smooth grey→white fade (410→740px, ~330px) so it blends gently into white
@@ -95,13 +95,35 @@ export default function HomePage() {
               For AI agents.
             </h1>
             <p className="max-w-[430px] text-[18px] font-normal leading-[26px] tracking-[-0.035em] text-white">
-              Pay for every API you use. 100 apps and 3000 actions, all in one platform.
+              Pay per call for any API, tool, or model. In USDC, no subscriptions, no accounts.
             </p>
           </div>
 
-          {/* Waitlist */}
-          <div className="absolute left-1/2 top-[481px] w-[464px] max-w-[calc(100vw-48px)] -translate-x-1/2">
-            <WaitlistForm className="w-full" />
+          {/* CTAs — the product is live, so link straight into it. */}
+          <div className="absolute left-1/2 top-[481px] flex max-w-[calc(100vw-48px)] -translate-x-1/2 items-center gap-3">
+            <a
+              href="https://mainnet.taelprotocol.xyz"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-[14px] bg-accent px-6 py-3.5 text-[15px] font-medium text-white shadow-[0_1px_2px_0_rgba(0,0,0,0.16)] transition-opacity hover:opacity-90"
+            >
+              Try on Mainnet
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path
+                  d="M5 12h14M13 6l6 6-6 6"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </a>
+            <a
+              href="/docs"
+              className="inline-flex items-center rounded-[14px] border border-white/25 px-6 py-3.5 text-[15px] font-medium text-white transition-colors hover:bg-white/10"
+            >
+              Read the docs
+            </a>
           </div>
         </div>
       </section>
@@ -113,6 +135,11 @@ export default function HomePage() {
           <ProviderCards />
         </div>
       </section>
+
+      {/* Support agent — landing page only, and desktop only (hidden on phones). */}
+      <div className="hidden md:block">
+        <TaelAgent />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
Landing-page batch.

## Hero
- Replaced the email waitlist with **two CTAs**: primary blue **Try on Mainnet** (`mainnet.taelprotocol.xyz`) + outline **Read the docs**. Blue is `bg-accent` (#156DFC), matching the site.
- Rewrote the placeholder subhead ("100 apps and 3000 actions") to: *"Pay per call for any API, tool, or model. In USDC, no subscriptions, no accounts."*

## Support agent
- Moved `<TaelAgent/>` out of the global layout onto the **landing page only**, wrapped `hidden md:block` so it's **desktop-only** (hidden on phones).
- Updated its suggested prompts to: *What is Tael? / How can I publish my capabilities? / How do I make a card or API key to access capabilities?*

## Footer
- A row of **logo icons**: GitHub, npm, Discord, X, YouTube.
- Columns: **Product** [Apps → /capabilities, Guide → /guide, FAQs] and **Try Tael** [Mainnet → mainnet.taelprotocol.xyz, Testnet → app.taelprotocol.xyz].

## New Guide page (`/guide`)
A clear explainer written from the product notes: Tael as a backbone, price your capabilities, the marketplace, **your autonomous agent** (runs every function, pitches, support, leads/meetings, pay/swap/TrustLine, one API), what a product gets (monetisation, sub-5-min integration, agent), the mission, and an *ask the agent* section with the 3 starter questions. Dark hero + light sections, reusing SiteHeader + FooterLinks. The footer/nav Guide link points here.

Verified: prettier, eslint, `web typecheck`, and `next build` all pass (`/guide` builds as a static route).