### PR TITLE
Added: Telegram wallet connect for paid product actions

### DIFF
--- a/apps/dashboard/app/api/connect/telegram/complete/route.ts
+++ b/apps/dashboard/app/api/connect/telegram/complete/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getCurrentUser } from "../../../../../features/capabilities/current-user";
+import { upsertTelegramChannelLink } from "../../../../../features/products/channel-links";
+import { verifyTelegramConnectToken } from "../../../../../lib/connect-token";
+
+export const runtime = "nodejs";
+
+const bodySchema = z.object({
+  token: z.string().min(1),
+  agentId: z.string().uuid(),
+});
+
+/** Complete Telegram wallet connect: bind telegram user → signed-in user + Card. */
+export async function POST(request: Request) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const raw = (await request.json().catch(() => null)) as unknown;
+  const parsed = bodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request." }, { status: 400 });
+  }
+
+  let connect;
+  try {
+    connect = await verifyTelegramConnectToken(parsed.data.token);
+  } catch {
+    return NextResponse.json(
+      { error: "This connect link expired. Send /connect in Telegram again." },
+      { status: 400 },
+    );
+  }
+
+  const result = await upsertTelegramChannelLink({
+    productId: connect.productId,
+    telegramUserId: connect.externalUserId,
+    userId: user.id,
+    agentId: parsed.data.agentId,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    productName: connect.productName,
+    walletAddress: user.walletAddress,
+  });
+}

--- a/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
@@ -3,13 +3,9 @@ import {
   getProductByPublicKey,
   getProductContentForChat,
 } from "../../../../../features/products/queries";
+import { handleTelegramActionCallback } from "../../../../../features/products/telegram-action-callback";
+import { handleTelegramWalletCommands } from "../../../../../features/products/telegram-wallet-commands";
 import {
-  getEnabledActionForPublicKey,
-  runProductAction,
-} from "../../../../../features/products/run-product-action";
-import {
-  answerTelegramCallbackQuery,
-  editTelegramMessageText,
   sendTelegramMessage,
   type TelegramUpdate,
 } from "../../../../../features/products/telegram";
