### PR TITLE
Added: Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,20 @@
+{
+  "name": "Tael",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "api",
+      "command": "pnpm --filter @tael/api dev"
+    },
+    {
+      "name": "web",
+      "command": "pnpm --filter web dev"
+    },
+    {
+      "name": "dashboard",
+      "command": "pnpm --filter dashboard dev"
+    }
+  ],
+  "ports": [3000, 3001, 3002]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Tael — Cloud Agent install (runs once; baked into the environment snapshot).
+# Idempotent: installs deps + PostgreSQL, prepares the local .env, applies
+# Drizzle migrations, and seeds a little demo data so the gateway + catalog have
+# something to serve. Per-boot service startup lives in start.sh.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+
+DEMO_WALLET="GDEMOPUBLISHER00000000000000000000000000000000000000000A"
+USDC_ISSUER="GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA"
+
+echo "==> Enabling corepack + installing workspace dependencies"
+corepack enable 2>/dev/null || true
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+pnpm install --frozen-lockfile
+
+echo "==> Ensuring PostgreSQL is installed"
+if ! command -v pg_ctlcluster >/dev/null 2>&1; then
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql postgresql-contrib
+fi
+
+echo "==> Starting PostgreSQL for setup"
+sudo pg_ctlcluster 16 main start 2>/dev/null || true
+for _ in $(seq 1 30); do pg_isready -h localhost -p 5432 >/dev/null 2>&1 && break; sleep 1; done
+
+echo "==> Setting the postgres role password (local dev only)"
+sudo -u postgres psql -tAc "ALTER USER postgres PASSWORD 'postgres';" >/dev/null
+
+echo "==> Preparing the root .env (only if missing)"
+if [ ! -f .env ]; then
+  cp .env.example .env
+  sed -i "s|^ENCRYPTION_KEY=.*|ENCRYPTION_KEY=$(openssl rand -hex 32)|" .env
+  sed -i "s|^AUTH_SECRET=.*|AUTH_SECRET=$(openssl rand -hex 32)|" .env
+  sed -i "s|^DATABASE_URL=.*|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres|" .env
+  sed -i "s|^DIRECT_URL=.*|DIRECT_URL=postgresql://postgres:postgres@localhost:5432/postgres|" .env
+fi
+
+echo "==> Linking per-app .env for the Next.js apps (they don't read the repo-root .env)"
+for app in web dashboard chat; do
+  ln -sfn ../../.env "apps/$app/.env"
+done
+
+echo "==> Applying database migrations"
+pnpm --filter @tael/database db:migrate
+
+echo "==> Seeding demo capabilities (idempotent)"
+sudo -u postgres psql -d postgres -v ON_ERROR_STOP=1 \
+  -v wallet="$DEMO_WALLET" -v issuer="$USDC_ISSUER" <<'SQL'
+INSERT INTO users (wallet_address, display_name)
+VALUES (:'wallet', 'Tael Demo Publisher')
+ON CONFLICT (wallet_address) DO NOTHING;
+
+INSERT INTO capabilities
+  (slug, name, description, kind, visibility, status, price, pay_to, upstream_url, upstream_auth, spec, publisher_id)
+SELECT 'fx-rates', 'FX Rates',
+       'Live foreign-exchange rates for 150+ currency pairs. Pay-per-lookup.',
+       'api', 'public', 'verified', 0.0200, :'issuer',
+       'https://api.example.com/fx',
+       '{"scheme":"none"}'::jsonb,
+       '{"method":"GET","operations":[]}'::jsonb,
+       u.id
+FROM users u WHERE u.wallet_address = :'wallet'
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO capabilities
+  (slug, name, description, kind, visibility, status, price, pay_to, upstream_url, upstream_auth, spec, publisher_id)
+SELECT 'text-extract', 'Text Extract',
+       'Extract clean text and structured data from any PDF or webpage.',
+       'api', 'public', 'verified', 0.0500, :'issuer',
+       'https://api.example.com/extract',
+       '{"scheme":"none"}'::jsonb,
+       '{"method":"POST","operations":[]}'::jsonb,
+       u.id
+FROM users u WHERE u.wallet_address = :'wallet'
+ON CONFLICT (slug) DO NOTHING;
+SQL
+
+echo "==> Install complete"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Tael — Cloud Agent start (runs on every boot). Brings PostgreSQL back up and
+# reconciles per-boot state. Must be idempotent and must return (the dev servers
+# themselves run as terminals, not here).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> Ensuring PostgreSQL is running"
+if ! pg_isready -h localhost -p 5432 >/dev/null 2>&1; then
+  sudo pg_ctlcluster 16 main start 2>/dev/null || true
+fi
+for _ in $(seq 1 30); do pg_isready -h localhost -p 5432 >/dev/null 2>&1 && break; sleep 1; done
+
+echo "==> Ensuring the local .env and per-app links exist"
+if [ ! -f .env ]; then
+  cp .env.example .env
+  sed -i "s|^ENCRYPTION_KEY=.*|ENCRYPTION_KEY=$(openssl rand -hex 32)|" .env
+  sed -i "s|^AUTH_SECRET=.*|AUTH_SECRET=$(openssl rand -hex 32)|" .env
+  sed -i "s|^DATABASE_URL=.*|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres|" .env
+  sed -i "s|^DIRECT_URL=.*|DIRECT_URL=postgresql://postgres:postgres@localhost:5432/postgres|" .env
+fi
+for app in web dashboard chat; do
+  ln -sfn ../../.env "apps/$app/.env"
+done
+
+echo "==> Applying any new database migrations"
+pnpm --filter @tael/database db:migrate || true
+
+echo "==> Start complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Adds a committed Cursor Cloud Agent environment so the repo becomes fully usable in Cloud Agents out of the box. Previously a fresh agent booted with nothing configured (no dependencies, no database). This provisions the whole local development experience — install, PostgreSQL, migrations, seed data, and the dev servers.

