### PR TITLE
Added: Per-product Discord agent (/ask + action buttons)

### DIFF
--- a/apps/dashboard/app/api/widget/[publicKey]/discord/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/discord/route.ts
@@ -1,0 +1,130 @@
+import { after } from "next/server";
+import { getProductByPublicKey } from "../../../../../features/products/queries";
+import {
+  DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE,
+  DISCORD_CALLBACK_PONG,
+  DISCORD_INTERACTION_APPLICATION_COMMAND,
+  DISCORD_INTERACTION_MESSAGE_COMPONENT,
+  DISCORD_INTERACTION_PING,
+  getDiscordOptionString,
+  verifyDiscordRequest,
+  type DiscordInteraction,
+} from "../../../../../features/products/discord";
+import {
+  handleDiscordActionConfirm,
+  handleDiscordAsk,
+} from "../../../../../features/products/discord-chat";
+import { createRateLimiter } from "../../../../../features/products/widget-chat";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const allowRequest = createRateLimiter(30, 60_000);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export async function POST(request: Request, context: { params: Promise<{ publicKey: string }> }) {
+  const { publicKey: rawKey } = await context.params;
+  const publicKey = decodeURIComponent(rawKey ?? "").trim();
+  if (!publicKey) return new Response("Missing public key.", { status: 400 });
+
+  const product = await getProductByPublicKey(publicKey);
+  if (!product) return new Response("Agent not found.", { status: 404 });
+
+  const settings = (product.settings as Record<string, unknown>) ?? {};
+  const enabled = settings.discordBotEnabled !== false;
+  const discordPublicKey =
+    typeof settings.discordPublicKey === "string" ? settings.discordPublicKey : null;
+  const applicationId =
+    typeof settings.discordClientId === "string" ? settings.discordClientId : null;
+
+  if (!discordPublicKey || !enabled) {
+    return new Response("Discord bot is not configured or disabled for this agent.", {
+      status: 400,
+    });
+  }
+
+  const signature = request.headers.get("x-signature-ed25519");
+  const timestamp = request.headers.get("x-signature-timestamp");
+  const rawBody = await request.text();
+
+  if (
+    !signature ||
+    !timestamp ||
+    !verifyDiscordRequest(discordPublicKey, signature, timestamp, rawBody)
+  ) {
+    return new Response("Invalid request signature.", { status: 401 });
+  }
+
+  let interaction: DiscordInteraction;
+  try {
+    interaction = JSON.parse(rawBody) as DiscordInteraction;
+  } catch {
+    return new Response("Invalid payload.", { status: 400 });
+  }
+
+  if (interaction.type === DISCORD_INTERACTION_PING) {
+    return jsonResponse({ type: DISCORD_CALLBACK_PONG });
+  }
+
+  if (!applicationId) {
+    return jsonResponse({
+      type: 4,
+      data: { content: "Discord bot is missing its Application ID. Reconnect in Tael Studio." },
+    });
+  }
+
+  if (interaction.type === DISCORD_INTERACTION_MESSAGE_COMPONENT) {
+    const customId = interaction.data?.custom_id ?? "";
+    if (!customId.startsWith("run:")) {
+      return jsonResponse({
+        type: 4,
+        data: { content: "Unknown button.", flags: 64 },
+      });
+    }
+
+    const parts = customId.split(":");
+    const actionId = parts[1] ?? "";
+    const paramsStr = parts.slice(2).join(":");
+
+    after(() =>
+      handleDiscordActionConfirm(publicKey, applicationId, interaction.token, actionId, paramsStr),
+    );
+    return jsonResponse({ type: DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE });
+  }
+
+  if (interaction.type === DISCORD_INTERACTION_APPLICATION_COMMAND) {
+    if (interaction.data?.name !== "ask") {
+      return jsonResponse({
+        type: 4,
+        data: { content: "Unknown command.", flags: 64 },
+      });
+    }
+
+    const question = getDiscordOptionString(interaction, "question")?.trim() ?? "";
+    if (!question) {
+      return jsonResponse({
+        type: 4,
+        data: { content: "Please include a question.", flags: 64 },
+      });
+    }
+
+    const userId = interaction.member?.user?.id ?? interaction.user?.id ?? "anon";
+    if (!allowRequest(`${publicKey}:${userId}`)) {
+      return jsonResponse({
+        type: 4,
+        data: { content: "Too many requests. Please wait a minute.", flags: 64 },
+      });
+    }
+
+    after(() => handleDiscordAsk(product, applicationId, interaction.token, question));
+    return jsonResponse({ type: DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE });
+  }
+
+  return jsonResponse({ type: 4, data: { content: "Unsupported interaction.", flags: 64 } });
+}

