### PR TITLE
feat: add Telegram delivery for product agents (#173)

### DIFF
--- a/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
@@ -85,7 +85,8 @@ export async function POST(request: Request, context: { params: Promise<{ public
   const settings = (product.settings as Record<string, unknown>) ?? {};
   const token = typeof settings.telegramBotToken === "string" ? settings.telegramBotToken : null;
   const enabled = settings.telegramBotEnabled !== false;
-  const secretToken = typeof settings.telegramSecretToken === "string" ? settings.telegramSecretToken : null;
+  const secretToken =
+    typeof settings.telegramSecretToken === "string" ? settings.telegramSecretToken : null;
 
   if (!token || !enabled) {
     return new Response("Telegram bot is not configured or disabled for this agent.", {
@@ -138,12 +139,7 @@ export async function POST(request: Request, context: { params: Promise<{ public
 
     const check = await getEnabledActionForPublicKey(publicKey, actionId);
     if (!check.ok) {
-      await editTelegramMessageText(
-        token,
-        chatId,
-        messageId,
-        `❌ Action failed: ${check.error}`,
-      );
+      await editTelegramMessageText(token, chatId, messageId, `❌ Action failed: ${check.error}`);
       return new Response("OK", { status: 200 });
     }
 
@@ -241,11 +237,7 @@ export async function POST(request: Request, context: { params: Promise<{ public
       const data = (await resp.json()) as OpenRouterResponse;
       const message = data.choices?.[0]?.message;
       if (!message) {
-        await sendTelegramMessage(
-          token,
-          chatId,
-          "No response received from the agent.",
-        );
+        await sendTelegramMessage(token, chatId, "No response received from the agent.");
         return new Response("OK", { status: 200 });
       }
 
@@ -302,11 +294,7 @@ export async function POST(request: Request, context: { params: Promise<{ public
     );
     return new Response("OK", { status: 200 });
   } catch {
-    await sendTelegramMessage(
-      token,
-      chatId,
-      "An error occurred while processing your request.",
-    );
+    await sendTelegramMessage(token, chatId, "An error occurred while processing your request.");
     return new Response("OK", { status: 200 });
   }
 }

--- a/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
@@ -1,0 +1,312 @@
+import {
+  getProductActionsForChat,
+  getProductByPublicKey,
+  getProductContentForChat,
+} from "../../../../../features/products/queries";
+import {
+  getEnabledActionForPublicKey,
+  runProductAction,
+} from "../../../../../features/products/run-product-action";
+import {
+  answerTelegramCallbackQuery,
+  editTelegramMessageText,
+  sendTelegramMessage,
+  type TelegramUpdate,
+} from "../../../../../features/products/telegram";
+import {
+  actionIdFromToolName,
+  buildWidgetSystemPrompt,
+  buildWidgetTools,
+  createRateLimiter,
+  proposeWidgetAction,
+} from "../../../../../features/products/widget-chat";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const MODEL = process.env.OPENROUTER_MODEL ?? "google/gemini-2.5-flash";
+const MAX_TOKENS = 700;
+const MAX_TOOL_HOPS = 3;
+
+const allowRequest = createRateLimiter(30, 60_000);
+
+interface ToolCall {
+  id: string;
+  function: { name: string; arguments: string };
+}
+
+interface ChatMessage {
+  role: string;
+  content: string | null;
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+interface OpenRouterResponse {
+  choices?: { message?: ChatMessage }[];
+}
+
+function safeParseArgs(raw: string | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const v: unknown = JSON.parse(raw);
+    return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Formats a compact callback_data string under Telegram's strict 64-byte limit. */
+function buildCallbackData(actionId: string, paramsStr: string): string {
+  const hex = actionId.replace(/-/g, ""); // 32 chars
+  const prefix = `a:${hex}`; // 34 chars
+  if (!paramsStr) return prefix;
+  const maxParamsLen = 63 - prefix.length - 1; // 28 chars max
+  const safeParams = paramsStr.slice(0, Math.max(0, maxParamsLen));
+  return `${prefix}:${safeParams}`;
+}
+
+/** Reconstructs UUID from 32-hex actionId in callback_data. */
+function parseCallbackActionId(rawHex: string): string {
+  if (rawHex.length !== 32) return rawHex;
+  return `${rawHex.slice(0, 8)}-${rawHex.slice(8, 12)}-${rawHex.slice(12, 16)}-${rawHex.slice(16, 20)}-${rawHex.slice(20)}`;
+}
+
+export async function POST(request: Request, context: { params: Promise<{ publicKey: string }> }) {
+  const { publicKey: rawKey } = await context.params;
+  const publicKey = decodeURIComponent(rawKey ?? "").trim();
+  if (!publicKey) return new Response("Missing public key.", { status: 400 });
+
+  const product = await getProductByPublicKey(publicKey);
+  if (!product) return new Response("Agent not found.", { status: 404 });
+
+  const settings = (product.settings as Record<string, unknown>) ?? {};
+  const token = typeof settings.telegramBotToken === "string" ? settings.telegramBotToken : null;
+  const enabled = settings.telegramBotEnabled !== false;
+  const secretToken = typeof settings.telegramSecretToken === "string" ? settings.telegramSecretToken : null;
+
+  if (!token || !enabled) {
+    return new Response("Telegram bot is not configured or disabled for this agent.", {
+      status: 400,
+    });
+  }
+
+  // Webhook security: verify secret_token if configured
+  if (secretToken) {
+    const incomingSecret = request.headers.get("x-telegram-bot-api-secret-token");
+    if (incomingSecret !== secretToken) {
+      return new Response("Unauthorized webhook request.", { status: 401 });
+    }
+  }
+
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    return new Response("OpenRouter key not configured.", { status: 503 });
+  }
+
+  const update = (await request.json().catch(() => null)) as TelegramUpdate | null;
+  if (!update) return new Response("Invalid payload", { status: 400 });
+
+  // Handle Telegram Callback Query (Action Confirmation Button Click)
+  if (update.callback_query) {
+    const cb = update.callback_query;
+    const data = cb.data ?? "";
+    const chatId = cb.message?.chat.id;
+    const messageId = cb.message?.message_id;
+
+    if ((!data.startsWith("a:") && !data.startsWith("run_action:")) || !chatId || !messageId) {
+      await answerTelegramCallbackQuery(token, cb.id);
+      return new Response("OK", { status: 200 });
+    }
+
+    let actionId: string;
+    let paramsStr: string;
+
+    if (data.startsWith("a:")) {
+      const parts = data.slice(2).split(":");
+      actionId = parseCallbackActionId(parts[0] ?? "");
+      paramsStr = parts.slice(1).join(":");
+    } else {
+      const parts = data.split(":");
+      actionId = parts[1] ?? "";
+      paramsStr = parts.slice(2).join(":");
+    }
+
+    await answerTelegramCallbackQuery(token, cb.id, "Running action...");
+
+    const check = await getEnabledActionForPublicKey(publicKey, actionId);
+    if (!check.ok) {
+      await editTelegramMessageText(
+        token,
+        chatId,
+        messageId,
+        `❌ Action failed: ${check.error}`,
+      );
+      return new Response("OK", { status: 200 });
+    }
+
+    let parsedParams: Record<string, unknown> | undefined;
+    if (paramsStr) {
+      try {
+        parsedParams = JSON.parse(paramsStr);
+      } catch {
+        parsedParams = { value: paramsStr };
+      }
+    }
+
+    const res = await runProductAction({
+      actionId: check.actionId,
+      params: parsedParams ?? paramsStr,
+    });
+
+    if (res.ok) {
+      const output = res.body ? `\n\n\`\`\`\n${res.body.slice(0, 1500)}\n\`\`\`` : "";
+      await editTelegramMessageText(
+        token,
+        chatId,
+        messageId,
+        `✅ Action executed successfully!${output}`,
+        { parseMode: "Markdown" },
+      );
+    } else {
+      await editTelegramMessageText(
+        token,
+        chatId,
+        messageId,
+        `❌ Action failed: ${res.error ?? "Unknown error"}`,
+      );
+    }
+
+    return new Response("OK", { status: 200 });
+  }
+
+  // Handle incoming message
+  const msg = update.message;
+  if (!msg || !msg.text || msg.from?.is_bot) {
+    return new Response("OK", { status: 200 });
+  }
+
+  const chatId = msg.chat.id;
+  const userText = msg.text.trim();
+
+  if (!allowRequest(`${publicKey}:${chatId}`)) {
+    await sendTelegramMessage(token, chatId, "Too many requests. Please wait a minute.");
+    return new Response("OK", { status: 200 });
+  }
+
+  const [content, actions] = await Promise.all([
+    getProductContentForChat(product.id),
+    getProductActionsForChat(product.id),
+  ]);
+
+  const system = buildWidgetSystemPrompt(product, content, actions);
+  const tools = buildWidgetTools(actions);
+  const actionsById = new Map(actions.map((a) => [a.id, a]));
+
+  const convo: ChatMessage[] = [
+    { role: "system", content: system },
+    { role: "user", content: userText.slice(0, 4000) },
+  ];
+
+  try {
+    for (let hop = 0; hop < MAX_TOOL_HOPS; hop += 1) {
+      const resp = await fetch(OPENROUTER_URL, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+          "HTTP-Referer": "https://taelprotocol.xyz",
+          "X-Title": "Tael Telegram Agent",
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          messages: convo,
+          ...(tools.length > 0 ? { tools, tool_choice: "auto" } : {}),
+          max_tokens: MAX_TOKENS,
+          temperature: 0.3,
+        }),
+      });
+
+      if (!resp.ok) {
+        await sendTelegramMessage(
+          token,
+          chatId,
+          "The agent is currently unavailable. Please try again later.",
+        );
+        return new Response("OK", { status: 200 });
+      }
+
+      const data = (await resp.json()) as OpenRouterResponse;
+      const message = data.choices?.[0]?.message;
+      if (!message) {
+        await sendTelegramMessage(
+          token,
+          chatId,
+          "No response received from the agent.",
+        );
+        return new Response("OK", { status: 200 });
+      }
+
+      if (message.tool_calls?.length) {
+        for (const call of message.tool_calls) {
+          const actionId = actionIdFromToolName(call.function.name);
+          if (!actionId) continue;
+          const action = actionsById.get(actionId);
+          if (!action) continue;
+
+          const args = safeParseArgs(call.function.arguments);
+          const proposed = proposeWidgetAction(action, args);
+          const paramsStr = args.params != null ? String(args.params) : "";
+          const callbackData = buildCallbackData(action.id, paramsStr);
+
+          await sendTelegramMessage(token, chatId, proposed.reply, {
+            replyMarkup: {
+              inline_keyboard: [
+                [
+                  {
+                    text: `▶ Run ${action.name}`,
+                    callback_data: callbackData,
+                  },
+                ],
+              ],
+            },
+          });
+          return new Response("OK", { status: 200 });
+        }
+
+        convo.push(message);
+        for (const call of message.tool_calls) {
+          convo.push({
+            role: "tool",
+            tool_call_id: call.id,
+            name: call.function.name,
+            content: JSON.stringify({ error: "unknown action" }),
+          });
+        }
+        continue;
+      }
+
+      const text = typeof message.content === "string" ? message.content.trim() : "";
+      if (text) {
+        await sendTelegramMessage(token, chatId, text, { parseMode: "Markdown" });
+      }
+      return new Response("OK", { status: 200 });
+    }
+
+    await sendTelegramMessage(
+      token,
+      chatId,
+      "I couldn't quite complete that request. Could you rephrase?",
+    );
+    return new Response("OK", { status: 200 });
+  } catch {
+    await sendTelegramMessage(
+      token,
+      chatId,
+      "An error occurred while processing your request.",
+    );
+    return new Response("OK", { status: 200 });
+  }
+}

--- a/apps/dashboard/features/products/actions.ts
+++ b/apps/dashboard/features/products/actions.ts
@@ -28,6 +28,7 @@ const updateProductSchema = z.object({
   greeting: greetingSchema.optional(),
   status: statusSchema.optional(),
   logoUrl: z.string().max(200_000).nullable().optional(),
+  settings: z.record(z.unknown()).optional(),
 });
 
 /** Update product settings. Ownership-checked. */
@@ -64,6 +65,92 @@ export async function updateProduct(
   }
 }
 
+/** Connect a Telegram Bot to this product agent. Ownership-checked. */
+export async function connectTelegramBot(
+  id: string,
+  botToken: string,
+  baseUrl: string,
+): Promise<ActionResult & { botUsername?: string }> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  const cleanToken = botToken.trim();
+  if (!cleanToken) return { ok: false, error: "Telegram Bot Token is required." };
+
+  const [product] = await db
+    .select()
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.ownerId, user.id)))
+    .limit(1);
+
+  if (!product) return { ok: false, error: "Agent not found." };
+
+  const { getTelegramBotInfo, setTelegramWebhook } = await import("./telegram");
+  const info = await getTelegramBotInfo(cleanToken);
+  if (!info.ok || !info.username) {
+    return { ok: false, error: info.error ?? "Invalid bot token." };
+  }
+
+  const secretToken = crypto.randomUUID().replace(/-/g, "");
+  const webhookUrl = `${baseUrl.replace(/\/$/, "")}/api/widget/${encodeURIComponent(product.publicKey)}/telegram`;
+  const hookResult = await setTelegramWebhook(cleanToken, webhookUrl, secretToken);
+  if (!hookResult.ok) {
+    return { ok: false, error: hookResult.error ?? "Could not configure Telegram webhook." };
+  }
+
+  const currentSettings = (product.settings as Record<string, unknown>) ?? {};
+  const updatedSettings = {
+    ...currentSettings,
+    telegramBotToken: cleanToken,
+    telegramBotUsername: info.username,
+    telegramBotEnabled: true,
+    telegramSecretToken: secretToken,
+  };
+
+  await db
+    .update(products)
+    .set({ settings: updatedSettings })
+    .where(eq(products.id, id));
+
+  revalidateStudioPaths();
+  return { ok: true, botUsername: info.username };
+}
+
+/** Disconnect / Disable Telegram Bot for this product agent. Ownership-checked. */
+export async function disconnectTelegramBot(id: string): Promise<ActionResult> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  const [product] = await db
+    .select()
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.ownerId, user.id)))
+    .limit(1);
+
+  if (!product) return { ok: false, error: "Agent not found." };
+
+  const currentSettings = (product.settings as Record<string, unknown>) ?? {};
+  const token = typeof currentSettings.telegramBotToken === "string" ? currentSettings.telegramBotToken : null;
+
+  if (token) {
+    const { deleteTelegramWebhook } = await import("./telegram");
+    await deleteTelegramWebhook(token);
+  }
+
+  const updatedSettings = {
+    ...currentSettings,
+    telegramBotEnabled: false,
+  };
+
+  await db
+    .update(products)
+    .set({ settings: updatedSettings })
+    .where(eq(products.id, id));
+
+  revalidateStudioPaths();
+  return { ok: true };
+}
+
 /** Delete a product the signed-in user owns. Cascades content + actions. */
 export async function deleteProduct(id: string): Promise<ActionResult> {
   const user = await getCurrentUser();
@@ -83,3 +170,4 @@ export async function deleteProduct(id: string): Promise<ActionResult> {
     return { ok: false, error: "Could not delete. Try again." };
   }
 }
+

--- a/apps/dashboard/features/products/actions.ts
+++ b/apps/dashboard/features/products/actions.ts
@@ -107,10 +107,7 @@ export async function connectTelegramBot(
     telegramSecretToken: secretToken,
   };
 
-  await db
-    .update(products)
-    .set({ settings: updatedSettings })
-    .where(eq(products.id, id));
+  await db.update(products).set({ settings: updatedSettings }).where(eq(products.id, id));
 
   revalidateStudioPaths();
   return { ok: true, botUsername: info.username };
@@ -130,7 +127,8 @@ export async function disconnectTelegramBot(id: string): Promise<ActionResult> {
   if (!product) return { ok: false, error: "Agent not found." };
 
   const currentSettings = (product.settings as Record<string, unknown>) ?? {};
-  const token = typeof currentSettings.telegramBotToken === "string" ? currentSettings.telegramBotToken : null;
+  const token =
+    typeof currentSettings.telegramBotToken === "string" ? currentSettings.telegramBotToken : null;
 
   if (token) {
     const { deleteTelegramWebhook } = await import("./telegram");
@@ -142,10 +140,7 @@ export async function disconnectTelegramBot(id: string): Promise<ActionResult> {
     telegramBotEnabled: false,
   };
 
-  await db
-    .update(products)
-    .set({ settings: updatedSettings })
-    .where(eq(products.id, id));
+  await db.update(products).set({ settings: updatedSettings }).where(eq(products.id, id));
 
   revalidateStudioPaths();
   return { ok: true };
@@ -170,4 +165,3 @@ export async function deleteProduct(id: string): Promise<ActionResult> {
     return { ok: false, error: "Could not delete. Try again." };
   }
 }
-

--- a/apps/dashboard/features/products/deploy-panel.tsx
+++ b/apps/dashboard/features/products/deploy-panel.tsx
@@ -16,7 +16,8 @@ export function DeployPanel({ product }: { product: Product }) {
   );
 
   const settings = (product.settings as Record<string, unknown>) ?? {};
-  const currentBotUsername = typeof settings.telegramBotUsername === "string" ? settings.telegramBotUsername : "";
+  const currentBotUsername =
+    typeof settings.telegramBotUsername === "string" ? settings.telegramBotUsername : "";
   const isTelegramEnabled = settings.telegramBotEnabled === true;
 
   const [telegramToken, setTelegramToken] = useState("");
@@ -50,7 +51,11 @@ export function DeployPanel({ product }: { product: Product }) {
     setTelegramError(null);
     setTelegramSuccess(null);
     startTransition(async () => {
-      const res = await connectTelegramBot(product.id, telegramToken, base || window.location.origin);
+      const res = await connectTelegramBot(
+        product.id,
+        telegramToken,
+        base || window.location.origin,
+      );
       if (res.ok) {
         setTelegramSuccess(`Connected successfully as @${res.botUsername ?? "bot"}`);
         router.refresh();
@@ -140,7 +145,8 @@ export function DeployPanel({ product }: { product: Product }) {
         <div>
           <h2 className="text-base font-semibold">Telegram Bot Integration</h2>
           <p className="text-sm text-muted-foreground">
-            Connect a Telegram Bot token to serve your product agent on Telegram. Train once, serve everywhere.
+            Connect a Telegram Bot token to serve your product agent on Telegram. Train once, serve
+            everywhere.
           </p>
         </div>
 
@@ -153,7 +159,9 @@ export function DeployPanel({ product }: { product: Product }) {
                 </span>
                 <div>
                   <p className="text-sm font-medium">Connected as @{currentBotUsername}</p>
-                  <p className="text-xs text-muted-foreground">Webhook active and listening for messages.</p>
+                  <p className="text-xs text-muted-foreground">
+                    Webhook active and listening for messages.
+                  </p>
                 </div>
               </div>
               <Button
@@ -203,7 +211,8 @@ export function DeployPanel({ product }: { product: Product }) {
         <div>
           <h2 className="text-base font-semibold">Channels</h2>
           <p className="text-sm text-muted-foreground">
-            Where this agent can show up. Website and Telegram are ready; more channels are on the way.
+            Where this agent can show up. Website and Telegram are ready; more channels are on the
+            way.
           </p>
         </div>
 
@@ -262,4 +271,3 @@ export function DeployPanel({ product }: { product: Product }) {
     </div>
   );
 }
-

--- a/apps/dashboard/features/products/deploy-panel.tsx
+++ b/apps/dashboard/features/products/deploy-panel.tsx
@@ -1,47 +1,27 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Check, Copy, Globe, MessageCircle, Radio, Server } from "lucide-react";
-import { Button, cn } from "@tael/ui";
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Check, Copy, Globe, MessageCircle, Radio, Server, Bot, Unplug } from "lucide-react";
+import { Button, Input, cn } from "@tael/ui";
 import type { Product } from "@tael/database";
+import { connectTelegramBot, disconnectTelegramBot } from "./actions";
 
-const CHANNELS = [
-  {
-    id: "website",
-    label: "Website",
-    description: "Embed the chat widget on your site.",
-    icon: Globe,
-    status: "live" as const,
-  },
-  {
-    id: "discord",
-    label: "Discord",
-    description: "Answer in your Discord server.",
-    icon: MessageCircle,
-    status: "soon" as const,
-  },
-  {
-    id: "telegram",
-    label: "Telegram",
-    description: "A bot for your Telegram channel.",
-    icon: Radio,
-    status: "soon" as const,
-  },
-  {
-    id: "mcp",
-    label: "MCP",
-    description: "Expose this agent as an MCP server.",
-    icon: Server,
-    status: "soon" as const,
-  },
-];
-
-/** Deploy: embed snippet + channel availability. */
 export function DeployPanel({ product }: { product: Product }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
   const [copied, setCopied] = useState(false);
   const [base, setBase] = useState(
     () => process.env.NEXT_PUBLIC_DASHBOARD_URL?.replace(/\/$/, "") ?? "",
   );
+
+  const settings = (product.settings as Record<string, unknown>) ?? {};
+  const currentBotUsername = typeof settings.telegramBotUsername === "string" ? settings.telegramBotUsername : "";
+  const isTelegramEnabled = settings.telegramBotEnabled === true;
+
+  const [telegramToken, setTelegramToken] = useState("");
+  const [telegramError, setTelegramError] = useState<string | null>(null);
+  const [telegramSuccess, setTelegramSuccess] = useState<string | null>(null);
 
   useEffect(() => {
     if (!process.env.NEXT_PUBLIC_DASHBOARD_URL) {
@@ -65,6 +45,66 @@ export function DeployPanel({ product }: { product: Product }) {
       // no-op
     }
   }
+
+  function handleConnectTelegram() {
+    setTelegramError(null);
+    setTelegramSuccess(null);
+    startTransition(async () => {
+      const res = await connectTelegramBot(product.id, telegramToken, base || window.location.origin);
+      if (res.ok) {
+        setTelegramSuccess(`Connected successfully as @${res.botUsername ?? "bot"}`);
+        router.refresh();
+      } else {
+        setTelegramError(res.error ?? "Could not connect Telegram Bot.");
+      }
+    });
+  }
+
+  function handleDisconnectTelegram() {
+    setTelegramError(null);
+    setTelegramSuccess(null);
+    startTransition(async () => {
+      const res = await disconnectTelegramBot(product.id);
+      if (res.ok) {
+        setTelegramSuccess("Telegram bot disconnected.");
+        setTelegramToken("");
+        router.refresh();
+      } else {
+        setTelegramError(res.error ?? "Could not disconnect Telegram Bot.");
+      }
+    });
+  }
+
+  const channels = [
+    {
+      id: "website",
+      label: "Website",
+      description: "Embed the chat widget on your site.",
+      icon: Globe,
+      status: "live" as const,
+    },
+    {
+      id: "telegram",
+      label: "Telegram",
+      description: "A bot for your Telegram channel.",
+      icon: Radio,
+      status: isTelegramEnabled ? ("live" as const) : ("ready" as const),
+    },
+    {
+      id: "discord",
+      label: "Discord",
+      description: "Answer in your Discord server.",
+      icon: MessageCircle,
+      status: "soon" as const,
+    },
+    {
+      id: "mcp",
+      label: "MCP",
+      description: "Expose this agent as an MCP server.",
+      icon: Server,
+      status: "soon" as const,
+    },
+  ];
 
   return (
     <div className="space-y-6">
@@ -98,16 +138,80 @@ export function DeployPanel({ product }: { product: Product }) {
 
       <section className="space-y-4 rounded-xl border p-5">
         <div>
+          <h2 className="text-base font-semibold">Telegram Bot Integration</h2>
+          <p className="text-sm text-muted-foreground">
+            Connect a Telegram Bot token to serve your product agent on Telegram. Train once, serve everywhere.
+          </p>
+        </div>
+
+        {isTelegramEnabled && currentBotUsername ? (
+          <div className="space-y-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2.5">
+                <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600">
+                  <Bot className="h-4 w-4" />
+                </span>
+                <div>
+                  <p className="text-sm font-medium">Connected as @{currentBotUsername}</p>
+                  <p className="text-xs text-muted-foreground">Webhook active and listening for messages.</p>
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleDisconnectTelegram}
+                disabled={pending}
+              >
+                <Unplug className="h-4 w-4 mr-1" /> Disconnect
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <label className="block space-y-1.5">
+              <span className="text-sm font-medium">Bot Token (from @BotFather)</span>
+              <Input
+                type="password"
+                placeholder="123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ"
+                value={telegramToken}
+                onChange={(e) => setTelegramToken(e.target.value)}
+              />
+            </label>
+            <div className="flex items-center gap-3">
+              <Button
+                type="button"
+                size="sm"
+                onClick={handleConnectTelegram}
+                disabled={pending || !telegramToken.trim()}
+              >
+                {pending ? "Connecting…" : "Connect & Deploy Bot"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {telegramError ? <p className="text-sm text-destructive">{telegramError}</p> : null}
+        {telegramSuccess ? (
+          <p className="text-sm text-emerald-600 flex items-center gap-1">
+            <Check className="h-4 w-4" /> {telegramSuccess}
+          </p>
+        ) : null}
+      </section>
+
+      <section className="space-y-4 rounded-xl border p-5">
+        <div>
           <h2 className="text-base font-semibold">Channels</h2>
           <p className="text-sm text-muted-foreground">
-            Where this agent can show up. Website is ready; more channels are on the way.
+            Where this agent can show up. Website and Telegram are ready; more channels are on the way.
           </p>
         </div>
 
         <ul className="divide-y overflow-hidden rounded-xl border">
-          {CHANNELS.map((ch) => {
+          {channels.map((ch) => {
             const Icon = ch.icon;
             const live = ch.status === "live";
+            const ready = ch.status === "ready";
             return (
               <li
                 key={ch.id}
@@ -118,7 +222,9 @@ export function DeployPanel({ product }: { product: Product }) {
                     "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border",
                     live
                       ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-                      : "border-border bg-muted/40 text-muted-foreground",
+                      : ready
+                        ? "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300"
+                        : "border-border bg-muted/40 text-muted-foreground",
                   )}
                 >
                   <Icon className="h-4 w-4" />
@@ -130,6 +236,10 @@ export function DeployPanel({ product }: { product: Product }) {
                 {live ? (
                   <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
                     <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Live
+                  </span>
+                ) : ready ? (
+                  <span className="rounded-full bg-blue-500/10 px-2.5 py-1 text-xs font-medium text-blue-700 dark:text-blue-300">
+                    Ready to connect
                   </span>
                 ) : (
                   <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
@@ -152,3 +262,4 @@ export function DeployPanel({ product }: { product: Product }) {
     </div>
   );
 }
+

--- a/apps/dashboard/features/products/telegram.ts
+++ b/apps/dashboard/features/products/telegram.ts
@@ -109,7 +109,9 @@ export async function setTelegramWebhook(
 }
 
 /** Delete webhook for Telegram bot. */
-export async function deleteTelegramWebhook(token: string): Promise<{ ok: boolean; error?: string }> {
+export async function deleteTelegramWebhook(
+  token: string,
+): Promise<{ ok: boolean; error?: string }> {
   try {
     const res = await fetch(`${TELEGRAM_API_BASE}/bot${token}/deleteWebhook`, {
       method: "POST",

--- a/apps/dashboard/features/products/telegram.ts
+++ b/apps/dashboard/features/products/telegram.ts
@@ -1,0 +1,242 @@
+/**
+ * Telegram Bot API client helpers.
+ * Direct REST implementation using fetch (no extra heavy npm dependencies).
+ */
+
+const TELEGRAM_API_BASE = "https://api.telegram.org";
+
+export interface TelegramUser {
+  id: number;
+  is_bot: boolean;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+}
+
+export interface TelegramChat {
+  id: number;
+  type: string;
+  title?: string;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+export interface TelegramMessage {
+  message_id: number;
+  from?: TelegramUser;
+  chat: TelegramChat;
+  date: number;
+  text?: string;
+}
+
+export interface TelegramCallbackQuery {
+  id: string;
+  from: TelegramUser;
+  message?: TelegramMessage;
+  data?: string;
+}
+
+export interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+  callback_query?: TelegramCallbackQuery;
+}
+
+export interface InlineKeyboardButton {
+  text: string;
+  callback_data: string;
+}
+
+export interface InlineKeyboardMarkup {
+  inline_keyboard: InlineKeyboardButton[][];
+}
+
+/** Get info about the bot associated with the token. */
+export async function getTelegramBotInfo(
+  token: string,
+): Promise<{ ok: boolean; username?: string; firstName?: string; error?: string }> {
+  try {
+    const res = await fetch(`${TELEGRAM_API_BASE}/bot${token}/getMe`, {
+      method: "GET",
+      headers: { "content-type": "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    const data = (await res.json()) as {
+      ok: boolean;
+      result?: { username?: string; first_name?: string };
+      description?: string;
+    };
+    if (!res.ok || !data.ok || !data.result) {
+      return { ok: false, error: data.description ?? "Invalid bot token." };
+    }
+    return {
+      ok: true,
+      username: data.result.username,
+      firstName: data.result.first_name,
+    };
+  } catch {
+    return { ok: false, error: "Could not reach Telegram API." };
+  }
+}
+
+/** Set webhook URL for Telegram bot with optional secret_token header verification. */
+export async function setTelegramWebhook(
+  token: string,
+  webhookUrl: string,
+  secretToken?: string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const body: Record<string, unknown> = { url: webhookUrl };
+    if (secretToken) {
+      body.secret_token = secretToken;
+    }
+
+    const res = await fetch(`${TELEGRAM_API_BASE}/bot${token}/setWebhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const data = (await res.json()) as { ok: boolean; description?: string };
+    if (!res.ok || !data.ok) {
+      return { ok: false, error: data.description ?? "Failed to set webhook." };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not reach Telegram API." };
+  }
+}
+
+/** Delete webhook for Telegram bot. */
+export async function deleteTelegramWebhook(token: string): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch(`${TELEGRAM_API_BASE}/bot${token}/deleteWebhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    const data = (await res.json()) as { ok: boolean; description?: string };
+    if (!res.ok || !data.ok) {
+      return { ok: false, error: data.description ?? "Failed to delete webhook." };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not reach Telegram API." };
+  }
+}
+
+/** Send text message (with optional inline keyboard). */
+export async function sendTelegramMessage(
+  token: string,
+  chatId: number | string,
+  text: string,
+  options?: {
+    replyMarkup?: InlineKeyboardMarkup;
+    parseMode?: "Markdown" | "HTML";
+  },
+): Promise<{ ok: boolean; messageId?: number; error?: string }> {
+  try {
+    const body: Record<string, unknown> = {
+      chat_id: chatId,
+      text,
+    };
+    if (options?.replyMarkup) {
+      body.reply_markup = options.replyMarkup;
+    }
+    if (options?.parseMode) {
+      body.parse_mode = options.parseMode;
+    }
+
+    const res = await fetch(`${TELEGRAM_API_BASE}/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const data = (await res.json()) as {
+      ok: boolean;
+      result?: { message_id: number };
+      description?: string;
+    };
+    if (!res.ok || !data.ok) {
+      if (options?.parseMode) {
+        return sendTelegramMessage(token, chatId, text, {
+          replyMarkup: options.replyMarkup,
+        });
+      }
+      return { ok: false, error: data.description ?? "Failed to send message." };
+    }
+    return { ok: true, messageId: data.result?.message_id };
+  } catch {
+    return { ok: false, error: "Could not send Telegram message." };
+  }
+}
+
+/** Edit existing Telegram message text. */
+export async function editTelegramMessageText(
+  token: string,
+  chatId: number | string,
+  messageId: number,
+  text: string,
+  options?: {
+    replyMarkup?: InlineKeyboardMarkup;
+    parseMode?: "Markdown" | "HTML";
+  },
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const body: Record<string, unknown> = {
+      chat_id: chatId,
+      message_id: messageId,
+      text,
+    };
+    if (options?.replyMarkup) {
+      body.reply_markup = options.replyMarkup;
+    }
+    if (options?.parseMode) {
+      body.parse_mode = options.parseMode;
+    }
+
+    const res = await fetch(`${TELEGRAM_API_BASE}/bot${token}/editMessageText`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const data = (await res.json()) as { ok: boolean; description?: string };
+    if (!res.ok || !data.ok) {
+      if (options?.parseMode) {
+        return editTelegramMessageText(token, chatId, messageId, text, {
+          replyMarkup: options.replyMarkup,
+        });
+      }
+      return { ok: false, error: data.description ?? "Failed to edit message." };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not edit Telegram message." };
+  }
+}
+
+/** Acknowledge callback query from inline keyboard click. */
+export async function answerTelegramCallbackQuery(
+  token: string,
+  callbackQueryId: string,
+  text?: string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch(`${TELEGRAM_API_BASE}/bot${token}/answerCallbackQuery`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        callback_query_id: callbackQueryId,
+        text,
+      }),
+      signal: AbortSignal.timeout(5_000),
+    });
+    const data = (await res.json()) as { ok: boolean; description?: string };
+    return { ok: data.ok, error: data.description };
+  } catch {
+    return { ok: false, error: "Could not answer callback query." };
+  }
+}


### PR DESCRIPTION
## Summary

Implements Telegram delivery for per-product agents.

This allows product owners to connect a Telegram Bot token from Studio → Deploy and serve the same agent on Telegram while reusing the widget's knowledge base and actions.

Closes #173

---

## What changed

- Added Telegram REST API helper
- Added Telegram webhook endpoint
- Added Studio Telegram Bot configuration
- Added webhook secret verification
- Added confirm-gated Telegram actions
- Added callback_data size handling (<64 bytes)
- Added Markdown fallback
- Added per-chat rate limiting

---

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Refactor / chore
- [ ] Docs

---

## Verification

- [x] pnpm build
- [x] Type checking
- [x] Live Telegram getMe()
- [x] Live setWebhook()
- [x] Telegram webhook verified
- [x] OpenRouter integration
- [x] Confirm-gated actions tested