### PR TITLE
feat(discord-bot): call Tael capabilities from Discord

### DIFF
--- a/apps/discord-bot/.env.example
+++ b/apps/discord-bot/.env.example
@@ -1,0 +1,21 @@
+# --- Discord ---
+# Bot token (Developer Portal -> your app -> Bot -> Reset Token)
+DISCORD_TOKEN=
+# Application (client) id (Developer Portal -> your app -> General Information)
+DISCORD_CLIENT_ID=
+# Optional: register slash commands to ONE server (instant). Leave blank for global.
+DISCORD_GUILD_ID=
+
+# --- Tael ---
+# API key linked to a funded Card the bot spends from (dashboard -> API Keys).
+TAEL_KEY=
+# Optional gateway override. Defaults to the SDK's testnet gateway.
+TAEL_BASE_URL=
+# Which network the explorer proof links point to: testnet | mainnet
+TAEL_NETWORK=testnet
+
+# --- Guardrails ---
+# Max calls per user per minute.
+RATE_LIMIT_PER_MIN=5
+# Max total calls the bot will make per day.
+DAILY_CALL_CAP=500

--- a/apps/discord-bot/Dockerfile
+++ b/apps/discord-bot/Dockerfile
@@ -1,0 +1,13 @@
+# Build + run the Tael Discord bot from the monorepo root:
+#   docker build -f apps/discord-bot/Dockerfile -t tael-discord-bot .
+FROM node:22-slim
+WORKDIR /app
+RUN corepack enable
+
+# Install workspace deps (needs the whole monorepo for pnpm workspaces).
+COPY . .
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter discord-bot build
+
+# A bot is a long-lived process, not an HTTP server.
+CMD ["pnpm", "--filter", "discord-bot", "start"]