New files (all under `.cursor/`):
- `environment.json` — declares `install`, `start`, three dev-server `terminals` (`api`, `web`, `dashboard`), and exposes ports `3000/3001/3002`.
- `install.sh` — one-time, idempotent setup: `corepack` + `pnpm install --frozen-lockfile`, installs PostgreSQL 16, prepares a local `.env` (generated `ENCRYPTION_KEY`/`AUTH_SECRET`, local DB URLs), symlinks per-app `.env` for the Next.js apps (they don't read the repo-root `.env`), runs Drizzle migrations, and seeds two demo capabilities so the gateway + catalog have something to serve.
- `start.sh` — per-boot reconciliation: starts PostgreSQL (idempotent), ensures `.env`/links exist, and applies any new migrations.

No application code is changed.

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor / chore
- [x] Docs / tooling (developer environment)

## Validation

All CI quality gates pass locally on this environment:

| Check | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | Passed (and idempotent on re-run) |
| `pnpm format:check` | Passed |
| `pnpm lint` | Passed (warnings only) |
| `pnpm typecheck` | Passed (14 workspaces) |
| `pnpm test` | Passed (7 suites) |
| `pnpm build` | Passed (11 tasks) |

End-to-end product flow verified against the running stack:
- `GET /health` → `{"status":"ok","service":"tael-api"}`
- `GET /capabilities` → serves the seeded capabilities from PostgreSQL
- `POST /c/fx-rates` (no payment) → `HTTP 402 Payment Required` with a valid x402 challenge (price, `payTo`, USDC asset, network) — the core product interaction
- Web `/capabilities` page renders the seeded capabilities fetched live from the local API:

[Tael capabilities page served from the local API + Postgres](https://cursor.com/agents/bc-d972b658-89f3-452b-bd25-6b5dc36c91d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftael_capabilities_page_local_api.webp)

**Environment build validation:** a draft Cloud Agent environment build of this exact config succeeded — `.cursor/install.sh` ran cleanly in the build pipeline (dependencies installed, PostgreSQL started, migrations applied, seed idempotent, exit code 0).

**Fresh Cloud Agent validation:** a brand-new agent booted from that tested build passed all checks — `node v22.14.0` / `pnpm 11.5.2`, dependencies present, 12 tables + both seeded capabilities in Postgres, `.env` + per-app symlinks in place, API `/health` + `/capabilities` + the `402` x402 challenge all correct, and `pnpm test` 7/7 suites passing.

## Checklist

- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` pass locally
- [ ] Added/updated tests for the change (N/A — environment tooling only)
- [ ] Added a changeset (N/A — no published `@tael/*` package changed)
- [ ] Updated docs (N/A — no boundary/public API changes)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d972b658-89f3-452b-bd25-6b5dc36c91d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d972b658-89f3-452b-bd25-6b5dc36c91d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