--- a/apps/dashboard/features/products/actions.ts
+++ b/apps/dashboard/features/products/actions.ts
@@ -146,6 +146,125 @@ export async function disconnectTelegramBot(id: string): Promise<ActionResult> {
   return { ok: true };
 }
 
+const discordPublicKeySchema = z
+  .string()
+  .trim()
+  .regex(/^[0-9a-fA-F]{64}$/, "Application Public Key must be 64 hex characters.");
+
+const discordClientIdSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{17,20}$/, "Application ID / Client ID looks invalid.");
+
+/**
+ * Connect a Discord bot to this product agent.
+ * Unlike Telegram, Discord Interactions Endpoint URL must be pasted in the Developer Portal.
+ */
+export async function connectDiscordBot(
+  id: string,
+  botToken: string,
+  publicKey: string,
+  clientId: string,
+  baseUrl: string,
+): Promise<ActionResult & { botUsername?: string; interactionsUrl?: string; inviteUrl?: string }> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  const cleanToken = botToken.trim();
+  if (!cleanToken) return { ok: false, error: "Discord Bot Token is required." };
+
+  const parsedKey = discordPublicKeySchema.safeParse(publicKey);
+  if (!parsedKey.success) {
+    return { ok: false, error: parsedKey.error.issues[0]?.message ?? "Invalid public key." };
+  }
+
+  const parsedClientId = discordClientIdSchema.safeParse(clientId);
+  if (!parsedClientId.success) {
+    return { ok: false, error: parsedClientId.error.issues[0]?.message ?? "Invalid client id." };
+  }
+
+  const [product] = await db
+    .select()
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.ownerId, user.id)))
+    .limit(1);
+
+  if (!product) return { ok: false, error: "Agent not found." };
+
+  const { getDiscordBotInfo, registerDiscordAskCommand, buildDiscordInviteUrl } =
+    await import("./discord");
+
+  const info = await getDiscordBotInfo(cleanToken);
+  if (!info.ok || !info.username) {
+    return { ok: false, error: info.error ?? "Invalid Discord bot token." };
+  }
+
+  const applicationId = parsedClientId.data;
+  const cmdResult = await registerDiscordAskCommand(cleanToken, applicationId);
+  if (!cmdResult.ok) {
+    return { ok: false, error: cmdResult.error ?? "Could not register /ask command." };
+  }
+
+  const interactionsUrl = `${baseUrl.replace(/\/$/, "")}/api/widget/${encodeURIComponent(product.publicKey)}/discord`;
+  const inviteUrl = buildDiscordInviteUrl(applicationId);
+
+  const currentSettings = (product.settings as Record<string, unknown>) ?? {};
+  const updatedSettings = {
+    ...currentSettings,
+    discordBotToken: cleanToken,
+    discordPublicKey: parsedKey.data.toLowerCase(),
+    discordClientId: applicationId,
+    discordBotUsername: info.username,
+    discordBotUserId: info.id,
+    discordBotEnabled: true,
+  };
+
+  await db.update(products).set({ settings: updatedSettings }).where(eq(products.id, id));
+
+  revalidateStudioPaths();
+  return {
+    ok: true,
+    botUsername: info.username,
+    interactionsUrl,
+    inviteUrl,
+  };
+}
+
+/** Disconnect / Disable Discord Bot for this product agent. Ownership-checked. */
+export async function disconnectDiscordBot(id: string): Promise<ActionResult> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, error: "Not signed in." };
+
+  const [product] = await db
+    .select()
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.ownerId, user.id)))
+    .limit(1);
+
+  if (!product) return { ok: false, error: "Agent not found." };
+
+  const currentSettings = (product.settings as Record<string, unknown>) ?? {};
+  const token =
+    typeof currentSettings.discordBotToken === "string" ? currentSettings.discordBotToken : null;
+  const clientId =
+    typeof currentSettings.discordClientId === "string" ? currentSettings.discordClientId : null;
+
+  if (token && clientId) {
+    const { deleteDiscordAskCommand } = await import("./discord");
+    await deleteDiscordAskCommand(token, clientId);
+  }
+
+  const updatedSettings = {
+    ...currentSettings,
+    discordBotEnabled: false,
+  };
+
+  await db.update(products).set({ settings: updatedSettings }).where(eq(products.id, id));
+
+  revalidateStudioPaths();
+  return { ok: true };
+}
+
 /** Delete a product the signed-in user owns. Cascades content + actions. */
 export async function deleteProduct(id: string): Promise<ActionResult> {
   const user = await getCurrentUser();

--- a/apps/dashboard/features/products/deploy-panel.tsx
+++ b/apps/dashboard/features/products/deploy-panel.tsx
@@ -6,6 +6,7 @@ import { Check, Copy, Globe, MessageCircle, Radio, Server, Bot, Unplug } from "l
 import { Button, Input, cn } from "@tael/ui";
 import type { Product } from "@tael/database";
 import { connectTelegramBot, disconnectTelegramBot } from "./actions";
+import { DiscordConnectPanel } from "./discord-connect-panel";
 
 export function DeployPanel({ product }: { product: Product }) {
   const router = useRouter();
@@ -19,6 +20,7 @@ export function DeployPanel({ product }: { product: Product }) {
   const currentBotUsername =
     typeof settings.telegramBotUsername === "string" ? settings.telegramBotUsername : "";
   const isTelegramEnabled = settings.telegramBotEnabled === true;
+  const isDiscordEnabled = settings.discordBotEnabled === true;
 
   const [telegramToken, setTelegramToken] = useState("");
   const [telegramError, setTelegramError] = useState<string | null>(null);
@@ -98,9 +100,9 @@ export function DeployPanel({ product }: { product: Product }) {
     {
       id: "discord",
       label: "Discord",
-      description: "Answer in your Discord server.",
+      description: "Answer product questions with /ask in your server.",
       icon: MessageCircle,
-      status: "soon" as const,
+      status: isDiscordEnabled ? ("live" as const) : ("ready" as const),
     },
     {
       id: "mcp",
@@ -207,11 +209,18 @@ export function DeployPanel({ product }: { product: Product }) {
         ) : null}
       </section>
 
+      <DiscordConnectPanel
+        product={product}
+        baseUrl={base}
+        pending={pending}
+        startTransition={startTransition}
+      />
+
       <section className="space-y-4 rounded-xl border p-5">
         <div>
           <h2 className="text-base font-semibold">Channels</h2>
           <p className="text-sm text-muted-foreground">
-            Where this agent can show up. Website and Telegram are ready; more channels are on the
+            Where this agent can show up. Website, Telegram, and Discord are ready; MCP is on the
             way.
           </p>
         </div>

--- a/apps/dashboard/features/products/discord-chat.ts
+++ b/apps/dashboard/features/products/discord-chat.ts
@@ -1,0 +1,230 @@
+import type { Product } from "@tael/database";
+import { getProductActionsForChat, getProductContentForChat } from "./queries";
+import { editDiscordInteractionResponse } from "./discord";
+import { getEnabledActionForPublicKey, runProductAction } from "./run-product-action";
+import {
+  actionIdFromToolName,
+  buildWidgetSystemPrompt,
+  buildWidgetTools,
+  proposeWidgetAction,
+} from "./widget-chat";
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const MODEL = process.env.OPENROUTER_MODEL ?? "google/gemini-2.5-flash";
+const MAX_TOKENS = 700;
+const MAX_TOOL_HOPS = 3;
+
+interface ToolCall {
+  id: string;
+  function: { name: string; arguments: string };
+}
+
+interface ChatMessage {
+  role: string;
+  content: string | null;
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+interface OpenRouterResponse {
+  choices?: { message?: ChatMessage }[];
+}
+
+function safeParseArgs(raw: string | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const v: unknown = JSON.parse(raw);
+    return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function runActionButton(actionId: string, paramsStr: string): unknown[] {
+  return [
+    {
+      type: 1,
+      components: [
+        {
+          type: 2,
+          style: 1,
+          label: "Run action",
+          custom_id: `run:${actionId}:${paramsStr}`.slice(0, 100),
+        },
+      ],
+    },
+  ];
+}
+
+export async function handleDiscordActionConfirm(
+  publicKey: string,
+  applicationId: string,
+  interactionToken: string,
+  actionId: string,
+  paramsStr: string,
+): Promise<void> {
+  const check = await getEnabledActionForPublicKey(publicKey, actionId);
+  if (!check.ok) {
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      `Action failed: ${check.error}`,
+    );
+    return;
+  }
+
+  let parsedParams: Record<string, unknown> | string | undefined = paramsStr || undefined;
+  if (paramsStr) {
+    try {
+      parsedParams = JSON.parse(paramsStr) as Record<string, unknown>;
+    } catch {
+      parsedParams = { value: paramsStr };
+    }
+  }
+
+  const res = await runProductAction({
+    actionId: check.actionId,
+    params: parsedParams,
+  });
+
+  if (res.ok) {
+    const output = res.body ? `\n\`\`\`\n${res.body.slice(0, 1500)}\n\`\`\`` : "";
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      `Action executed successfully.${output}`,
+    );
+    return;
+  }
+
+  await editDiscordInteractionResponse(
+    applicationId,
+    interactionToken,
+    `Action failed: ${res.error ?? "Unknown error"}`,
+  );
+}
+
+export async function handleDiscordAsk(
+  product: Product,
+  applicationId: string,
+  interactionToken: string,
+  question: string,
+): Promise<void> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      "The agent is currently unavailable (missing model key).",
+    );
+    return;
+  }
+
+  const [content, actions] = await Promise.all([
+    getProductContentForChat(product.id),
+    getProductActionsForChat(product.id),
+  ]);
+
+  const system = buildWidgetSystemPrompt(product, content, actions);
+  const tools = buildWidgetTools(actions);
+  const actionsById = new Map(actions.map((a) => [a.id, a]));
+
+  const convo: ChatMessage[] = [
+    { role: "system", content: system },
+    { role: "user", content: question.slice(0, 4000) },
+  ];
+
+  try {
+    for (let hop = 0; hop < MAX_TOOL_HOPS; hop += 1) {
+      const resp = await fetch(OPENROUTER_URL, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+          "HTTP-Referer": "https://taelprotocol.xyz",
+          "X-Title": "Tael Discord Agent",
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          messages: convo,
+          ...(tools.length > 0 ? { tools, tool_choice: "auto" } : {}),
+          max_tokens: MAX_TOKENS,
+          temperature: 0.3,
+        }),
+      });
+
+      if (!resp.ok) {
+        await editDiscordInteractionResponse(
+          applicationId,
+          interactionToken,
+          "The agent is currently unavailable. Please try again later.",
+        );
+        return;
+      }
+
+      const data = (await resp.json()) as OpenRouterResponse;
+      const message = data.choices?.[0]?.message;
+      if (!message) {
+        await editDiscordInteractionResponse(
+          applicationId,
+          interactionToken,
+          "No response received from the agent.",
+        );
+        return;
+      }
+
+      if (message.tool_calls?.length) {
+        for (const call of message.tool_calls) {
+          const actionId = actionIdFromToolName(call.function.name);
+          if (!actionId) continue;
+          const action = actionsById.get(actionId);
+          if (!action) continue;
+
+          const args = safeParseArgs(call.function.arguments);
+          const proposed = proposeWidgetAction(action, args);
+          const paramsStr = args.params != null ? String(args.params) : "";
+
+          await editDiscordInteractionResponse(
+            applicationId,
+            interactionToken,
+            proposed.reply,
+            runActionButton(action.id, paramsStr),
+          );
+          return;
+        }
+
+        convo.push(message);
+        for (const call of message.tool_calls) {
+          convo.push({
+            role: "tool",
+            tool_call_id: call.id,
+            name: call.function.name,
+            content: JSON.stringify({ error: "unknown action" }),
+          });
+        }
+        continue;
+      }
+
+      const text = typeof message.content === "string" ? message.content.trim() : "";
+      await editDiscordInteractionResponse(
+        applicationId,
+        interactionToken,
+        text || "I could not find an answer for that.",
+      );
+      return;
+    }
+
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      "I couldn't quite complete that request. Could you rephrase?",
+    );
+  } catch {
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      "An error occurred while processing your request.",
+    );
+  }
+}

