### PR TITLE
Fixed: Stop repeating greeting on every agent reply

### DIFF
--- a/apps/dashboard/features/products/widget-chat.ts
+++ b/apps/dashboard/features/products/widget-chat.ts
@@ -161,8 +161,9 @@ export function buildWidgetSystemPrompt(
     `You are the on-site assistant for ${product.name}.`,
     description ? `About this product: ${description}` : null,
     greeting
-      ? `When starting a conversation, you may greet users in this spirit: "${greeting}"`
+      ? `Opening greeting (use ONLY on the very first reply in a new conversation, or when the user says /start). Do not repeat it on later messages. Spirit: "${greeting}"`
       : null,
+    "Never start a reply with a canned greeting like \"How can I help you?\" unless this is the first message and that phrase is the configured opening greeting.",
     "",
     "Answer using only the product knowledge below. If the answer is not in that knowledge, say you do not know based on the information you have. Do not invent facts, prices, or policies. Keep replies concise and helpful.",
     "",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Gemini was repeating the Studio **Greeting** on every Telegram/widget/Discord reply (e.g. “How can I help you?”).

Tightened `buildWidgetSystemPrompt` so the greeting is only for the first reply / `/start`, and later answers must not open with a canned greeting.

## Type of change

- [x] Fix

## Checklist

- [x] Prompt-only change in `widget-chat.ts` (shared by widget, Telegram, Discord)
- [ ] After merge: redeploy dashboard and retest Telegram
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