@@ -59,18 +55,12 @@ function safeParseArgs(raw: string | undefined): Record<string, unknown> {
 
 /** Formats a compact callback_data string under Telegram's strict 64-byte limit. */
 function buildCallbackData(actionId: string, paramsStr: string): string {
-  const hex = actionId.replace(/-/g, ""); // 32 chars
-  const prefix = `a:${hex}`; // 34 chars
+  const hex = actionId.replace(/-/g, "");
+  const prefix = `a:${hex}`;
   if (!paramsStr) return prefix;
-  const maxParamsLen = 63 - prefix.length - 1; // 28 chars max
+  const maxParamsLen = 63 - prefix.length - 1;
   const safeParams = paramsStr.slice(0, Math.max(0, maxParamsLen));
   return `${prefix}:${safeParams}`;
-}
-
-/** Reconstructs UUID from 32-hex actionId in callback_data. */
-function parseCallbackActionId(rawHex: string): string {
-  if (rawHex.length !== 32) return rawHex;
-  return `${rawHex.slice(0, 8)}-${rawHex.slice(8, 12)}-${rawHex.slice(12, 16)}-${rawHex.slice(16, 20)}-${rawHex.slice(20)}`;
 }
 
 export async function POST(request: Request, context: { params: Promise<{ publicKey: string }> }) {
@@ -93,7 +83,6 @@ export async function POST(request: Request, context: { params: Promise<{ public
     });
   }
 
-  // Webhook security: verify secret_token if configured
   if (secretToken) {
     const incomingSecret = request.headers.get("x-telegram-bot-api-secret-token");
     if (incomingSecret !== secretToken) {
@@ -102,82 +91,23 @@ export async function POST(request: Request, context: { params: Promise<{ public
   }
 
   const llm = getLlmConfig();
-  if (!llm) {
-    return new Response("Model key not configured.", { status: 503 });
-  }
-
   const update = (await request.json().catch(() => null)) as TelegramUpdate | null;
   if (!update) return new Response("Invalid payload", { status: 400 });
 
-  // Handle Telegram Callback Query (Action Confirmation Button Click)
+  const dashboardBase = (
+    process.env.NEXT_PUBLIC_DASHBOARD_URL ?? new URL(request.url).origin
+  ).replace(/\/$/, "");
+
   if (update.callback_query) {
-    const cb = update.callback_query;
-    const data = cb.data ?? "";
-    const chatId = cb.message?.chat.id;
-    const messageId = cb.message?.message_id;
-
-    if ((!data.startsWith("a:") && !data.startsWith("run_action:")) || !chatId || !messageId) {
-      await answerTelegramCallbackQuery(token, cb.id);
-      return new Response("OK", { status: 200 });
-    }
-
-    let actionId: string;
-    let paramsStr: string;
-
-    if (data.startsWith("a:")) {
-      const parts = data.slice(2).split(":");
-      actionId = parseCallbackActionId(parts[0] ?? "");
-      paramsStr = parts.slice(1).join(":");
-    } else {
-      const parts = data.split(":");
-      actionId = parts[1] ?? "";
-      paramsStr = parts.slice(2).join(":");
-    }
-
-    await answerTelegramCallbackQuery(token, cb.id, "Running action...");
-
-    const check = await getEnabledActionForPublicKey(publicKey, actionId);
-    if (!check.ok) {
-      await editTelegramMessageText(token, chatId, messageId, `❌ Action failed: ${check.error}`);
-      return new Response("OK", { status: 200 });
-    }
-
-    let parsedParams: Record<string, unknown> | undefined;
-    if (paramsStr) {
-      try {
-        parsedParams = JSON.parse(paramsStr);
-      } catch {
-        parsedParams = { value: paramsStr };
-      }
-    }
-
-    const res = await runProductAction({
-      actionId: check.actionId,
-      params: parsedParams ?? paramsStr,
+    await handleTelegramActionCallback({
+      token,
+      publicKey,
+      productId: product.id,
+      callback: update.callback_query,
     });
-
-    if (res.ok) {
-      const output = res.body ? `\n\n\`\`\`\n${res.body.slice(0, 1500)}\n\`\`\`` : "";
-      await editTelegramMessageText(
-        token,
-        chatId,
-        messageId,
-        `✅ Action executed successfully!${output}`,
-        { parseMode: "Markdown" },
-      );
-    } else {
-      await editTelegramMessageText(
-        token,
-        chatId,
-        messageId,
-        `❌ Action failed: ${res.error ?? "Unknown error"}`,
-      );
-    }
-
     return new Response("OK", { status: 200 });
   }
 
-  // Handle incoming message
   const msg = update.message;
   if (!msg || !msg.text || msg.from?.is_bot) {
     return new Response("OK", { status: 200 });
@@ -185,9 +115,33 @@ export async function POST(request: Request, context: { params: Promise<{ public
 
   const chatId = msg.chat.id;
   const userText = msg.text.trim();
+  const telegramUserId = msg.from?.id != null ? String(msg.from.id) : null;
+  const command = userText.split(/\s+/)[0]?.split("@")[0]?.toLowerCase() ?? "";
 
   if (!allowRequest(`${publicKey}:${chatId}`)) {
     await sendTelegramMessage(token, chatId, "Too many requests. Please wait a minute.");
+    return new Response("OK", { status: 200 });
+  }
+
+  if (
+    await handleTelegramWalletCommands({
+      token,
+      chatId,
+      command,
+      telegramUserId,
+      product,
+      dashboardBase,
+    })
+  ) {
+    return new Response("OK", { status: 200 });
+  }
+
+  if (!llm) {
+    await sendTelegramMessage(
+      token,
+      chatId,
+      "The agent is currently unavailable (missing model key).",
+    );
     return new Response("OK", { status: 200 });
   }
 
@@ -242,18 +196,16 @@ export async function POST(request: Request, context: { params: Promise<{ public
           const paramsStr = args.params != null ? String(args.params) : "";
           const callbackData = buildCallbackData(action.id, paramsStr);
 
-          await sendTelegramMessage(token, chatId, proposed.reply, {
-            replyMarkup: {
-              inline_keyboard: [
-                [
-                  {
-                    text: `▶ Run ${action.name}`,
-                    callback_data: callbackData,
-                  },
-                ],
-              ],
+          await sendTelegramMessage(
+            token,
+            chatId,
+            `${proposed.reply}\n\nNeed a linked wallet? Send /connect first.`,
+            {
+              replyMarkup: {
+                inline_keyboard: [[{ text: `Run ${action.name}`, callback_data: callbackData }]],
+              },
             },
-          });
+          );
           return new Response("OK", { status: 200 });
         }
 

--- a/apps/dashboard/app/connect/telegram/page.tsx
+++ b/apps/dashboard/app/connect/telegram/page.tsx
@@ -1,0 +1,55 @@
+import { TelegramConnectClient } from "../../../features/connect/telegram-connect-client";
+import { listCardsForPicker } from "../../../features/agents/queries";
+import { getCurrentUser } from "../../../features/capabilities/current-user";
+import { verifyTelegramConnectToken } from "../../../lib/connect-token";
+
+export const dynamic = "force-dynamic";
+
+export default async function TelegramConnectPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ t?: string }>;
+}) {
+  const { t: token } = await searchParams;
+  if (!token?.trim()) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-md items-center px-4 py-10">
+        <p className="text-sm text-muted-foreground">
+          Missing connect token. Send <span className="font-mono">/connect</span> in the Telegram
+          bot and open the new link.
+        </p>
+      </main>
+    );
+  }
+
+  let connect;
+  try {
+    connect = await verifyTelegramConnectToken(token.trim());
+  } catch {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-md items-center px-4 py-10">
+        <p className="text-sm text-muted-foreground">
+          This connect link expired or is invalid. Send <span className="font-mono">/connect</span>{" "}
+          in Telegram again.
+        </p>
+      </main>
+    );
+  }
+
+  const user = await getCurrentUser();
+  const cards = user ? await listCardsForPicker() : [];
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md items-center px-4 py-10">
+      <div className="w-full">
+        <TelegramConnectClient
+          token={token.trim()}
+          productName={connect.productName || "this product"}
+          signedIn={Boolean(user)}
+          walletAddress={user?.walletAddress ?? null}
+          cards={cards}
+        />
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/features/agents/actions.ts
+++ b/apps/dashboard/features/agents/actions.ts
@@ -33,6 +33,8 @@ const createAgentSchema = z.object({
 
 export interface CreateAgentResult {
   ok: boolean;
+  /** New agent/Card id. */
+  id?: string;
   /** The new hot wallet's public address to fund. */
   address?: string;
   /** True once the wallet is provisioned (funded + USDC trustline) and can receive USDC. */
@@ -62,6 +64,7 @@ export async function createAgent(input: {
   const { name, maxPerCall, dailyLimit } = parsed.data;
 
   const keypair = generateKeypair();
+  let agentId: string | undefined;
 
   try {
     await db.transaction(async (tx) => {
@@ -75,12 +78,16 @@ export async function createAgent(input: {
         })
         .returning({ id: wallets.id });
 
-      await tx.insert(agents).values({
-        ownerId: user.id,
-        name,
-        walletId: wallet!.id,
-        policy: { maxPerCall, dailyLimit, blockedPublishers: [] },
-      });
+      const [agent] = await tx
+        .insert(agents)
+        .values({
+          ownerId: user.id,
+          name,
+          walletId: wallet!.id,
+          policy: { maxPerCall, dailyLimit, blockedPublishers: [] },
+        })
+        .returning({ id: agents.id });
+      agentId = agent?.id;
     });
   } catch (error) {
     console.error("[agents] create failed:", error);
@@ -111,6 +118,7 @@ export async function createAgent(input: {
   revalidatePath("/agents");
   return {
     ok: true,
+    id: agentId,
     address: keypair.publicKey,
     ready: provision.ready,
     provisionError: provision.ok ? undefined : provision.error,

--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -164,9 +164,18 @@ export async function runCapability(input: {
   body?: string;
   /** Query string for GET calls (e.g. `address=G…`), appended to the URL. */
   query?: string;
+  /**
+   * When set, pay as this user (must own the Card). Used by Telegram/Discord
+   * channel runners that have no browser session cookie.
+   */
+  ownerId?: string;
 }): Promise<RunResult> {
-  const user = await getCurrentUser();
-  if (!user) return { ok: false, error: "Not signed in." };
+  let ownerId = input.ownerId;
+  if (!ownerId) {
+    const user = await getCurrentUser();
+    if (!user) return { ok: false, error: "Not signed in." };
+    ownerId = user.id;
+  }
 
   const [agent] = await db
     .select({
@@ -176,7 +185,7 @@ export async function runCapability(input: {
     })
     .from(agents)
     .innerJoin(wallets, eq(agents.walletId, wallets.id))
-    .where(and(eq(agents.id, input.agentId), eq(agents.ownerId, user.id)))
+    .where(and(eq(agents.id, input.agentId), eq(agents.ownerId, ownerId)))
     .limit(1);
 
   if (!agent?.secretEnc) return { ok: false, error: "Agent wallet not found." };

--- a/apps/dashboard/features/auth/connect-wallet-button.tsx
+++ b/apps/dashboard/features/auth/connect-wallet-button.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@tael/ui";
 import { getWalletKit } from "./wallet-kit";
 
-export function ConnectWalletButton() {
+export function ConnectWalletButton({ redirectTo }: { redirectTo?: string }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -40,7 +40,7 @@ export function ConnectWalletButton() {
         throw new Error(data.error ?? "Sign-in failed");
       }
 
-      router.push("/");
+      router.push(redirectTo && redirectTo.startsWith("/") ? redirectTo : "/");
       router.refresh();
     } catch (err) {
       // authModal rejects when the user simply closes the picker — don't shout about that.

--- a/apps/dashboard/features/connect/telegram-connect-client.tsx
+++ b/apps/dashboard/features/connect/telegram-connect-client.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@tael/ui";
+import { ConnectWalletButton } from "../../features/auth/connect-wallet-button";
+import { createAgent } from "../../features/agents/actions";
+import type { CardPickerOption } from "../../features/agents/queries";
+
+interface TelegramConnectClientProps {
+  token: string;
+  productName: string;
+  signedIn: boolean;
+  walletAddress: string | null;
+  cards: CardPickerOption[];
+}
+
+export function TelegramConnectClient({
+  token,
+  productName,
+  signedIn,
+  walletAddress,
+  cards: initialCards,
+}: TelegramConnectClientProps) {
+  const [cards, setCards] = useState(initialCards);
+  const [agentId, setAgentId] = useState(initialCards[0]?.id ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const redirectTo = `/connect/telegram?t=${encodeURIComponent(token)}`;
+
+  function handleCreateCard() {
+    setError(null);
+    startTransition(async () => {
+      const res = await createAgent({
+        name: "Telegram Card",
+        maxPerCall: "5",
+        dailyLimit: "50",
+      });
+      if (!res.ok || !res.id) {
+        setError(res.error ?? "Could not create a Card.");
+        return;
+      }
+      const next = [...cards, { id: res.id, name: "Telegram Card", policy: null }];
+      setCards(next);
+      setAgentId(res.id);
+    });
+  }
+
+  function handleComplete() {
+    setError(null);
+    if (!agentId) {
+      setError("Create or select a Card first.");
+      return;
+    }
+    startTransition(async () => {
+      const res = await fetch("/api/connect/telegram/complete", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token, agentId }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string; ok?: boolean };
+      if (!res.ok || !data.ok) {
+        setError(data.error ?? "Could not link wallet.");
+        return;
+      }
+      setDone(true);
+    });
+  }
+
+  if (done) {
+    return (
+      <div className="space-y-3 rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-5">
+        <h1 className="text-lg font-semibold">Wallet connected</h1>
+        <p className="text-sm text-muted-foreground">
+          Your Stellar wallet is linked to{" "}
+          <span className="font-medium text-foreground">{productName}</span> on Telegram. Go back to
+          the bot and run an action — your Card will pay.
+        </p>
+        {walletAddress ? (
+          <p className="font-mono text-xs text-muted-foreground">{walletAddress}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (!signedIn) {
+    return (
+      <div className="space-y-4 rounded-xl border p-5">
+        <div>
+          <h1 className="text-lg font-semibold">Connect wallet for {productName}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Sign in with Freighter so this Telegram bot can run paid actions using your Card.
+          </p>
+        </div>
+        <ConnectWalletButton redirectTo={redirectTo} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-xl border p-5">
+      <div>
+        <h1 className="text-lg font-semibold">Link Card for {productName}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Signed in as <span className="font-mono text-xs">{walletAddress}</span>. Pick the Card
+          that will pay for actions in Telegram.
+        </p>
+      </div>
+
+      {cards.length > 0 ? (
+        <label className="block space-y-1.5">
+          <span className="text-sm font-medium">Card</span>
+          <select
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            value={agentId}
+            onChange={(e) => setAgentId(e.target.value)}
+          >
+            {cards.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          You do not have a Card yet. Create one to pay for Telegram actions.
+        </p>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        {cards.length === 0 ? (
+          <Button type="button" size="sm" onClick={handleCreateCard} disabled={pending}>
+            {pending ? "Creating…" : "Create Card"}
+          </Button>
+        ) : (
+          <Button type="button" size="sm" onClick={handleComplete} disabled={pending || !agentId}>
+            {pending ? "Linking…" : "Link to Telegram"}
+          </Button>
+        )}
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/dashboard/features/products/channel-links.ts
+++ b/apps/dashboard/features/products/channel-links.ts
@@ -1,0 +1,93 @@
+import "server-only";
+
+import { and, channelLinks, eq, agents } from "@tael/database";
+import { db } from "../../lib/db";
+
+export interface ResolvedChannelLink {
+  userId: string;
+  agentId: string;
+}
+
+/** Look up a Telegram user's linked Card for a product bot. */
+export async function getTelegramChannelLink(
+  productId: string,
+  telegramUserId: string,
+): Promise<ResolvedChannelLink | null> {
+  const [row] = await db
+    .select({
+      userId: channelLinks.userId,
+      agentId: channelLinks.agentId,
+    })
+    .from(channelLinks)
+    .where(
+      and(
+        eq(channelLinks.channel, "telegram"),
+        eq(channelLinks.productId, productId),
+        eq(channelLinks.externalUserId, telegramUserId),
+      ),
+    )
+    .limit(1);
+
+  if (!row?.agentId) return null;
+  return { userId: row.userId, agentId: row.agentId };
+}
+
+/** Upsert Telegram → user + Card link for a product. Verifies Card ownership. */
+export async function upsertTelegramChannelLink(input: {
+  productId: string;
+  telegramUserId: string;
+  userId: string;
+  agentId: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const [card] = await db
+    .select({ id: agents.id })
+    .from(agents)
+    .where(and(eq(agents.id, input.agentId), eq(agents.ownerId, input.userId)))
+    .limit(1);
+
+  if (!card) return { ok: false, error: "That Card does not belong to you." };
+
+  const existing = await getTelegramChannelLink(input.productId, input.telegramUserId);
+  if (existing) {
+    await db
+      .update(channelLinks)
+      .set({
+        userId: input.userId,
+        agentId: input.agentId,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(channelLinks.channel, "telegram"),
+          eq(channelLinks.productId, input.productId),
+          eq(channelLinks.externalUserId, input.telegramUserId),
+        ),
+      );
+  } else {
+    await db.insert(channelLinks).values({
+      channel: "telegram",
+      productId: input.productId,
+      externalUserId: input.telegramUserId,
+      userId: input.userId,
+      agentId: input.agentId,
+    });
+  }
+
+  return { ok: true };
+}
+
+/** Remove a Telegram link for this product. */
+export async function deleteTelegramChannelLink(
+  productId: string,
+  telegramUserId: string,
+): Promise<void> {
+  await db
+    .delete(channelLinks)
+    .where(
+      and(
+        eq(channelLinks.channel, "telegram"),
+        eq(channelLinks.productId, productId),
+        eq(channelLinks.externalUserId, telegramUserId),
+      ),
+    );
+}

--- a/apps/dashboard/features/products/run-product-action.ts
+++ b/apps/dashboard/features/products/run-product-action.ts
@@ -52,6 +52,11 @@ export async function runProductAction(input: {
   agentId?: string;
   /** Params from the confirm proposal. */
   params?: string | Record<string, unknown>;
+  /**
+   * When set (Telegram/Discord channel link), pay as this user instead of
+   * requiring the product owner session.
+   */
+  payerUserId?: string;
 }): Promise<RunProductActionResult> {
   const [row] = await db
     .select({
@@ -71,10 +76,21 @@ export async function runProductAction(input: {
   if (!row || !row.enabled) return { ok: false, error: "Action not found." };
 
   if (row.kind === "capability") {
-    const user = await getCurrentUser();
-    if (!user) return { ok: false, error: "Not signed in." };
-    if (user.id !== row.ownerId) return { ok: false, error: "Not allowed." };
-    if (!input.agentId) return { ok: false, error: "Pick a Card to pay for this run." };
+    let payerUserId: string;
+    let agentId = input.agentId;
+
+    if (input.payerUserId) {
+      payerUserId = input.payerUserId;
+      if (!agentId) {
+        return { ok: false, error: "No Card linked. Send /connect in this bot first." };
+      }
+    } else {
+      const user = await getCurrentUser();
+      if (!user) return { ok: false, error: "Not signed in." };
+      if (user.id !== row.ownerId) return { ok: false, error: "Not allowed." };
+      payerUserId = user.id;
+      if (!agentId) return { ok: false, error: "Pick a Card to pay for this run." };
+    }
 
     const slug = "slug" in row.config ? row.config.slug : "";
     if (!slug) return { ok: false, error: "Action is misconfigured." };
@@ -89,11 +105,12 @@ export async function runProductAction(input: {
     // Default to GET with query; JSON body → POST.
     const method = looksJson ? "POST" : "GET";
     const result: RunResult = await runCapability({
-      agentId: input.agentId,
+      agentId,
       slug,
       method,
       body: looksJson ? paramsStr : undefined,
       query: !looksJson ? paramsStr : undefined,
+      ownerId: payerUserId,
     });
     return {
       ok: result.ok,

--- a/apps/dashboard/features/products/telegram-action-callback.ts
+++ b/apps/dashboard/features/products/telegram-action-callback.ts
@@ -1,0 +1,102 @@
+import { getEnabledActionForPublicKey, runProductAction } from "./run-product-action";
+import { getTelegramChannelLink } from "./channel-links";
+import {
+  answerTelegramCallbackQuery,
+  editTelegramMessageText,
+  type TelegramCallbackQuery,
+} from "./telegram";
+
+/** Reconstructs UUID from 32-hex actionId in callback_data. */
+function parseCallbackActionId(rawHex: string): string {
+  if (rawHex.length !== 32) return rawHex;
+  return `${rawHex.slice(0, 8)}-${rawHex.slice(8, 12)}-${rawHex.slice(12, 16)}-${rawHex.slice(16, 20)}-${rawHex.slice(20)}`;
+}
+
+/** Handle action-confirm button clicks. Returns true if handled. */
+export async function handleTelegramActionCallback(input: {
+  token: string;
+  publicKey: string;
+  productId: string;
+  callback: TelegramCallbackQuery;
+}): Promise<boolean> {
+  const { token, publicKey, productId, callback: cb } = input;
+  const data = cb.data ?? "";
+  const chatId = cb.message?.chat.id;
+  const messageId = cb.message?.message_id;
+  const telegramUserId = cb.from?.id != null ? String(cb.from.id) : null;
+
+  if ((!data.startsWith("a:") && !data.startsWith("run_action:")) || !chatId || !messageId) {
+    await answerTelegramCallbackQuery(token, cb.id);
+    return true;
+  }
+
+  let actionId: string;
+  let paramsStr: string;
+
+  if (data.startsWith("a:")) {
+    const parts = data.slice(2).split(":");
+    actionId = parseCallbackActionId(parts[0] ?? "");
+    paramsStr = parts.slice(1).join(":");
+  } else {
+    const parts = data.split(":");
+    actionId = parts[1] ?? "";
+    paramsStr = parts.slice(2).join(":");
+  }
+
+  await answerTelegramCallbackQuery(token, cb.id, "Running action...");
+
+  const check = await getEnabledActionForPublicKey(publicKey, actionId);
+  if (!check.ok) {
+    await editTelegramMessageText(token, chatId, messageId, `Action failed: ${check.error}`);
+    return true;
+  }
+
+  let parsedParams: Record<string, unknown> | undefined;
+  if (paramsStr) {
+    try {
+      parsedParams = JSON.parse(paramsStr);
+    } catch {
+      parsedParams = { value: paramsStr };
+    }
+  }
+
+  const link = telegramUserId ? await getTelegramChannelLink(productId, telegramUserId) : null;
+  if (!link) {
+    await editTelegramMessageText(
+      token,
+      chatId,
+      messageId,
+      "Connect your wallet first. Send /connect then open the link.",
+    );
+    return true;
+  }
+
+  const res = await runProductAction({
+    actionId: check.actionId,
+    params: parsedParams ?? paramsStr,
+    payerUserId: link.userId,
+    agentId: link.agentId,
+  });
+
+  if (res.ok) {
+    const paid = res.paid ? `\nPaid: ${res.paid} USDC` : "";
+    const proof = res.txHash ? `\nTx: \`${res.txHash}\`` : "";
+    const output = res.body ? `\n\n\`\`\`\n${res.body.slice(0, 1500)}\n\`\`\`` : "";
+    await editTelegramMessageText(
+      token,
+      chatId,
+      messageId,
+      `Action executed successfully!${paid}${proof}${output}`,
+      { parseMode: "Markdown" },
+    );
+  } else {
+    await editTelegramMessageText(
+      token,
+      chatId,
+      messageId,
+      `Action failed: ${res.error ?? "Unknown error"}`,
+    );
+  }
+
+  return true;
+}

--- a/apps/dashboard/features/products/telegram-wallet-commands.ts
+++ b/apps/dashboard/features/products/telegram-wallet-commands.ts
@@ -1,0 +1,70 @@
+import type { Product } from "@tael/database";
+import { deleteTelegramChannelLink, getTelegramChannelLink } from "./channel-links";
+import { sendTelegramMessage } from "./telegram";
+import { createTelegramConnectToken } from "../../lib/connect-token";
+
+/** Handle /connect /wallet /disconnect. Returns true if a command was handled. */
+export async function handleTelegramWalletCommands(input: {
+  token: string;
+  chatId: number;
+  command: string;
+  telegramUserId: string | null;
+  product: Product;
+  dashboardBase: string;
+}): Promise<boolean> {
+  const { token, chatId, command, telegramUserId, product, dashboardBase } = input;
+
+  if (command === "/connect") {
+    if (!telegramUserId) {
+      await sendTelegramMessage(token, chatId, "Could not identify your Telegram user.");
+      return true;
+    }
+    const connectToken = await createTelegramConnectToken({
+      externalUserId: telegramUserId,
+      productId: product.id,
+      productPublicKey: product.publicKey,
+      productName: product.name,
+    });
+    const url = `${dashboardBase}/connect/telegram?t=${encodeURIComponent(connectToken)}`;
+    await sendTelegramMessage(
+      token,
+      chatId,
+      `Connect your Stellar wallet to run paid actions for ${product.name}.\n\n1. Open this link (expires in 15 min)\n${url}\n\n2. Sign in with Freighter\n3. Link a Card\n4. Come back here and confirm an action`,
+    );
+    return true;
+  }
+
+  if (command === "/wallet") {
+    if (!telegramUserId) {
+      await sendTelegramMessage(token, chatId, "Could not identify your Telegram user.");
+      return true;
+    }
+    const link = await getTelegramChannelLink(product.id, telegramUserId);
+    if (!link) {
+      await sendTelegramMessage(
+        token,
+        chatId,
+        "No wallet linked yet. Send /connect to link your Stellar wallet + Card.",
+      );
+    } else {
+      await sendTelegramMessage(
+        token,
+        chatId,
+        "Wallet linked. Paid actions will use your linked Card. Send /disconnect to unlink.",
+      );
+    }
+    return true;
+  }
+
+  if (command === "/disconnect") {
+    if (!telegramUserId) {
+      await sendTelegramMessage(token, chatId, "Could not identify your Telegram user.");
+      return true;
+    }
+    await deleteTelegramChannelLink(product.id, telegramUserId);
+    await sendTelegramMessage(token, chatId, "Wallet unlinked from this bot.");
+    return true;
+  }
+
+  return false;
+}

--- a/apps/dashboard/lib/connect-token.ts
+++ b/apps/dashboard/lib/connect-token.ts
@@ -1,0 +1,20 @@
+import {
+  createTelegramConnectToken as mintTelegramConnectToken,
+  verifyTelegramConnectToken as checkTelegramConnectToken,
+  type TelegramConnectPayload,
+} from "@tael/auth";
+import { AUTH_SECRET } from "./config";
+
+export type { TelegramConnectPayload };
+
+/** Mint a short-lived token for the Telegram → web wallet connect flow. */
+export async function createTelegramConnectToken(
+  payload: Omit<TelegramConnectPayload, "channel">,
+): Promise<string> {
+  return mintTelegramConnectToken(payload, AUTH_SECRET);
+}
+
+/** Verify a Telegram connect token. Throws on invalid/expired. */
+export async function verifyTelegramConnectToken(token: string): Promise<TelegramConnectPayload> {
+  return checkTelegramConnectToken(token, AUTH_SECRET);
+}

--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -21,8 +21,9 @@ export async function middleware(request: NextRequest) {
   const authed = await isAuthenticated(request);
   const { pathname } = request.nextUrl;
   const isAuthRoute = pathname.startsWith("/login") || pathname.startsWith("/signup");
+  const isPublicConnect = pathname.startsWith("/connect");
 
-  if (!authed && !isAuthRoute) {
+  if (!authed && !isAuthRoute && !isPublicConnect) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
     return NextResponse.redirect(url);

--- a/packages/auth/src/connect-token.ts
+++ b/packages/auth/src/connect-token.ts
@@ -1,0 +1,54 @@
+import { SignJWT, jwtVerify } from "jose";
+import { secretKey } from "./secret";
+
+const CONNECT_TTL = "15m";
+
+export interface TelegramConnectPayload {
+  channel: "telegram";
+  externalUserId: string;
+  productId: string;
+  productPublicKey: string;
+  productName: string;
+}
+
+/** Mint a short-lived token for Telegram → web wallet connect. */
+export async function createTelegramConnectToken(
+  payload: Omit<TelegramConnectPayload, "channel">,
+  secret: string,
+): Promise<string> {
+  return new SignJWT({
+    channel: "telegram",
+    externalUserId: payload.externalUserId,
+    productId: payload.productId,
+    productPublicKey: payload.productPublicKey,
+    productName: payload.productName,
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(CONNECT_TTL)
+    .sign(secretKey(secret));
+}
+
+/** Verify a Telegram connect token. Throws on invalid/expired. */
+export async function verifyTelegramConnectToken(
+  token: string,
+  secret: string,
+): Promise<TelegramConnectPayload> {
+  const { payload } = await jwtVerify(token, secretKey(secret));
+  if (payload.channel !== "telegram") throw new Error("Invalid connect token channel.");
+  const externalUserId = typeof payload.externalUserId === "string" ? payload.externalUserId : "";
+  const productId = typeof payload.productId === "string" ? payload.productId : "";
+  const productPublicKey =
+    typeof payload.productPublicKey === "string" ? payload.productPublicKey : "";
+  const productName = typeof payload.productName === "string" ? payload.productName : "";
+  if (!externalUserId || !productId || !productPublicKey) {
+    throw new Error("Invalid connect token payload.");
+  }
+  return {
+    channel: "telegram",
+    externalUserId,
+    productId,
+    productPublicKey,
+    productName,
+  };
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -5,3 +5,4 @@
 // is composed at the route-handler (Node) layer.
 export * from "./challenge";
 export * from "./session";
+export * from "./connect-token";

--- a/packages/database/drizzle/0017_channel_links.sql
+++ b/packages/database/drizzle/0017_channel_links.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "channel_links" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"agent_id" uuid,
+	"channel" text NOT NULL,
+	"external_user_id" text NOT NULL,
+	"product_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "channel_links" ADD CONSTRAINT "channel_links_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "channel_links" ADD CONSTRAINT "channel_links_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "channel_links" ADD CONSTRAINT "channel_links_product_id_products_id_fk" FOREIGN KEY ("product_id") REFERENCES "public"."products"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "channel_links_channel_ext_product_uidx" ON "channel_links" USING btree ("channel","external_user_id","product_id");
+--> statement-breakpoint
+CREATE INDEX "channel_links_user_id_idx" ON "channel_links" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX "channel_links_product_id_idx" ON "channel_links" USING btree ("product_id");

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1785490120134,
       "tag": "0016_common_captain_cross",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1787479200000,
+      "tag": "0017_channel_links",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/channel-links.ts
+++ b/packages/database/src/schema/channel-links.ts
@@ -1,0 +1,41 @@
+import { index, pgTable, text, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { primaryId, timestamps } from "./_shared";
+import { users } from "./users";
+import { agents } from "./agents";
+import { products } from "./products";
+
+/**
+ * Links a chat-platform user (Telegram/Discord) to a Tael user + default Card
+ * for paid capability runs on a specific product bot.
+ */
+export const channelLinks = pgTable(
+  "channel_links",
+  {
+    id: primaryId(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /** Card that pays; must belong to userId. */
+    agentId: uuid("agent_id").references(() => agents.id, { onDelete: "set null" }),
+    /** "telegram" | "discord" */
+    channel: text("channel").notNull(),
+    /** Telegram: String(from.id); Discord: snowflake */
+    externalUserId: text("external_user_id").notNull(),
+    productId: uuid("product_id")
+      .notNull()
+      .references(() => products.id, { onDelete: "cascade" }),
+    ...timestamps,
+  },
+  (t) => [
+    uniqueIndex("channel_links_channel_ext_product_uidx").on(
+      t.channel,
+      t.externalUserId,
+      t.productId,
+    ),
+    index("channel_links_user_id_idx").on(t.userId),
+    index("channel_links_product_id_idx").on(t.productId),
+  ],
+);
+
+export type ChannelLink = typeof channelLinks.$inferSelect;
+export type NewChannelLink = typeof channelLinks.$inferInsert;

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -9,5 +9,6 @@ export * from "./payments";
 export * from "./api-keys";
 export * from "./reviews";
 export * from "./products";
+export * from "./channel-links";
 export * from "./relations";
 export * from "./chat";

--- a/packages/database/src/schema/relations.ts
+++ b/packages/database/src/schema/relations.ts
@@ -7,6 +7,7 @@ import { payments } from "./payments";
 import { apiKeys } from "./api-keys";
 import { chatThreads, chatMessages } from "./chat";
 import { products, productContent, productActions } from "./products";
+import { channelLinks } from "./channel-links";
 
 // Typed relations enable Drizzle's relational query API (db.query.users.findMany
 // with `with: { wallets: true }`, etc.) without hand-written joins.
@@ -17,6 +18,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   capabilities: many(capabilities),
   apiKeys: many(apiKeys),
   products: many(products),
+  channelLinks: many(channelLinks),
 }));
 
 export const walletsRelations = relations(wallets, ({ one, many }) => ({
@@ -33,6 +35,7 @@ export const agentsRelations = relations(agents, ({ one, many }) => ({
   owner: one(users, { fields: [agents.ownerId], references: [users.id] }),
   wallet: one(wallets, { fields: [agents.walletId], references: [wallets.id] }),
   payments: many(payments),
+  channelLinks: many(channelLinks),
 }));
 
 export const paymentsRelations = relations(payments, ({ one }) => ({
@@ -57,6 +60,7 @@ export const productsRelations = relations(products, ({ one, many }) => ({
   owner: one(users, { fields: [products.ownerId], references: [users.id] }),
   content: many(productContent),
   actions: many(productActions),
+  channelLinks: many(channelLinks),
 }));
 
 export const productContentRelations = relations(productContent, ({ one }) => ({
@@ -65,4 +69,10 @@ export const productContentRelations = relations(productContent, ({ one }) => ({
 
 export const productActionsRelations = relations(productActions, ({ one }) => ({
   product: one(products, { fields: [productActions.productId], references: [products.id] }),
+}));
+
+export const channelLinksRelations = relations(channelLinks, ({ one }) => ({
+  user: one(users, { fields: [channelLinks.userId], references: [users.id] }),
+  agent: one(agents, { fields: [channelLinks.agentId], references: [agents.id] }),
+  product: one(products, { fields: [channelLinks.productId], references: [products.id] }),
 }));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Telegram product bots could answer questions, but paid capability actions failed with **Not signed in** because confirms ran without a web session or Card.

This adds end-user wallet linking so each Telegram user connects Freighter, picks a Card, and paid actions run as **their** Card — not the product owner.

## Flow
1. User sends `/connect` in the product bot
2. Opens `mainnet.taelprotocol.xyz/connect/telegram?t=…`
3. SIWS with Freighter → pick/create Card → link
4. Confirm an action in Telegram → pays from linked Card → receipt/tx in chat

Also: `/wallet`, `/disconnect`

## Type of change
- [x] Feature

## Checklist
- [x] `channel_links` table + migration `0017_channel_links.sql`
- [x] `runCapability` / `runProductAction` support payer without owner session
- [x] Dashboard typecheck passes
- [ ] **Run migration on production DB** before/after deploy: `pnpm --filter @tael/database db:migrate`
- [ ] Fund linked Card with USDC on mainnet before testing paid calls

## Test plan
1. Merge + migrate + redeploy dashboard
2. Telegram: `/connect` → Freighter → Link Card
3. Ask bot to run a capability → confirm button
4. Expect success (or clear insufficient USDC), not Not signed in
5. `/wallet` shows linked; `/disconnect` unlinks
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

