### PR TITLE
Added: Gemini direct LLM (OpenRouter fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,14 @@ NEXT_PUBLIC_USDC_ISSUER=GBCDXWBEN7YMCBI3DPIWQ5QBGG2NE7G5REZLNJI2E57VVNVDQM7PF7RA
 # Tael-team wallet addresses (comma-separated) allowed to grant the Verified
 # badge on capabilities. Server-only. Empty = no one can verify.
 ADMIN_WALLET_ADDRESSES=
+# Gemini direct (preferred) for Studio agents: widget, Telegram, Discord, copilot.
+# Get a key from https://aistudio.google.com/apikey
+GEMINI_API_KEY=
+# Optional. Default: gemini-2.5-flash
+GEMINI_MODEL=
+# Optional fallback if GEMINI_API_KEY is unset.
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL=
 
 # --- Chat (apps/chat) ---
 NEXT_PUBLIC_CHAT_URL=http://localhost:3003

--- a/apps/dashboard/app/api/agent/route.ts
+++ b/apps/dashboard/app/api/agent/route.ts
@@ -8,20 +8,19 @@ import {
 } from "../../../features/capabilities/queries";
 import { getPaymentsData } from "../../../features/payments/queries";
 import { getWalletOverview } from "../../../features/wallet/queries";
+import { createLlmChatCompletion, getLlmConfig } from "../../../lib/llm";
 
 // The dashboard's Tael copilot. It runs a tool loop over the same server queries
 // the pages use (scoped to the signed-in user's session), so it answers with the
 // account's real, live data. It can also PROPOSE running a capability — that
 // never runs on its own; it returns a confirmation the user approves before a
-// card pays. Talks to OpenRouter (default Gemini 2.5 Flash, swappable). Node
-// runtime: reads a server-only key and touches server-only queries.
+// card pays. Talks to Gemini direct (with OpenRouter fallback). Node runtime:
+// reads a server-only key and touches server-only queries.
 export const runtime = "nodejs";
 // The tool loop makes several model calls; give it room so multi-step asks
 // (e.g. "run the TrustLine capability") don't hit the default function timeout.
 export const maxDuration = 60;
 
-const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
-const MODEL = process.env.OPENROUTER_MODEL ?? "google/gemini-2.5-flash";
 const MAX_TOKENS = 700;
 // Cap the tool loop so a confused model can never spin forever.
 const MAX_TOOL_HOPS = 5;
@@ -395,9 +394,8 @@ interface AgentRequestBody {
 }
 
 export async function POST(request: Request) {
-  const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey)
-    return jsonError("The agent isn't configured yet (missing OPENROUTER_API_KEY).", 503);
+  const llm = getLlmConfig();
+  if (!llm) return jsonError("The agent isn't configured yet (missing GEMINI_API_KEY).", 503);
 
   const body = (await request.json().catch(() => null)) as AgentRequestBody | null;
   const messages = body?.messages;
@@ -431,26 +429,16 @@ export async function POST(request: Request) {
   for (let hop = 0; hop < MAX_TOOL_HOPS; hop += 1) {
     let data: OpenRouterResponse;
     try {
-      const resp = await fetch(OPENROUTER_URL, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${apiKey}`,
-          "content-type": "application/json",
-          "HTTP-Referer": "https://taelprotocol.xyz",
-          "X-Title": "Tael Agent",
-        },
-        body: JSON.stringify({
-          model: MODEL,
-          messages: convo,
-          tools: TOOLS,
-          tool_choice: "auto",
-          max_tokens: MAX_TOKENS,
-          temperature: 0.3,
-        }),
+      const resp = await createLlmChatCompletion(llm, {
+        messages: convo,
+        tools: TOOLS,
+        maxTokens: MAX_TOKENS,
+        title: "Tael Agent",
       });
       if (!resp.ok) {
         console.error(
-          "[copilot] openrouter error:",
+          "[copilot] llm error:",
+          llm.provider,
           resp.status,
           await resp.text().catch(() => ""),
         );
@@ -458,7 +446,7 @@ export async function POST(request: Request) {
       }
       data = (await resp.json()) as OpenRouterResponse;
     } catch (error) {
-      console.error("[copilot] openrouter request failed:", error);
+      console.error("[copilot] llm request failed:", error);
       return reply("Sorry, something went wrong on my end. Please try again.");
     }
 

--- a/apps/dashboard/app/api/widget/[publicKey]/chat/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/chat/route.ts
@@ -11,16 +11,15 @@ import {
   proposeWidgetAction,
   type ProposedWidgetAction,
 } from "../../../../../features/products/widget-chat";
+import { createLlmChatCompletion, getLlmConfig } from "../../../../../lib/llm";
 
 // Public per-product widget chat. Answers from that product's enabled content
 // and can PROPOSE enabled actions (confirm-gated; never runs them here).
 // No auth: the publicKey is the Stripe-style publishable key. Node runtime for
-// the OpenRouter key; room for a short tool loop.
+// the Gemini/OpenRouter key; room for a short tool loop.
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
-const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
-const MODEL = process.env.OPENROUTER_MODEL ?? "google/gemini-2.5-flash";
 const MAX_TOKENS = 700;
 const MAX_MESSAGES = 20;
 const MAX_TOOL_HOPS = 3;
@@ -106,8 +105,8 @@ export async function POST(request: Request, context: { params: Promise<{ public
     return json({ error: "Too many requests. Try again in a minute." }, 429);
   }
 
-  const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) {
+  const llm = getLlmConfig();
+  if (!llm) {
     return json({ error: "The agent is not configured yet." }, 503);
   }
 
@@ -150,21 +149,11 @@ export async function POST(request: Request, context: { params: Promise<{ public
 
   try {
     for (let hop = 0; hop < MAX_TOOL_HOPS; hop += 1) {
-      const resp = await fetch(OPENROUTER_URL, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${apiKey}`,
-          "content-type": "application/json",
-          "HTTP-Referer": "https://taelprotocol.xyz",
-          "X-Title": "Tael Widget Agent",
-        },
-        body: JSON.stringify({
-          model: MODEL,
-          messages: convo,
-          ...(tools.length > 0 ? { tools, tool_choice: "auto" } : {}),
-          max_tokens: MAX_TOKENS,
-          temperature: 0.3,
-        }),
+      const resp = await createLlmChatCompletion(llm, {
+        messages: convo,
+        tools: tools.length > 0 ? tools : undefined,
+        maxTokens: MAX_TOKENS,
+        title: "Tael Widget Agent",
       });
 
       if (!resp.ok) {

--- a/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
@@ -20,12 +20,11 @@ import {
   createRateLimiter,
   proposeWidgetAction,
 } from "../../../../../features/products/widget-chat";
+import { createLlmChatCompletion, getLlmConfig } from "../../../../../lib/llm";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
-const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
-const MODEL = process.env.OPENROUTER_MODEL ?? "google/gemini-2.5-flash";
 const MAX_TOKENS = 700;
 const MAX_TOOL_HOPS = 3;
 
@@ -102,9 +101,9 @@ export async function POST(request: Request, context: { params: Promise<{ public
     }
   }
 
-  const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) {
-    return new Response("OpenRouter key not configured.", { status: 503 });
+  const llm = getLlmConfig();
+  if (!llm) {
+    return new Response("Model key not configured.", { status: 503 });
   }
 
   const update = (await request.json().catch(() => null)) as TelegramUpdate | null;
@@ -208,21 +207,11 @@ export async function POST(request: Request, context: { params: Promise<{ public
 
   try {
     for (let hop = 0; hop < MAX_TOOL_HOPS; hop += 1) {
-      const resp = await fetch(OPENROUTER_URL, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${apiKey}`,
-          "content-type": "application/json",
-          "HTTP-Referer": "https://taelprotocol.xyz",
-          "X-Title": "Tael Telegram Agent",
-        },
-        body: JSON.stringify({
-          model: MODEL,
-          messages: convo,
-          ...(tools.length > 0 ? { tools, tool_choice: "auto" } : {}),
-          max_tokens: MAX_TOKENS,
-          temperature: 0.3,
-        }),
+      const resp = await createLlmChatCompletion(llm, {
+        messages: convo,
+        tools: tools.length > 0 ? tools : undefined,
+        maxTokens: MAX_TOKENS,
+        title: "Tael Telegram Agent",
       });
 
       if (!resp.ok) {

--- a/apps/dashboard/features/products/discord-chat.ts
+++ b/apps/dashboard/features/products/discord-chat.ts
@@ -1,4 +1,5 @@
 import type { Product } from "@tael/database";
+import { createLlmChatCompletion, getLlmConfig } from "../../lib/llm";
 import { getProductActionsForChat, getProductContentForChat } from "./queries";
 import { editDiscordInteractionResponse } from "./discord";
 import { getEnabledActionForPublicKey, runProductAction } from "./run-product-action";
@@ -9,8 +10,6 @@ import {
   proposeWidgetAction,
 } from "./widget-chat";
 
-const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
-const MODEL = process.env.OPENROUTER_MODEL ?? "google/gemini-2.5-flash";
 const MAX_TOKENS = 700;
 const MAX_TOOL_HOPS = 3;
 
@@ -111,8 +110,8 @@ export async function handleDiscordAsk(
   interactionToken: string,
   question: string,
 ): Promise<void> {
-  const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) {
+  const llm = getLlmConfig();
+  if (!llm) {
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
@@ -137,21 +136,11 @@ export async function handleDiscordAsk(
 
   try {
     for (let hop = 0; hop < MAX_TOOL_HOPS; hop += 1) {
-      const resp = await fetch(OPENROUTER_URL, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${apiKey}`,
-          "content-type": "application/json",
-          "HTTP-Referer": "https://taelprotocol.xyz",
-          "X-Title": "Tael Discord Agent",
-        },
-        body: JSON.stringify({
-          model: MODEL,
-          messages: convo,
-          ...(tools.length > 0 ? { tools, tool_choice: "auto" } : {}),
-          max_tokens: MAX_TOKENS,
-          temperature: 0.3,
-        }),
+      const resp = await createLlmChatCompletion(llm, {
+        messages: convo,
+        tools: tools.length > 0 ? tools : undefined,
+        maxTokens: MAX_TOKENS,
+        title: "Tael Discord Agent",
       });
 
       if (!resp.ok) {

--- a/apps/dashboard/lib/llm.ts
+++ b/apps/dashboard/lib/llm.ts
@@ -1,0 +1,85 @@
+/**
+ * Chat LLM provider for dashboard agents (widget, Telegram, Discord, copilot).
+ * Prefers Google Gemini direct (OpenAI-compatible endpoint). Falls back to OpenRouter.
+ */
+
+const GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+export type LlmProvider = "gemini" | "openrouter";
+
+export interface LlmConfig {
+  provider: LlmProvider;
+  apiKey: string;
+  model: string;
+  url: string;
+}
+
+/** Resolve Gemini-first, then OpenRouter. Returns null if neither key is set. */
+export function getLlmConfig(): LlmConfig | null {
+  const geminiKey = process.env.GEMINI_API_KEY?.trim();
+  if (geminiKey) {
+    return {
+      provider: "gemini",
+      apiKey: geminiKey,
+      model: process.env.GEMINI_MODEL?.trim() || "gemini-2.5-flash",
+      url: GEMINI_URL,
+    };
+  }
+
+  const openRouterKey = process.env.OPENROUTER_API_KEY?.trim();
+  if (openRouterKey) {
+    return {
+      provider: "openrouter",
+      apiKey: openRouterKey,
+      model: process.env.OPENROUTER_MODEL?.trim() || "google/gemini-2.5-flash",
+      url: OPENROUTER_URL,
+    };
+  }
+
+  return null;
+}
+
+export interface LlmChatRequest {
+  messages: unknown[];
+  tools?: unknown[];
+  toolChoice?: "auto" | "none";
+  maxTokens?: number;
+  temperature?: number;
+  /** Shown on OpenRouter only; ignored by Gemini. */
+  title?: string;
+}
+
+/** POST a chat completion to the configured provider. */
+export async function createLlmChatCompletion(
+  config: LlmConfig,
+  request: LlmChatRequest,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${config.apiKey}`,
+    "content-type": "application/json",
+  };
+
+  if (config.provider === "openrouter") {
+    headers["HTTP-Referer"] = "https://taelprotocol.xyz";
+    headers["X-Title"] = request.title ?? "Tael Agent";
+  }
+
+  const body: Record<string, unknown> = {
+    model: config.model,
+    messages: request.messages,
+    max_tokens: request.maxTokens ?? 700,
+    temperature: request.temperature ?? 0.3,
+  };
+
+  if (request.tools && request.tools.length > 0) {
+    body.tools = request.tools;
+    body.tool_choice = request.toolChoice ?? "auto";
+  }
+
+  return fetch(config.url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,8 @@
   "globalDependencies": ["**/.env", "tsconfig.json"],
   "globalEnv": [
     "NODE_ENV",
+    "GEMINI_API_KEY",
+    "GEMINI_MODEL",
     "OPENROUTER_API_KEY",
     "OPENROUTER_MODEL",
     "RESEND_API_KEY",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dashboard agents (website widget, Telegram, Discord, Studio copilot) now call **Google Gemini directly** via Google’s OpenAI-compatible endpoint, with **OpenRouter as fallback** if `GEMINI_API_KEY` is unset.

## Changes
- New shared helper: `apps/dashboard/lib/llm.ts`
- Wired: widget chat, Telegram, Discord chat, dashboard `/api/agent`
- Env docs: `GEMINI_API_KEY` / `GEMINI_MODEL` in `.env.example` + `turbo.json`

## Deploy steps (mainnet dashboard)
1. Add `GEMINI_API_KEY` from https://aistudio.google.com/apikey
2. Optional: `GEMINI_MODEL=gemini-2.5-flash` (default)
3. Redeploy; Telegram/Discord/widget use Gemini first
4. `OPENROUTER_API_KEY` can stay as backup or be removed later

## Test plan
- [ ] Set `GEMINI_API_KEY` on dashboard
- [ ] Widget chat replies
- [ ] Telegram bot replies
- [ ] Discord `/ask` replies
- [ ] Without Gemini key, OpenRouter still works if set
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