--- a/apps/dashboard/features/products/discord-connect-panel.tsx
+++ b/apps/dashboard/features/products/discord-connect-panel.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Check, Copy, ExternalLink, MessageCircle, Unplug } from "lucide-react";
+import { Button, Input } from "@tael/ui";
+import type { Product } from "@tael/database";
+import { connectDiscordBot, disconnectDiscordBot } from "./actions";
+
+interface DiscordConnectPanelProps {
+  product: Product;
+  baseUrl: string;
+  pending: boolean;
+  startTransition: ReturnType<typeof useTransition>[1];
+}
+
+export function DiscordConnectPanel({
+  product,
+  baseUrl,
+  pending,
+  startTransition,
+}: DiscordConnectPanelProps) {
+  const router = useRouter();
+  const settings = (product.settings as Record<string, unknown>) ?? {};
+  const discordBotUsername =
+    typeof settings.discordBotUsername === "string" ? settings.discordBotUsername : "";
+  const isDiscordEnabled = settings.discordBotEnabled === true;
+  const discordClientId =
+    typeof settings.discordClientId === "string" ? settings.discordClientId : "";
+
+  const [discordToken, setDiscordToken] = useState("");
+  const [discordPublicKey, setDiscordPublicKey] = useState("");
+  const [discordAppId, setDiscordAppId] = useState("");
+  const [discordError, setDiscordError] = useState<string | null>(null);
+  const [discordSuccess, setDiscordSuccess] = useState<string | null>(null);
+  const [discordInviteUrl, setDiscordInviteUrl] = useState<string | null>(null);
+  const [copiedInteractions, setCopiedInteractions] = useState(false);
+
+  const interactionsUrl = baseUrl
+    ? `${baseUrl}/api/widget/${encodeURIComponent(product.publicKey)}/discord`
+    : "";
+
+  const inviteUrl = discordClientId
+    ? `https://discord.com/oauth2/authorize?client_id=${discordClientId}&scope=bot%20applications.commands&permissions=2147485696`
+    : discordInviteUrl;
+
+  async function copyInteractionsUrl() {
+    if (!interactionsUrl) return;
+    try {
+      await navigator.clipboard.writeText(interactionsUrl);
+      setCopiedInteractions(true);
+      setTimeout(() => setCopiedInteractions(false), 1500);
+    } catch {
+      // no-op
+    }
+  }
+
+  function handleConnectDiscord() {
+    setDiscordError(null);
+    setDiscordSuccess(null);
+    startTransition(async () => {
+      const res = await connectDiscordBot(
+        product.id,
+        discordToken,
+        discordPublicKey,
+        discordAppId,
+        baseUrl || window.location.origin,
+      );
+      if (res.ok) {
+        setDiscordSuccess(
+          `Connected as ${res.botUsername ?? "bot"}. Paste the Interactions URL in Discord.`,
+        );
+        setDiscordInviteUrl(res.inviteUrl ?? null);
+        setDiscordToken("");
+        router.refresh();
+      } else {
+        setDiscordError(res.error ?? "Could not connect Discord Bot.");
+      }
+    });
+  }
+
+  function handleDisconnectDiscord() {
+    setDiscordError(null);
+    setDiscordSuccess(null);
+    startTransition(async () => {
+      const res = await disconnectDiscordBot(product.id);
+      if (res.ok) {
+        setDiscordSuccess("Discord bot disconnected.");
+        setDiscordToken("");
+        setDiscordPublicKey("");
+        setDiscordAppId("");
+        setDiscordInviteUrl(null);
+        router.refresh();
+      } else {
+        setDiscordError(res.error ?? "Could not disconnect Discord Bot.");
+      }
+    });
+  }
+
+  return (
+    <section className="space-y-4 rounded-xl border p-5">
+      <div>
+        <h2 className="text-base font-semibold">Discord Bot Integration</h2>
+        <p className="text-sm text-muted-foreground">
+          Connect your Discord application so anyone in the server can run{" "}
+          <span className="font-mono text-xs">/ask</span> and get answers from this product agent.
+          Action confirmations show as buttons, same as Telegram.
+        </p>
+      </div>
+
+      {isDiscordEnabled && discordBotUsername ? (
+        <div className="space-y-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2.5">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600">
+                <MessageCircle className="h-4 w-4" />
+              </span>
+              <div>
+                <p className="text-sm font-medium">Connected as {discordBotUsername}</p>
+                <p className="text-xs text-muted-foreground">
+                  /ask registered. Finish setup by pasting the Interactions URL in Discord.
+                </p>
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleDisconnectDiscord}
+              disabled={pending}
+            >
+              <Unplug className="h-4 w-4 mr-1" /> Disconnect
+            </Button>
+          </div>
+
+          <div className="space-y-2 rounded-lg border bg-background/60 p-3">
+            <p className="text-xs font-medium">1. Interactions Endpoint URL</p>
+            <p className="text-xs text-muted-foreground">
+              Discord Developer Portal → your app → General Information → Interactions Endpoint URL.
+              Paste this, then Save Changes (Discord will ping to verify).
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <code className="max-w-full truncate rounded bg-muted px-2 py-1 font-mono text-[11px]">
+                {interactionsUrl}
+              </code>
+              <Button type="button" variant="outline" size="sm" onClick={copyInteractionsUrl}>
+                {copiedInteractions ? (
+                  <Check className="h-4 w-4 text-emerald-600" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+                {copiedInteractions ? "Copied" : "Copy URL"}
+              </Button>
+            </div>
+          </div>
+
+          {inviteUrl ? (
+            <div className="space-y-2 rounded-lg border bg-background/60 p-3">
+              <p className="text-xs font-medium">2. Invite the bot to your server</p>
+              <a
+                href={inviteUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm text-foreground underline-offset-4 hover:underline"
+              >
+                Open invite link <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            Create an application at{" "}
+            <a
+              href="https://discord.com/developers/applications"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2"
+            >
+              discord.com/developers/applications
+            </a>
+            . Copy Application ID, Public Key (General Information), and Bot Token (Bot tab).
+          </p>
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium">Bot Token</span>
+            <Input
+              type="password"
+              placeholder="Discord bot token"
+              value={discordToken}
+              onChange={(e) => setDiscordToken(e.target.value)}
+            />
+          </label>
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium">Application Public Key</span>
+            <Input
+              type="text"
+              placeholder="64-character hex public key"
+              value={discordPublicKey}
+              onChange={(e) => setDiscordPublicKey(e.target.value)}
+            />
+          </label>
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium">Application ID (Client ID)</span>
+            <Input
+              type="text"
+              placeholder="Discord application / client id"
+              value={discordAppId}
+              onChange={(e) => setDiscordAppId(e.target.value)}
+            />
+          </label>
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleConnectDiscord}
+              disabled={
+                pending || !discordToken.trim() || !discordPublicKey.trim() || !discordAppId.trim()
+              }
+            >
+              {pending ? "Connecting…" : "Connect & Deploy Bot"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {discordError ? <p className="text-sm text-destructive">{discordError}</p> : null}
+      {discordSuccess ? (
+        <p className="text-sm text-emerald-600 flex items-center gap-1">
+          <Check className="h-4 w-4" /> {discordSuccess}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/dashboard/features/products/discord.ts
+++ b/apps/dashboard/features/products/discord.ts
@@ -1,0 +1,215 @@
+/**
+ * Discord Bot API helpers for per-product agents.
+ * Uses fetch + Node crypto (no discord.js) so the dashboard stays serverless-friendly.
+ */
+
+import { createPublicKey, verify as cryptoVerify } from "node:crypto";
+
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+
+export const DISCORD_INTERACTION_PING = 1;
+export const DISCORD_INTERACTION_APPLICATION_COMMAND = 2;
+export const DISCORD_INTERACTION_MESSAGE_COMPONENT = 3;
+
+export const DISCORD_CALLBACK_PONG = 1;
+export const DISCORD_CALLBACK_CHANNEL_MESSAGE = 4;
+export const DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE = 5;
+export const DISCORD_CALLBACK_UPDATE_MESSAGE = 7;
+
+export interface DiscordBotUser {
+  id: string;
+  username: string;
+  bot?: boolean;
+}
+
+export interface DiscordInteractionOption {
+  name: string;
+  type: number;
+  value?: string | number | boolean;
+}
+
+export interface DiscordInteractionData {
+  id?: string;
+  name?: string;
+  custom_id?: string;
+  options?: DiscordInteractionOption[];
+}
+
+export interface DiscordInteraction {
+  id: string;
+  type: number;
+  token: string;
+  application_id?: string;
+  guild_id?: string;
+  channel_id?: string;
+  data?: DiscordInteractionData;
+  member?: { user?: { id: string; username?: string; bot?: boolean } };
+  user?: { id: string; username?: string; bot?: boolean };
+}
+
+/** Verify Discord Ed25519 request signature (Interactions Endpoint security). */
+export function verifyDiscordRequest(
+  publicKeyHex: string,
+  signatureHex: string,
+  timestamp: string,
+  rawBody: string,
+): boolean {
+  try {
+    const key = createPublicKey({
+      key: Buffer.concat([
+        Buffer.from("302a300506032b6570032100", "hex"),
+        Buffer.from(publicKeyHex, "hex"),
+      ]),
+      format: "der",
+      type: "spki",
+    });
+    return cryptoVerify(
+      null,
+      Buffer.from(timestamp + rawBody),
+      key,
+      Buffer.from(signatureHex, "hex"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Validate bot token and return the bot user. */
+export async function getDiscordBotInfo(
+  token: string,
+): Promise<{ ok: boolean; id?: string; username?: string; error?: string }> {
+  try {
+    const res = await fetch(`${DISCORD_API_BASE}/users/@me`, {
+      method: "GET",
+      headers: {
+        authorization: `Bot ${token}`,
+        "content-type": "application/json",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    const data = (await res.json().catch(() => null)) as
+      (DiscordBotUser & { message?: string }) | null;
+    if (!res.ok || !data?.id || !data.username) {
+      return {
+        ok: false,
+        error: data?.message ?? "Invalid Discord bot token.",
+      };
+    }
+    if (data.bot === false) {
+      return { ok: false, error: "Token must belong to a Discord bot application." };
+    }
+    return { ok: true, id: data.id, username: data.username };
+  } catch {
+    return { ok: false, error: "Could not reach Discord API." };
+  }
+}
+
+/** Register the product /ask slash command on this application. */
+export async function registerDiscordAskCommand(
+  token: string,
+  applicationId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch(`${DISCORD_API_BASE}/applications/${applicationId}/commands`, {
+      method: "POST",
+      headers: {
+        authorization: `Bot ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        name: "ask",
+        description: "Ask this product agent a question",
+        options: [
+          {
+            name: "question",
+            description: "What do you want to know?",
+            type: 3,
+            required: true,
+          },
+        ],
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const data = (await res.json().catch(() => null)) as { message?: string; code?: number } | null;
+    if (!res.ok) {
+      return { ok: false, error: data?.message ?? "Failed to register /ask command." };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not register Discord slash commands." };
+  }
+}
+
+/** Best-effort cleanup of the /ask command on disconnect. */
+export async function deleteDiscordAskCommand(token: string, applicationId: string): Promise<void> {
+  try {
+    const listRes = await fetch(`${DISCORD_API_BASE}/applications/${applicationId}/commands`, {
+      method: "GET",
+      headers: {
+        authorization: `Bot ${token}`,
+        "content-type": "application/json",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!listRes.ok) return;
+    const commands = (await listRes.json().catch(() => [])) as { id: string; name: string }[];
+    const ask = commands.find((c) => c.name === "ask");
+    if (!ask) return;
+    await fetch(`${DISCORD_API_BASE}/applications/${applicationId}/commands/${ask.id}`, {
+      method: "DELETE",
+      headers: { authorization: `Bot ${token}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+/** Follow up on a deferred interaction with the final reply. */
+export async function editDiscordInteractionResponse(
+  applicationId: string,
+  interactionToken: string,
+  content: string,
+  components?: unknown[],
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const body: Record<string, unknown> = { content: content.slice(0, 2000) };
+    if (components) body.components = components;
+
+    const res = await fetch(
+      `${DISCORD_API_BASE}/webhooks/${applicationId}/${interactionToken}/messages/@original`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!res.ok) {
+      const data = (await res.json().catch(() => null)) as { message?: string } | null;
+      return { ok: false, error: data?.message ?? "Failed to update Discord reply." };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Could not send Discord reply." };
+  }
+}
+
+/** Build the OAuth invite URL for a product bot. */
+export function buildDiscordInviteUrl(clientId: string): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    scope: "bot applications.commands",
+    permissions: "2147485696", // Send Messages + Use Application Commands
+  });
+  return `https://discord.com/oauth2/authorize?${params.toString()}`;
+}
+
+/** Extract a slash-command string option by name. */
+export function getDiscordOptionString(
+  interaction: DiscordInteraction,
+  name: string,
+): string | null {
+  const opt = interaction.data?.options?.find((o) => o.name === name);
+  return typeof opt?.value === "string" ? opt.value : null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Per-product Discord channel for Tael Studio agents, mirroring the Telegram connect → webhook → chat flow.

### What shipped
- **Connect/disconnect** in Deploy: Bot Token + Application Public Key + Application ID
- **Interactions endpoint** at `/api/widget/[publicKey]/discord` (Discord Ed25519 verify + PING/PONG)
- **`/ask question:`** slash command — answers from the product’s trained knowledge (same OpenRouter + widget prompt path as Telegram)
- **Action confirm buttons** when the agent proposes a product action
- Channel list marks Discord as Live / Ready to connect (no longer “Coming soon”)

### How to go live (per product)
1. Create a Discord application + bot
2. Paste Bot Token, Public Key, Application ID in Deploy → Connect
3. Copy the Interactions Endpoint URL into Discord Developer Portal → General Information → Save (Discord pings to verify)
4. Invite the bot with the generated invite link
5. In the server: `/ask question:…`

### Note on @mentions
Discord HTTP interactions cannot receive message mentions (unlike Telegram webhooks). Mentions need a Gateway worker — follow-up work. v1 uses `/ask`, which fits Vercel/serverless the same way Telegram does.

### Not in this PR
- @mention replies (Gateway worker)
- Marketplace `apps/discord-bot` changes (separate product)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