--- a/apps/discord-bot/README.md
+++ b/apps/discord-bot/README.md
@@ -1,0 +1,53 @@
+# Tael Discord bot
+
+Call Tael marketplace capabilities from Discord. A community member runs a slash
+command, the bot's Card pays per call in USDC, and the result comes back in the
+channel with an on-chain proof link.
+
+```
+/tael list                          → capabilities you can call here
+/tael search query:weather          → search the marketplace
+/tael call capability:Cat Facts     → run it (the bot pays per call)
+/tael call capability:Weather Now params:city=London
+```
+
+## Guardrails
+
+The bot spends from **one shared Card**, so it is deliberately locked down:
+
+- **Data capabilities only:** an allowlist in `src/config.ts`. There is **no
+  `pay` / `swap`**, so no one can move USDC out of the Card with a command.
+- **Per-user rate limit** (`RATE_LIMIT_PER_MIN`, default 5/min).
+- **Daily call cap** (`DAILY_CALL_CAP`, default 500) across all users.
+- The Card's own **per-call and daily spend caps** still bound everything at the
+  protocol level.
+
+## Setup
+
+1. **Create the Discord app**: <https://discord.com/developers/applications> →
+   New Application. Copy the **Application ID** (`DISCORD_CLIENT_ID`). Under
+   **Bot**, reset and copy the **token** (`DISCORD_TOKEN`).
+2. **Invite it** to your server with the `applications.commands` (and `bot`)
+   scopes:
+   `https://discord.com/oauth2/authorize?client_id=<CLIENT_ID>&scope=bot+applications.commands`
+3. **Create a Tael key** (dashboard → API Keys) linked to a **funded Card**, and
+   set `TAEL_KEY`. Keep the Card on **testnet** for a public playground.
+4. Copy `.env.example` → `.env` and fill it in. Set `DISCORD_GUILD_ID` to your
+   server id for **instant** command registration while testing.
+
+## Run
+
+```bash
+pnpm --filter discord-bot dev     # watch mode
+# or
+pnpm --filter discord-bot build && pnpm --filter discord-bot start
+```
+
+## Deploy
+
+A bot is a long-lived process, so deploy it as a **worker**, not a web service.
+
+- **Render** → New → **Background Worker**, repo root, build
+  `pnpm install && pnpm --filter discord-bot build`, start
+  `pnpm --filter discord-bot start`, and set the env vars.
+- **Docker**: `docker build -f apps/discord-bot/Dockerfile -t tael-discord-bot .`

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "discord-bot",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Tael Discord bot: call marketplace capabilities from Discord, paid per call in USDC.",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsup src/index.ts --format esm --target node22 --clean",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@tael/sdk": "workspace:*",
+    "discord.js": "^14.16.3"
+  },
+  "devDependencies": {
+    "@tael/config": "workspace:*",
+    "@types/node": "catalog:",
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/discord-bot/src/commands.ts
+++ b/apps/discord-bot/src/commands.ts
@@ -1,0 +1,127 @@
+import {
+  EmbedBuilder,
+  MessageFlags,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+} from "discord.js";
+import { TaelError, type Tael } from "@tael/sdk";
+import { ALLOWED, explorerTx, isAllowed, type BotConfig } from "./config";
+import type { Guard } from "./rate-limit";
+
+const BRAND = 0x156dfc;
+
+/** The single `/tael` command with list / search / call subcommands. */
+export const command = new SlashCommandBuilder()
+  .setName("tael")
+  .setDescription("Call Tael capabilities. An agent pays per call in USDC")
+  .addSubcommand((s) => s.setName("list").setDescription("List the capabilities you can call here"))
+  .addSubcommand((s) =>
+    s
+      .setName("search")
+      .setDescription("Search the Tael marketplace")
+      .addStringOption((o) => o.setName("query").setDescription("e.g. weather").setRequired(true)),
+  )
+  .addSubcommand((s) => {
+    s.setName("call").setDescription("Call a capability (the bot pays per call)");
+    s.addStringOption((o) => {
+      o.setName("capability").setDescription("Which capability").setRequired(true);
+      for (const a of ALLOWED.slice(0, 25)) o.addChoices({ name: a.label, value: a.slug });
+      return o;
+    });
+    s.addStringOption((o) =>
+      o.setName("params").setDescription("Query params, e.g. city=London").setRequired(false),
+    );
+    return s;
+  });
+
+export interface Ctx {
+  tael: Tael;
+  guard: Guard;
+  network: BotConfig["network"];
+}
+
+export async function handle(i: ChatInputCommandInteraction, ctx: Ctx): Promise<void> {
+  switch (i.options.getSubcommand()) {
+    case "list":
+      return list(i);
+    case "search":
+      return search(i, ctx);
+    case "call":
+      return call(i, ctx);
+  }
+}
+
+async function list(i: ChatInputCommandInteraction): Promise<void> {
+  const lines = ALLOWED.map(
+    (a) => `• **${a.label}** · \`${a.slug}\`${a.hint ? ` · params: \`${a.hint}\`` : ""}`,
+  );
+  const embed = new EmbedBuilder()
+    .setTitle("Callable capabilities")
+    .setDescription(lines.join("\n"))
+    .setColor(BRAND)
+    .setFooter({ text: "Use /tael call to run one. The bot pays per call in USDC" });
+  await i.reply({ embeds: [embed] });
+}
+
+async function search(i: ChatInputCommandInteraction, ctx: Ctx): Promise<void> {
+  await i.deferReply();
+  const q = i.options.getString("query", true);
+  const found = await ctx.tael.search(q);
+  const lines = found
+    .slice(0, 15)
+    .map(
+      (c) =>
+        `• **${c.name}** · \`${c.slug}\` · ${Number(c.price) > 0 ? `$${c.price}/call` : "free"}`,
+    );
+  const embed = new EmbedBuilder()
+    .setTitle(`Search: ${q}`)
+    .setDescription(lines.join("\n") || "No matches.")
+    .setColor(BRAND);
+  await i.editReply({ embeds: [embed] });
+}
+
+async function call(i: ChatInputCommandInteraction, ctx: Ctx): Promise<void> {
+  const slug = i.options.getString("capability", true);
+  const paramsStr = i.options.getString("params") ?? "";
+
+  // Guardrail 1: only allowlisted, data-only capabilities.
+  if (!isAllowed(slug)) {
+    await i.reply({
+      content: "That capability isn't available here.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  // Guardrail 2: per-user rate limit + daily cap.
+  const gate = ctx.guard.check(i.user.id);
+  if (!gate.ok) {
+    await i.reply({ content: gate.reason, flags: MessageFlags.Ephemeral });
+    return;
+  }
+
+  await i.deferReply(); // public: the result + on-chain proof are visible to the channel
+
+  const query = Object.fromEntries(new URLSearchParams(paramsStr));
+  try {
+    const res = await ctx.tael.call(slug, Object.keys(query).length ? { query } : {});
+    const body = JSON.stringify(res.data);
+    const embed = new EmbedBuilder()
+      .setTitle(`Ran ${slug}`)
+      .setDescription("```json\n" + body.slice(0, 1500) + "\n```")
+      .setColor(BRAND)
+      .setFooter({ text: `Paid per call in USDC · requested by ${i.user.username}` });
+    if (res.receipt?.txHash) {
+      embed.addFields({
+        name: "On-chain proof",
+        value: `[${res.receipt.txHash.slice(0, 12)}…](${explorerTx(res.receipt.txHash, ctx.network)})`,
+      });
+    }
+    await i.editReply({ embeds: [embed] });
+  } catch (err) {
+    const msg =
+      err instanceof TaelError
+        ? `Couldn't run it (${err.status}): ${err.message}`
+        : "The call failed. Try again.";
+    await i.editReply(msg);
+  }
+}

--- a/apps/discord-bot/src/config.ts
+++ b/apps/discord-bot/src/config.ts
@@ -1,0 +1,75 @@
+// Bot configuration: env (validated at startup) plus the static allowlist of
+// capabilities the bot is willing to call.
+
+export interface BotConfig {
+  discordToken: string;
+  /** Application (client) id, used to register slash commands. */
+  clientId: string;
+  /** Optional: register commands to one guild (instant) instead of globally. */
+  guildId?: string;
+  /** Tael API key linked to the funded Card the bot spends from. */
+  taelKey: string;
+  /** Override the gateway base URL (defaults to the SDK's testnet gateway). */
+  taelBaseUrl?: string;
+  /** Which network's explorer to link proofs to. */
+  network: "testnet" | "public";
+  /** Guardrail: max calls per user per minute. */
+  perUserPerMinute: number;
+  /** Guardrail: max total calls the bot will make per day. */
+  dailyCallCap: number;
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing required env var: ${name}`);
+  return v;
+}
+
+export function loadConfig(): BotConfig {
+  return {
+    discordToken: required("DISCORD_TOKEN"),
+    clientId: required("DISCORD_CLIENT_ID"),
+    guildId: process.env.DISCORD_GUILD_ID || undefined,
+    taelKey: required("TAEL_KEY"),
+    taelBaseUrl: process.env.TAEL_BASE_URL || undefined,
+    network: process.env.TAEL_NETWORK === "mainnet" ? "public" : "testnet",
+    perUserPerMinute: Number(process.env.RATE_LIMIT_PER_MIN ?? "5"),
+    dailyCallCap: Number(process.env.DAILY_CALL_CAP ?? "500"),
+  };
+}
+
+/** A capability the bot will call, with the params it expects. */
+export interface AllowedCap {
+  slug: string;
+  label: string;
+  hint?: string;
+}
+
+/**
+ * The ONLY capabilities the bot will call. Data lookups only, deliberately no
+ * `pay` / `swap`, so no one can move USDC out of the shared Card with a command.
+ */
+export const ALLOWED: AllowedCap[] = [
+  { slug: "cat-facts-ee8103", label: "Cat Facts" },
+  { slug: "weather-now-2ddf45", label: "Weather Now", hint: "city=London" },
+  { slug: "fx-rates/rates", label: "FX Rates", hint: "base=USD" },
+  { slug: "stellar/account", label: "Stellar · Account", hint: "address=G…" },
+  { slug: "stellar/balance", label: "Stellar · Balance", hint: "address=G…" },
+  { slug: "stellar/portfolio", label: "Stellar · Portfolio", hint: "address=G…" },
+  {
+    slug: "stellar/quote",
+    label: "Stellar · Quote",
+    hint: "source=USDC:<issuer>&dest=native&amount=100",
+  },
+  { slug: "stellar/explain", label: "Stellar · Explain", hint: "hash=<64-hex tx>" },
+  { slug: "trustline", label: "TrustLine (credit)" },
+];
+
+/** True only if the slug is allowlisted AND is not a money-moving op. */
+export function isAllowed(slug: string): boolean {
+  return ALLOWED.some((a) => a.slug === slug) && !/(^|\/)(pay|swap)\b/i.test(slug);
+}
+
+export function explorerTx(hash: string, network: "testnet" | "public"): string {
+  return `https://stellar.expert/explorer/${network}/tx/${hash}`;
+}

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -1,0 +1,49 @@
+import { Client, Events, GatewayIntentBits, MessageFlags, REST, Routes } from "discord.js";
+import { loadConfig } from "./config";
+import { makeClient } from "./tael";
+import { Guard } from "./rate-limit";
+import { command, handle, type Ctx } from "./commands";
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  const ctx: Ctx = {
+    tael: makeClient(cfg.taelKey, cfg.taelBaseUrl),
+    guard: new Guard(cfg.perUserPerMinute, cfg.dailyCallCap),
+    network: cfg.network,
+  };
+
+  const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+  client.once(Events.ClientReady, async (c) => {
+    // Register /tael. Guild-scoped is instant; global can take up to an hour.
+    const rest = new REST().setToken(cfg.discordToken);
+    const body = [command.toJSON()];
+    if (cfg.guildId) {
+      await rest.put(Routes.applicationGuildCommands(cfg.clientId, cfg.guildId), { body });
+      console.log(`Registered /tael to guild ${cfg.guildId}`);
+    } else {
+      await rest.put(Routes.applicationCommands(cfg.clientId), { body });
+      console.log("Registered /tael globally (can take up to 1h to appear)");
+    }
+    console.log(`Tael bot ready as ${c.user.tag}`);
+  });
+
+  client.on(Events.InteractionCreate, async (i) => {
+    if (!i.isChatInputCommand() || i.commandName !== "tael") return;
+    try {
+      await handle(i, ctx);
+    } catch (err) {
+      console.error("interaction error:", err);
+      const content = "Something went wrong. Please try again.";
+      if (i.deferred || i.replied) await i.editReply(content).catch(() => {});
+      else await i.reply({ content, flags: MessageFlags.Ephemeral }).catch(() => {});
+    }
+  });
+
+  await client.login(cfg.discordToken);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/discord-bot/src/rate-limit.ts
+++ b/apps/discord-bot/src/rate-limit.ts
@@ -1,0 +1,34 @@
+// Simple in-memory guardrail: a per-user sliding window plus a global daily cap.
+// Single-instance (fine for one bot process); a shared store would be the
+// multi-instance follow-up, same as the gateway's limiter.
+
+export class Guard {
+  private readonly hits = new Map<string, number[]>();
+  private day = { date: "", count: 0 };
+
+  constructor(
+    private readonly perUserPerMinute: number,
+    private readonly dailyCap: number,
+  ) {}
+
+  /** Returns { ok } if the call is allowed, or { ok: false, reason } to show the user. */
+  check(userId: string): { ok: true } | { ok: false; reason: string } {
+    const now = Date.now();
+
+    const today = new Date().toISOString().slice(0, 10);
+    if (this.day.date !== today) this.day = { date: today, count: 0 };
+    if (this.day.count >= this.dailyCap) {
+      return { ok: false, reason: "The bot has hit its daily call cap. Try again tomorrow." };
+    }
+
+    const recent = (this.hits.get(userId) ?? []).filter((t) => now - t < 60_000);
+    if (recent.length >= this.perUserPerMinute) {
+      return { ok: false, reason: `Slow down. Max ${this.perUserPerMinute} calls per minute.` };
+    }
+
+    recent.push(now);
+    this.hits.set(userId, recent);
+    this.day.count += 1;
+    return { ok: true };
+  }
+}

--- a/apps/discord-bot/src/tael.ts
+++ b/apps/discord-bot/src/tael.ts
@@ -1,0 +1,6 @@
+import { Tael } from "@tael/sdk";
+
+/** The buy-side SDK client the bot uses to call capabilities and pay per call. */
+export function makeClient(apiKey: string, baseUrl?: string): Tael {
+  return new Tael({ apiKey, ...(baseUrl ? { baseUrl } : {}) });
+}

--- a/apps/discord-bot/tsconfig.json
+++ b/apps/discord-bot/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@tael/config/tsconfig/library.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,31 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  apps/discord-bot:
+    dependencies:
+      '@tael/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      discord.js:
+        specifier: ^14.16.3
+        version: 14.27.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    devDependencies:
+      '@tael/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.0
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@heroui/react':
@@ -834,6 +859,34 @@ packages:
   '@creit.tech/xbull-wallet-connect@0.4.0':
     resolution: {integrity: sha512-LrCUIqUz50SkZ4mv2hTqSmwews8CNRYVoZ9+VjLsK/1U8PByzXTxv1vZyenj6avRTG86ifpoeihz7D3D5YIDrQ==}
     engines: {node: '>=16'}
+
+  '@discordjs/builders@1.14.1':
+    resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@1.5.3':
+    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@2.1.1':
+    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/formatters@0.6.2':
+    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/rest@2.6.3':
+    resolution: {integrity: sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/util@1.2.0':
+    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/ws@1.2.3':
+    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
+    engines: {node: '>=16.11.0'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -3855,6 +3908,18 @@ packages:
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/shapeshift@4.0.0':
+    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
+    engines: {node: '>=v16'}
+
+  '@sapphire/snowflake@3.5.5':
+    resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
@@ -4915,6 +4980,10 @@ packages:
   '@vitest/utils@3.2.6':
     resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
+  '@vladfrangu/async_event_emitter@2.4.7':
+    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@wallet-standard/base@1.1.1':
     resolution: {integrity: sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==}
     engines: {node: '>=22'}
@@ -5577,6 +5646,13 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  discord-api-types@0.38.52:
+    resolution: {integrity: sha512-uwe9EKfbjsmgWc2fdFjvDbj+dQqx3lp7wqDCmIha0jInuU+xeQjkCK9tMMn+p7RXfdVQORCInq4cD3U2ymDmyg==}
+
+  discord.js@14.27.0:
+    resolution: {integrity: sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==}
+    engines: {node: '>=18'}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -6339,8 +6415,14 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   long@5.2.5:
     resolution: {integrity: sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw==}
@@ -6363,6 +6445,9 @@ packages:
     resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  magic-bytes.js@1.13.1:
+    resolution: {integrity: sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -7389,6 +7474,10 @@ packages:
   undici-types@7.28.0:
     resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
 
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -8062,6 +8151,55 @@ snapshots:
       rxjs: 7.8.1
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
+
+  '@discordjs/builders@1.14.1':
+    dependencies:
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/util': 1.2.0
+      '@sapphire/shapeshift': 4.0.0
+      discord-api-types: 0.38.52
+      fast-deep-equal: 3.1.3
+      ts-mixer: 6.0.4
+      tslib: 2.8.1
+
+  '@discordjs/collection@1.5.3': {}
+
+  '@discordjs/collection@2.1.1': {}
+
+  '@discordjs/formatters@0.6.2':
+    dependencies:
+      discord-api-types: 0.38.52
+
+  '@discordjs/rest@2.6.3':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@sapphire/snowflake': 3.5.5
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.52
+      magic-bytes.js: 1.13.1
+      tslib: 2.8.1
+      undici: 6.28.0
+
+  '@discordjs/util@1.2.0':
+    dependencies:
+      discord-api-types: 0.38.52
+
+  '@discordjs/ws@1.2.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/rest': 2.6.3
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@types/ws': 8.18.1
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.52
+      tslib: 2.8.1
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -11936,6 +12074,15 @@ snapshots:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     optional: true
 
+  '@sapphire/async-queue@1.5.5': {}
+
+  '@sapphire/shapeshift@4.0.0':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      lodash: 4.18.1
+
+  '@sapphire/snowflake@3.5.5': {}
+
   '@scure/base@1.2.6': {}
 
   '@scure/base@2.2.0': {}
@@ -13419,6 +13566,8 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@vladfrangu/async_event_emitter@2.4.7': {}
+
   '@wallet-standard/base@1.1.1': {}
 
   '@wallet-standard/features@1.1.1':
@@ -14470,6 +14619,27 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  discord-api-types@0.38.52: {}
+
+  discord.js@14.27.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@discordjs/builders': 1.14.1
+      '@discordjs/collection': 1.5.3
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/rest': 2.6.3
+      '@discordjs/util': 1.2.0
+      '@discordjs/ws': 1.2.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@sapphire/snowflake': 3.5.5
+      discord-api-types: 0.38.52
+      fast-deep-equal: 3.1.3
+      lodash.snakecase: 4.1.1
+      magic-bytes.js: 1.13.1
+      tslib: 2.8.1
+      undici: 6.28.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   dlv@1.1.3: {}
 
   dom-helpers@5.2.1:
@@ -15242,7 +15412,11 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash.snakecase@4.1.1: {}
+
   lodash.startcase@4.4.0: {}
+
+  lodash@4.18.1: {}
 
   long@5.2.5: {}
 
@@ -15259,6 +15433,8 @@ snapshots:
   lucide-react@0.469.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  magic-bytes.js@1.13.1: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -16375,6 +16551,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.28.0: {}
+
+  undici@6.28.0: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
A new **`apps/discord-bot`** — a discord.js bot that lets community members call Tael marketplace capabilities right from Discord. The bot's Card pays per call in USDC via `@tael/sdk`, and each result comes back with an on-chain proof link. Real, multi-user, verifiable transactions.

## Commands
```
/tael list                      -> capabilities you can call here
/tael search query:weather      -> search the marketplace
/tael call capability:Cat Facts -> run it (the bot pays per call)
/tael call capability:Weather Now params:city=London
```

## Guardrails (it spends from one shared Card, so it's locked down)
- **Data-only allowlist** in `config.ts` — **no `pay`/`swap`**, so no one can move USDC out of the Card with a command.
- **Per-user rate limit** (default 5/min) and a **daily call cap** (default 500).
- The Card's own per-call + daily spend caps still bound everything at the protocol level.

## Files
- `src/config.ts` — env (validated at startup) + the capability allowlist.
- `src/tael.ts` — the `@tael/sdk` buy client.
- `src/rate-limit.ts` — per-user window + daily cap guard.
- `src/commands.ts` — the `/tael` command (list / search / call) with embeds + proof links.
- `src/index.ts` — bot entry: registers the command, routes interactions.
- `README.md`, `.env.example`, `Dockerfile` — setup + deploy (Render worker or Docker).

## To run it (your side)
Needs a **Discord bot token** + **Application ID**, and a **testnet `TAEL_KEY`** linked to a funded Card. Steps are in the README; set `DISCORD_GUILD_ID` for instant command registration while testing.

Verified: `typecheck`, `tsup build`, `prettier`, `eslint` all pass. (Live behavior needs the Discord token, which I can't hold.)