### PR TITLE
Fixed: Telegram Pay confirms, product agent voice, and HTML formatting

### DIFF
--- a/apps/dashboard/app/api/widget/[publicKey]/discord/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/discord/route.ts
@@ -81,19 +81,25 @@ export async function POST(request: Request, context: { params: Promise<{ public
 
   if (interaction.type === DISCORD_INTERACTION_MESSAGE_COMPONENT) {
     const customId = interaction.data?.custom_id ?? "";
-    if (!customId.startsWith("run:")) {
+    if (!customId.startsWith("c:")) {
       return jsonResponse({
         type: 4,
         data: { content: "Unknown button.", flags: 64 },
       });
     }
 
-    const parts = customId.split(":");
-    const actionId = parts[1] ?? "";
-    const paramsStr = parts.slice(2).join(":");
+    const pendingToken = customId.slice(2).trim();
+    const discordUserId = interaction.member?.user?.id ?? interaction.user?.id ?? null;
 
     after(() =>
-      handleDiscordActionConfirm(publicKey, applicationId, interaction.token, actionId, paramsStr),
+      handleDiscordActionConfirm(
+        publicKey,
+        product.id,
+        applicationId,
+        interaction.token,
+        pendingToken,
+        discordUserId,
+      ),
     );
     return jsonResponse({ type: DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE });
   }
@@ -122,7 +128,9 @@ export async function POST(request: Request, context: { params: Promise<{ public
       });
     }
 
-    after(() => handleDiscordAsk(product, applicationId, interaction.token, question));
+    after(() =>
+      handleDiscordAsk(product, applicationId, interaction.token, question, userId),
+    );
     return jsonResponse({ type: DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE });
   }
 

--- a/apps/dashboard/app/api/widget/[publicKey]/discord/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/discord/route.ts
@@ -128,9 +128,7 @@ export async function POST(request: Request, context: { params: Promise<{ public
       });
     }
 
-    after(() =>
-      handleDiscordAsk(product, applicationId, interaction.token, question, userId),
-    );
+    after(() => handleDiscordAsk(product, applicationId, interaction.token, question, userId));
     return jsonResponse({ type: DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE });
   }
 

--- a/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
@@ -59,9 +59,7 @@ function safeParseArgs(raw: string | undefined): Record<string, unknown> {
 }
 
 /** Normalize tool params into a value we can store + later run. */
-function normalizeToolParams(
-  raw: unknown,
-): string | Record<string, unknown> | null {
+function normalizeToolParams(raw: unknown): string | Record<string, unknown> | null {
   if (raw == null) return null;
   if (typeof raw === "object" && !Array.isArray(raw)) {
     return raw as Record<string, unknown>;

--- a/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/telegram/route.ts
@@ -6,6 +6,11 @@ import {
 import { handleTelegramActionCallback } from "../../../../../features/products/telegram-action-callback";
 import { handleTelegramWalletCommands } from "../../../../../features/products/telegram-wallet-commands";
 import {
+  buildPendingCallbackData,
+  createPendingActionConfirm,
+} from "../../../../../features/products/pending-action-confirms";
+import { markdownToTelegramHtml } from "../../../../../features/products/telegram-html";
+import {
   sendTelegramMessage,
   type TelegramUpdate,
 } from "../../../../../features/products/telegram";
@@ -53,14 +58,27 @@ function safeParseArgs(raw: string | undefined): Record<string, unknown> {
   }
 }
 
-/** Formats a compact callback_data string under Telegram's strict 64-byte limit. */
-function buildCallbackData(actionId: string, paramsStr: string): string {
-  const hex = actionId.replace(/-/g, "");
-  const prefix = `a:${hex}`;
-  if (!paramsStr) return prefix;
-  const maxParamsLen = 63 - prefix.length - 1;
-  const safeParams = paramsStr.slice(0, Math.max(0, maxParamsLen));
-  return `${prefix}:${safeParams}`;
+/** Normalize tool params into a value we can store + later run. */
+function normalizeToolParams(
+  raw: unknown,
+): string | Record<string, unknown> | null {
+  if (raw == null) return null;
+  if (typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  const asString = String(raw).trim();
+  if (!asString) return null;
+  if (asString.startsWith("{")) {
+    try {
+      const parsed: unknown = JSON.parse(asString);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // keep string
+    }
+  }
+  return asString;
 }
 
 export async function POST(request: Request, context: { params: Promise<{ publicKey: string }> }) {
@@ -117,6 +135,7 @@ export async function POST(request: Request, context: { params: Promise<{ public
   const userText = msg.text.trim();
   const telegramUserId = msg.from?.id != null ? String(msg.from.id) : null;
   const command = userText.split(/\s+/)[0]?.split("@")[0]?.toLowerCase() ?? "";
+  const isStart = command === "/start";
 
   if (!allowRequest(`${publicKey}:${chatId}`)) {
     await sendTelegramMessage(token, chatId, "Too many requests. Please wait a minute.");
@@ -150,7 +169,10 @@ export async function POST(request: Request, context: { params: Promise<{ public
     getProductActionsForChat(product.id),
   ]);
 
-  const system = buildWidgetSystemPrompt(product, content, actions);
+  // Telegram webhooks are single-turn (no history), so greet only on /start.
+  const system = buildWidgetSystemPrompt(product, content, actions, {
+    allowGreeting: isStart,
+  });
   const tools = buildWidgetTools(actions);
   const actionsById = new Map(actions.map((a) => [a.id, a]));
 
@@ -193,14 +215,24 @@ export async function POST(request: Request, context: { params: Promise<{ public
 
           const args = safeParseArgs(call.function.arguments);
           const proposed = proposeWidgetAction(action, args);
-          const paramsStr = args.params != null ? String(args.params) : "";
-          const callbackData = buildCallbackData(action.id, paramsStr);
+          const pendingParams = normalizeToolParams(args.params);
+          const pendingToken = await createPendingActionConfirm({
+            productId: product.id,
+            actionId: action.id,
+            channel: "telegram",
+            externalUserId: telegramUserId,
+            params: pendingParams,
+          });
+          const callbackData = buildPendingCallbackData(pendingToken);
 
           await sendTelegramMessage(
             token,
             chatId,
-            `${proposed.reply}\n\nNeed a linked wallet? Send /connect first.`,
+            markdownToTelegramHtml(
+              `${proposed.reply}\n\nNeed a linked wallet? Send /connect first.`,
+            ),
             {
+              parseMode: "HTML",
               replyMarkup: {
                 inline_keyboard: [[{ text: `Run ${action.name}`, callback_data: callbackData }]],
               },
@@ -223,7 +255,9 @@ export async function POST(request: Request, context: { params: Promise<{ public
 
       const text = typeof message.content === "string" ? message.content.trim() : "";
       if (text) {
-        await sendTelegramMessage(token, chatId, text, { parseMode: "Markdown" });
+        await sendTelegramMessage(token, chatId, markdownToTelegramHtml(text), {
+          parseMode: "HTML",
+        });
       }
       return new Response("OK", { status: 200 });
     }

--- a/apps/dashboard/features/products/action-actions.ts
+++ b/apps/dashboard/features/products/action-actions.ts
@@ -13,6 +13,7 @@ const httpMethodSchema = z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]);
 
 const capabilityConfigSchema = z.object({
   slug: z.string().trim().min(1, "Capability slug is required").max(120),
+  operation: z.string().trim().min(1).max(80).optional(),
 });
 
 const httpConfigSchema = z.object({

--- a/apps/dashboard/features/products/action-dialogs.tsx
+++ b/apps/dashboard/features/products/action-dialogs.tsx
@@ -41,6 +41,7 @@ export function ConnectActionDialog({
   const [description, setDescription] = useState("");
   const [kind, setKind] = useState<Kind>("capability");
   const [slug, setSlug] = useState("");
+  const [operation, setOperation] = useState("");
   const [url, setUrl] = useState("");
   const [method, setMethod] = useState<"GET" | "POST" | "PUT" | "PATCH" | "DELETE">("POST");
   const [shareAsCapability, setShareAsCapability] = useState(false);
@@ -51,6 +52,7 @@ export function ConnectActionDialog({
     setDescription("");
     setKind("capability");
     setSlug("");
+    setOperation("");
     setUrl("");
     setMethod("POST");
     setShareAsCapability(false);
@@ -66,7 +68,10 @@ export function ConnectActionDialog({
               name,
               description,
               kind: "capability",
-              config: { slug },
+              config: {
+                slug: slug.trim(),
+                ...(operation.trim() ? { operation: operation.trim() } : {}),
+              },
               shareAsCapability,
             }
           : {
@@ -157,14 +162,24 @@ export function ConnectActionDialog({
           </fieldset>
 
           {kind === "capability" ? (
-            <Field label="Capability slug">
-              <Input
-                value={slug}
-                onChange={(e) => setSlug(e.target.value)}
-                placeholder="e.g. stellar-pay"
-                className="font-mono text-sm"
-              />
-            </Field>
+            <>
+              <Field label="Capability slug">
+                <Input
+                  value={slug}
+                  onChange={(e) => setSlug(e.target.value)}
+                  placeholder="e.g. stellar"
+                  className="font-mono text-sm"
+                />
+              </Field>
+              <Field label="Operation (optional)">
+                <Input
+                  value={operation}
+                  onChange={(e) => setOperation(e.target.value)}
+                  placeholder="e.g. pay — or put stellar/pay in the slug"
+                  className="font-mono text-sm"
+                />
+              </Field>
+            </>
           ) : (
             <>
               <Field label="URL">

--- a/apps/dashboard/features/products/capability-call.ts
+++ b/apps/dashboard/features/products/capability-call.ts
@@ -19,10 +19,7 @@ export interface CapabilityRequest {
  * Accepts either `{ slug: "stellar", operation: "pay" }` or combined
  * `{ slug: "stellar/pay" }` (legacy Studio entries).
  */
-export function resolveCapabilityRef(config: {
-  slug: string;
-  operation?: string;
-}): CapabilityRef {
+export function resolveCapabilityRef(config: { slug: string; operation?: string }): CapabilityRef {
   const rawSlug = config.slug.trim().replace(/^\/+|\/+$/g, "");
   const op = config.operation?.trim();
   if (op) {

--- a/apps/dashboard/features/products/capability-call.ts
+++ b/apps/dashboard/features/products/capability-call.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure helpers for invoking a product capability action
+ * (slug/operation parsing + param → GET query / POST body).
+ */
+
+export interface CapabilityRef {
+  slug: string;
+  operation?: string;
+}
+
+export interface CapabilityRequest {
+  method: "GET" | "POST";
+  query?: string;
+  body?: string;
+}
+
+/**
+ * Resolve capability path pieces from product action config.
+ * Accepts either `{ slug: "stellar", operation: "pay" }` or combined
+ * `{ slug: "stellar/pay" }` (legacy Studio entries).
+ */
+export function resolveCapabilityRef(config: {
+  slug: string;
+  operation?: string;
+}): CapabilityRef {
+  const rawSlug = config.slug.trim().replace(/^\/+|\/+$/g, "");
+  const op = config.operation?.trim();
+  if (op) {
+    return { slug: rawSlug.split("/")[0] || rawSlug, operation: op.replace(/^\/+/, "") };
+  }
+  const slash = rawSlug.indexOf("/");
+  if (slash === -1) return { slug: rawSlug };
+  return {
+    slug: rawSlug.slice(0, slash),
+    operation: rawSlug.slice(slash + 1).replace(/^\/+/, "") || undefined,
+  };
+}
+
+function isFlatPrimitive(value: unknown): boolean {
+  return (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+/** Flat object of primitives → URLSearchParams query string. */
+export function flatObjectToQuery(obj: Record<string, unknown>): string {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === null || value === undefined) continue;
+    qs.set(key, String(value));
+  }
+  return qs.toString();
+}
+
+/**
+ * Map model/tool params into a capability HTTP call.
+ * Flat JSON like `{ to, amount }` becomes GET `to=…&amount=…` (Pay/Swap style).
+ * Nested objects stay POST JSON. Raw query strings stay GET.
+ */
+export function toCapabilityRequest(
+  params?: string | Record<string, unknown> | null,
+): CapabilityRequest {
+  if (params == null) return { method: "GET" };
+
+  if (typeof params === "string") {
+    const trimmed = params.trim();
+    if (!trimmed) return { method: "GET" };
+    if (trimmed.startsWith("{")) {
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          return toCapabilityRequest(parsed as Record<string, unknown>);
+        }
+      } catch {
+        return { method: "GET", query: trimmed.replace(/^\?/, "") };
+      }
+      return { method: "POST", body: trimmed };
+    }
+    return { method: "GET", query: trimmed.replace(/^\?/, "") };
+  }
+
+  const entries = Object.entries(params);
+  if (entries.length === 0) return { method: "GET" };
+
+  const allFlat = entries.every(([, value]) => isFlatPrimitive(value));
+  if (allFlat) {
+    const query = flatObjectToQuery(params);
+    return query ? { method: "GET", query } : { method: "GET" };
+  }
+
+  return { method: "POST", body: JSON.stringify(params) };
+}

--- a/apps/dashboard/features/products/discord-chat.ts
+++ b/apps/dashboard/features/products/discord-chat.ts
@@ -2,6 +2,10 @@ import type { Product } from "@tael/database";
 import { createLlmChatCompletion, getLlmConfig } from "../../lib/llm";
 import { getProductActionsForChat, getProductContentForChat } from "./queries";
 import { editDiscordInteractionResponse } from "./discord";
+import {
+  createPendingActionConfirm,
+  consumePendingActionConfirm,
+} from "./pending-action-confirms";
 import { getEnabledActionForPublicKey, runProductAction } from "./run-product-action";
 import {
   actionIdFromToolName,
@@ -40,7 +44,29 @@ function safeParseArgs(raw: string | undefined): Record<string, unknown> {
   }
 }
 
-function runActionButton(actionId: string, paramsStr: string): unknown[] {
+function normalizeToolParams(
+  raw: unknown,
+): string | Record<string, unknown> | null {
+  if (raw == null) return null;
+  if (typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  const asString = String(raw).trim();
+  if (!asString) return null;
+  if (asString.startsWith("{")) {
+    try {
+      const parsed: unknown = JSON.parse(asString);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // keep string
+    }
+  }
+  return asString;
+}
+
+function runPendingButton(token: string): unknown[] {
   return [
     {
       type: 1,
@@ -49,7 +75,7 @@ function runActionButton(actionId: string, paramsStr: string): unknown[] {
           type: 2,
           style: 1,
           label: "Run action",
-          custom_id: `run:${actionId}:${paramsStr}`.slice(0, 100),
+          custom_id: `c:${token}`.slice(0, 100),
         },
       ],
     },
@@ -58,12 +84,27 @@ function runActionButton(actionId: string, paramsStr: string): unknown[] {
 
 export async function handleDiscordActionConfirm(
   publicKey: string,
+  productId: string,
   applicationId: string,
   interactionToken: string,
-  actionId: string,
-  paramsStr: string,
+  pendingToken: string,
+  discordUserId?: string | null,
 ): Promise<void> {
-  const check = await getEnabledActionForPublicKey(publicKey, actionId);
+  const pending = await consumePendingActionConfirm({
+    token: pendingToken,
+    channel: "discord",
+    externalUserId: discordUserId,
+  });
+  if (!pending || pending.productId !== productId) {
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      "This confirmation expired. Ask again to get a new button.",
+    );
+    return;
+  }
+
+  const check = await getEnabledActionForPublicKey(publicKey, pending.actionId);
   if (!check.ok) {
     await editDiscordInteractionResponse(
       applicationId,
@@ -73,18 +114,9 @@ export async function handleDiscordActionConfirm(
     return;
   }
 
-  let parsedParams: Record<string, unknown> | string | undefined = paramsStr || undefined;
-  if (paramsStr) {
-    try {
-      parsedParams = JSON.parse(paramsStr) as Record<string, unknown>;
-    } catch {
-      parsedParams = { value: paramsStr };
-    }
-  }
-
   const res = await runProductAction({
     actionId: check.actionId,
-    params: parsedParams,
+    params: pending.params,
   });
 
   if (res.ok) {
@@ -109,6 +141,7 @@ export async function handleDiscordAsk(
   applicationId: string,
   interactionToken: string,
   question: string,
+  discordUserId?: string | null,
 ): Promise<void> {
   const llm = getLlmConfig();
   if (!llm) {
@@ -125,7 +158,10 @@ export async function handleDiscordAsk(
     getProductActionsForChat(product.id),
   ]);
 
-  const system = buildWidgetSystemPrompt(product, content, actions);
+  // Each /ask is single-turn — never open with a canned greeting.
+  const system = buildWidgetSystemPrompt(product, content, actions, {
+    allowGreeting: false,
+  });
   const tools = buildWidgetTools(actions);
   const actionsById = new Map(actions.map((a) => [a.id, a]));
 
@@ -172,13 +208,19 @@ export async function handleDiscordAsk(
 
           const args = safeParseArgs(call.function.arguments);
           const proposed = proposeWidgetAction(action, args);
-          const paramsStr = args.params != null ? String(args.params) : "";
+          const pendingToken = await createPendingActionConfirm({
+            productId: product.id,
+            actionId: action.id,
+            channel: "discord",
+            externalUserId: discordUserId,
+            params: normalizeToolParams(args.params),
+          });
 
           await editDiscordInteractionResponse(
             applicationId,
             interactionToken,
             proposed.reply,
-            runActionButton(action.id, paramsStr),
+            runPendingButton(pendingToken),
           );
           return;
         }

--- a/apps/dashboard/features/products/discord-chat.ts
+++ b/apps/dashboard/features/products/discord-chat.ts
@@ -2,10 +2,7 @@ import type { Product } from "@tael/database";
 import { createLlmChatCompletion, getLlmConfig } from "../../lib/llm";
 import { getProductActionsForChat, getProductContentForChat } from "./queries";
 import { editDiscordInteractionResponse } from "./discord";
-import {
-  createPendingActionConfirm,
-  consumePendingActionConfirm,
-} from "./pending-action-confirms";
+import { createPendingActionConfirm, consumePendingActionConfirm } from "./pending-action-confirms";
 import { getEnabledActionForPublicKey, runProductAction } from "./run-product-action";
 import {
   actionIdFromToolName,
@@ -44,9 +41,7 @@ function safeParseArgs(raw: string | undefined): Record<string, unknown> {
   }
 }
 
-function normalizeToolParams(
-  raw: unknown,
-): string | Record<string, unknown> | null {
+function normalizeToolParams(raw: unknown): string | Record<string, unknown> | null {
   if (raw == null) return null;
   if (typeof raw === "object" && !Array.isArray(raw)) {
     return raw as Record<string, unknown>;

--- a/apps/dashboard/features/products/pending-action-confirms.ts
+++ b/apps/dashboard/features/products/pending-action-confirms.ts
@@ -1,0 +1,96 @@
+import "server-only";
+
+import { and, eq, gt, pendingActionConfirms } from "@tael/database";
+import { randomBytes } from "node:crypto";
+import { db } from "../../lib/db";
+
+export {
+  buildPendingCallbackData,
+  parseActionCallbackData,
+} from "./pending-callback";
+
+const TTL_MS = 15 * 60 * 1000;
+
+function newToken(): string {
+  return randomBytes(12).toString("base64url");
+}
+
+export interface CreatePendingConfirmInput {
+  productId: string;
+  actionId: string;
+  channel: "telegram" | "discord";
+  externalUserId?: string | null;
+  params?: string | Record<string, unknown> | null;
+}
+
+/** Persist action params and return a short token for callback_data. */
+export async function createPendingActionConfirm(
+  input: CreatePendingConfirmInput,
+): Promise<string> {
+  const token = newToken();
+  const expiresAt = new Date(Date.now() + TTL_MS);
+  await db.insert(pendingActionConfirms).values({
+    token,
+    productId: input.productId,
+    actionId: input.actionId,
+    channel: input.channel,
+    externalUserId: input.externalUserId ?? null,
+    params: input.params ?? null,
+    expiresAt,
+  });
+  return token;
+}
+
+export interface ConsumedPendingConfirm {
+  actionId: string;
+  productId: string;
+  params: string | Record<string, unknown> | null;
+}
+
+/**
+ * Load + delete a pending confirm by token. Returns null if missing, expired,
+ * wrong channel, or external user mismatch.
+ */
+export async function consumePendingActionConfirm(input: {
+  token: string;
+  channel: "telegram" | "discord";
+  externalUserId?: string | null;
+}): Promise<ConsumedPendingConfirm | null> {
+  const now = new Date();
+  const [row] = await db
+    .select({
+      id: pendingActionConfirms.id,
+      actionId: pendingActionConfirms.actionId,
+      productId: pendingActionConfirms.productId,
+      params: pendingActionConfirms.params,
+      externalUserId: pendingActionConfirms.externalUserId,
+      channel: pendingActionConfirms.channel,
+    })
+    .from(pendingActionConfirms)
+    .where(
+      and(
+        eq(pendingActionConfirms.token, input.token),
+        eq(pendingActionConfirms.channel, input.channel),
+        gt(pendingActionConfirms.expiresAt, now),
+      ),
+    )
+    .limit(1);
+
+  if (!row) return null;
+
+  if (
+    row.externalUserId &&
+    input.externalUserId &&
+    row.externalUserId !== input.externalUserId
+  ) {
+    return null;
+  }
+
+  await db.delete(pendingActionConfirms).where(eq(pendingActionConfirms.id, row.id));
+
+  return {
+    actionId: row.actionId,
+    productId: row.productId,
+    params: row.params ?? null,
+  };
+}

--- a/apps/dashboard/features/products/pending-action-confirms.ts
+++ b/apps/dashboard/features/products/pending-action-confirms.ts
@@ -4,10 +4,7 @@ import { and, eq, gt, pendingActionConfirms } from "@tael/database";
 import { randomBytes } from "node:crypto";
 import { db } from "../../lib/db";
 
-export {
-  buildPendingCallbackData,
-  parseActionCallbackData,
-} from "./pending-callback";
+export { buildPendingCallbackData, parseActionCallbackData } from "./pending-callback";
 
 const TTL_MS = 15 * 60 * 1000;
 
@@ -78,11 +75,7 @@ export async function consumePendingActionConfirm(input: {
 
   if (!row) return null;
 
-  if (
-    row.externalUserId &&
-    input.externalUserId &&
-    row.externalUserId !== input.externalUserId
-  ) {
+  if (row.externalUserId && input.externalUserId && row.externalUserId !== input.externalUserId) {
     return null;
   }
 

--- a/apps/dashboard/features/products/pending-callback.ts
+++ b/apps/dashboard/features/products/pending-callback.ts
@@ -1,0 +1,34 @@
+/** Telegram callback_data: `c:<token>` (well under the 64-byte limit). */
+export function buildPendingCallbackData(token: string): string {
+  return `c:${token}`;
+}
+
+/** Parse `c:<token>` or legacy `a:<hex>:<params>` / `run_action:…`. */
+export function parseActionCallbackData(data: string):
+  | { kind: "pending"; token: string }
+  | { kind: "legacy"; actionIdHex: string; paramsStr: string }
+  | null {
+  if (data.startsWith("c:")) {
+    const token = data.slice(2).trim();
+    if (!token) return null;
+    return { kind: "pending", token };
+  }
+
+  if (data.startsWith("a:")) {
+    const parts = data.slice(2).split(":");
+    const actionIdHex = parts[0] ?? "";
+    const paramsStr = parts.slice(1).join(":");
+    if (!actionIdHex) return null;
+    return { kind: "legacy", actionIdHex, paramsStr };
+  }
+
+  if (data.startsWith("run_action:")) {
+    const parts = data.split(":");
+    const actionIdHex = (parts[1] ?? "").replace(/-/g, "");
+    const paramsStr = parts.slice(2).join(":");
+    if (!actionIdHex) return null;
+    return { kind: "legacy", actionIdHex, paramsStr };
+  }
+
+  return null;
+}

--- a/apps/dashboard/features/products/pending-callback.ts
+++ b/apps/dashboard/features/products/pending-callback.ts
@@ -4,7 +4,9 @@ export function buildPendingCallbackData(token: string): string {
 }
 
 /** Parse `c:<token>` or legacy `a:<hex>:<params>` / `run_action:…`. */
-export function parseActionCallbackData(data: string):
+export function parseActionCallbackData(
+  data: string,
+):
   | { kind: "pending"; token: string }
   | { kind: "legacy"; actionIdHex: string; paramsStr: string }
   | null {

--- a/apps/dashboard/features/products/run-product-action.ts
+++ b/apps/dashboard/features/products/run-product-action.ts
@@ -4,6 +4,7 @@ import { and, eq, productActions, products } from "@tael/database";
 import { db } from "../../lib/db";
 import { runCapability, type RunResult } from "../agents/run-capability";
 import { getCurrentUser } from "../capabilities/current-user";
+import { resolveCapabilityRef, toCapabilityRequest } from "./capability-call";
 
 const FETCH_TIMEOUT_MS = 15_000;
 
@@ -51,7 +52,7 @@ export async function runProductAction(input: {
   /** Required for capability actions: the Card that pays. */
   agentId?: string;
   /** Params from the confirm proposal. */
-  params?: string | Record<string, unknown>;
+  params?: string | Record<string, unknown> | null;
   /**
    * When set (Telegram/Discord channel link), pay as this user instead of
    * requiring the product owner session.
@@ -92,24 +93,24 @@ export async function runProductAction(input: {
       if (!agentId) return { ok: false, error: "Pick a Card to pay for this run." };
     }
 
-    const slug = "slug" in row.config ? row.config.slug : "";
-    if (!slug) return { ok: false, error: "Action is misconfigured." };
+    if (!("slug" in row.config) || !row.config.slug) {
+      return { ok: false, error: "Action is misconfigured." };
+    }
 
-    const paramsStr =
-      typeof input.params === "string"
-        ? input.params
-        : input.params
-          ? JSON.stringify(input.params)
-          : undefined;
-    const looksJson = !!paramsStr?.trim().startsWith("{");
-    // Default to GET with query; JSON body → POST.
-    const method = looksJson ? "POST" : "GET";
+    const ref = resolveCapabilityRef({
+      slug: row.config.slug,
+      operation: row.config.operation,
+    });
+    if (!ref.slug) return { ok: false, error: "Action is misconfigured." };
+
+    const call = toCapabilityRequest(input.params);
     const result: RunResult = await runCapability({
       agentId,
-      slug,
-      method,
-      body: looksJson ? paramsStr : undefined,
-      query: !looksJson ? paramsStr : undefined,
+      slug: ref.slug,
+      operation: ref.operation,
+      method: call.method,
+      body: call.body,
+      query: call.query,
       ownerId: payerUserId,
     });
     return {

--- a/apps/dashboard/features/products/telegram-action-callback.ts
+++ b/apps/dashboard/features/products/telegram-action-callback.ts
@@ -1,15 +1,20 @@
 import { getEnabledActionForPublicKey, runProductAction } from "./run-product-action";
 import { getTelegramChannelLink } from "./channel-links";
 import {
+  consumePendingActionConfirm,
+} from "./pending-action-confirms";
+import { parseActionCallbackData } from "./pending-callback";
+import {
   answerTelegramCallbackQuery,
   editTelegramMessageText,
   type TelegramCallbackQuery,
 } from "./telegram";
 
-/** Reconstructs UUID from 32-hex actionId in callback_data. */
+/** Reconstructs UUID from 32-hex actionId in legacy callback_data. */
 function parseCallbackActionId(rawHex: string): string {
-  if (rawHex.length !== 32) return rawHex;
-  return `${rawHex.slice(0, 8)}-${rawHex.slice(8, 12)}-${rawHex.slice(12, 16)}-${rawHex.slice(16, 20)}-${rawHex.slice(20)}`;
+  const hex = rawHex.replace(/-/g, "");
+  if (hex.length !== 32) return rawHex;
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 /** Handle action-confirm button clicks. Returns true if handled. */
@@ -25,39 +30,49 @@ export async function handleTelegramActionCallback(input: {
   const messageId = cb.message?.message_id;
   const telegramUserId = cb.from?.id != null ? String(cb.from.id) : null;
 
-  if ((!data.startsWith("a:") && !data.startsWith("run_action:")) || !chatId || !messageId) {
+  const parsed = parseActionCallbackData(data);
+  if (!parsed || !chatId || !messageId) {
     await answerTelegramCallbackQuery(token, cb.id);
     return true;
   }
 
-  let actionId: string;
-  let paramsStr: string;
-
-  if (data.startsWith("a:")) {
-    const parts = data.slice(2).split(":");
-    actionId = parseCallbackActionId(parts[0] ?? "");
-    paramsStr = parts.slice(1).join(":");
-  } else {
-    const parts = data.split(":");
-    actionId = parts[1] ?? "";
-    paramsStr = parts.slice(2).join(":");
-  }
-
   await answerTelegramCallbackQuery(token, cb.id, "Running action...");
+
+  let actionId: string;
+  let actionParams: string | Record<string, unknown> | null | undefined;
+
+  if (parsed.kind === "pending") {
+    const pending = await consumePendingActionConfirm({
+      token: parsed.token,
+      channel: "telegram",
+      externalUserId: telegramUserId,
+    });
+    if (!pending || pending.productId !== productId) {
+      await editTelegramMessageText(
+        token,
+        chatId,
+        messageId,
+        "This confirmation expired. Ask again to get a new button.",
+      );
+      return true;
+    }
+    actionId = pending.actionId;
+    actionParams = pending.params;
+  } else {
+    actionId = parseCallbackActionId(parsed.actionIdHex);
+    if (parsed.paramsStr) {
+      try {
+        actionParams = JSON.parse(parsed.paramsStr) as Record<string, unknown>;
+      } catch {
+        actionParams = parsed.paramsStr;
+      }
+    }
+  }
 
   const check = await getEnabledActionForPublicKey(publicKey, actionId);
   if (!check.ok) {
     await editTelegramMessageText(token, chatId, messageId, `Action failed: ${check.error}`);
     return true;
-  }
-
-  let parsedParams: Record<string, unknown> | undefined;
-  if (paramsStr) {
-    try {
-      parsedParams = JSON.parse(paramsStr);
-    } catch {
-      parsedParams = { value: paramsStr };
-    }
   }
 
   const link = telegramUserId ? await getTelegramChannelLink(productId, telegramUserId) : null;
@@ -73,21 +88,27 @@ export async function handleTelegramActionCallback(input: {
 
   const res = await runProductAction({
     actionId: check.actionId,
-    params: parsedParams ?? paramsStr,
+    params: actionParams,
     payerUserId: link.userId,
     agentId: link.agentId,
   });
 
   if (res.ok) {
     const paid = res.paid ? `\nPaid: ${res.paid} USDC` : "";
-    const proof = res.txHash ? `\nTx: \`${res.txHash}\`` : "";
-    const output = res.body ? `\n\n\`\`\`\n${res.body.slice(0, 1500)}\n\`\`\`` : "";
+    const proof = res.txHash ? `\nTx: <code>${res.txHash}</code>` : "";
+    const safeBody = res.body
+      ? `\n\n<pre>${res.body
+          .slice(0, 1500)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")}</pre>`
+      : "";
     await editTelegramMessageText(
       token,
       chatId,
       messageId,
-      `Action executed successfully!${paid}${proof}${output}`,
-      { parseMode: "Markdown" },
+      `Action executed successfully!${paid}${proof}${safeBody}`,
+      { parseMode: "HTML" },
     );
   } else {
     await editTelegramMessageText(

--- a/apps/dashboard/features/products/telegram-action-callback.ts
+++ b/apps/dashboard/features/products/telegram-action-callback.ts
@@ -1,8 +1,6 @@
 import { getEnabledActionForPublicKey, runProductAction } from "./run-product-action";
 import { getTelegramChannelLink } from "./channel-links";
-import {
-  consumePendingActionConfirm,
-} from "./pending-action-confirms";
+import { consumePendingActionConfirm } from "./pending-action-confirms";
 import { parseActionCallbackData } from "./pending-callback";
 import {
   answerTelegramCallbackQuery,

--- a/apps/dashboard/features/products/telegram-html.ts
+++ b/apps/dashboard/features/products/telegram-html.ts
@@ -1,0 +1,37 @@
+/**
+ * Convert light Markdown (what LLMs usually emit) into Telegram HTML.
+ * Telegram's legacy Markdown parse mode often fails on `**bold**` and falls
+ * back to plain text — HTML is more reliable.
+ */
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Escape then apply a small set of Markdown → HTML transforms.
+ * Unsupported Markdown is left as visible text (already escaped).
+ */
+export function markdownToTelegramHtml(input: string): string {
+  const escaped = escapeHtml(input);
+
+  // Fenced code blocks first (greedy non-nested).
+  let out = escaped.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, (_m, code: string) => {
+    return `<pre>${code.replace(/^\n+|\n+$/g, "")}</pre>`;
+  });
+
+  // Inline code
+  out = out.replace(/`([^`\n]+)`/g, (_m, code: string) => `<code>${code}</code>`);
+
+  // Bold **text** or __text__
+  out = out.replace(/\*\*([^*]+)\*\*/g, "<b>$1</b>");
+  out = out.replace(/__([^_]+)__/g, "<b>$1</b>");
+
+  // Italic *text* (single asterisk, not part of **)
+  out = out.replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, "$1<i>$2</i>");
+
+  // Links [label](url) — only http(s)
+  out = out.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, '<a href="$2">$1</a>');
+
+  return out;
+}

--- a/apps/dashboard/features/products/train-actions-panel.tsx
+++ b/apps/dashboard/features/products/train-actions-panel.tsx
@@ -33,7 +33,9 @@ const KIND_META: Record<ProductAction["kind"], { label: string; icon: typeof Zap
 
 function configSummary(item: ProductAction): string {
   if (item.kind === "capability" && "slug" in item.config) {
-    return item.config.slug;
+    return item.config.operation
+      ? `${item.config.slug}/${item.config.operation}`
+      : item.config.slug;
   }
   if (item.kind === "http" && "url" in item.config) {
     return `${item.config.method} ${item.config.url}`;

--- a/apps/dashboard/features/products/widget-chat.ts
+++ b/apps/dashboard/features/products/widget-chat.ts
@@ -169,7 +169,7 @@ export function buildWidgetSystemPrompt(
             return `- ${a.name} (${a.kind})${suffix}: ${a.description}`;
           }),
           "",
-          "For capability actions that need inputs (e.g. Pay: destination + amount), put them in the tool `params` as a JSON object like {\"to\":\"G…\",\"amount\":\"0.05\"} or as a query string to=G…&amount=0.05.",
+          'For capability actions that need inputs (e.g. Pay: destination + amount), put them in the tool `params` as a JSON object like {"to":"G…","amount":"0.05"} or as a query string to=G…&amount=0.05.',
         ]
       : [];
 
@@ -181,7 +181,7 @@ export function buildWidgetSystemPrompt(
         'Never start a reply with a canned greeting like "How can I help you?" unless this is the first message and that phrase is the configured opening greeting.',
       ]
     : [
-        "This is a continuing conversation. Do NOT greet. Do NOT say hello, hi, or \"How can I help you?\". Answer the user's latest message directly.",
+        'This is a continuing conversation. Do NOT greet. Do NOT say hello, hi, or "How can I help you?". Answer the user\'s latest message directly.',
       ];
 
   const parts = [

--- a/apps/dashboard/features/products/widget-chat.ts
+++ b/apps/dashboard/features/products/widget-chat.ts
@@ -64,7 +64,7 @@ export function buildWidgetTools(actions: ProductAction[]): WidgetToolDef[] {
         description:
           action.kind === "http"
             ? "Optional JSON object of parameters to send with the HTTP request."
-            : "Optional parameters for the capability (query string or JSON), if any are needed.",
+            : 'Parameters for the capability. Prefer a JSON object string like {"to":"G…","amount":"0.05"} for Pay, or a query string to=G…&amount=0.05.',
       },
     };
     return {
@@ -142,30 +142,56 @@ export function buildWidgetSystemPrompt(
   product: Product,
   content: ProductContent[],
   actions: ProductAction[] = [],
+  options?: {
+    /** When false, never open with a greeting (Telegram mid-chat turns). */
+    allowGreeting?: boolean;
+  },
 ): string {
   const knowledge = formatContentForPrompt(content, CONTENT_BUDGET_CHARS);
   const description = product.description.trim();
   const greeting = product.greeting.trim();
+  const allowGreeting = options?.allowGreeting !== false;
 
   const actionLines =
     actions.length > 0
       ? [
           "",
           "## Available actions",
-          "You can propose the following actions via tools when they clearly help the user. Do not claim an action already ran: proposing returns a confirmation the user must approve first.",
-          ...actions.map((a) => `- ${a.name} (${a.kind}): ${a.description}`),
+          "You can propose ONLY the following product actions via tools when they clearly help the user. Do not invent other capabilities. Do not claim an action already ran: proposing returns a confirmation the user must approve first.",
+          ...actions.map((a) => {
+            const slug =
+              a.kind === "capability" && "slug" in a.config
+                ? a.config.operation
+                  ? `${a.config.slug}/${a.config.operation}`
+                  : a.config.slug
+                : null;
+            const suffix = slug ? ` [capability: ${slug}]` : "";
+            return `- ${a.name} (${a.kind})${suffix}: ${a.description}`;
+          }),
+          "",
+          "For capability actions that need inputs (e.g. Pay: destination + amount), put them in the tool `params` as a JSON object like {\"to\":\"G…\",\"amount\":\"0.05\"} or as a query string to=G…&amount=0.05.",
         ]
       : [];
 
+  const greetingLines = allowGreeting
+    ? [
+        greeting
+          ? `Opening greeting (use ONLY on the very first reply in a new conversation, or when the user says /start). Do not repeat it on later messages. Spirit: "${greeting}"`
+          : null,
+        'Never start a reply with a canned greeting like "How can I help you?" unless this is the first message and that phrase is the configured opening greeting.',
+      ]
+    : [
+        "This is a continuing conversation. Do NOT greet. Do NOT say hello, hi, or \"How can I help you?\". Answer the user's latest message directly.",
+      ];
+
   const parts = [
-    `You are the on-site assistant for ${product.name}.`,
+    `You are the product assistant for ${product.name}. Speak as this product's own agent — helpful, concise, and on-brand — not as a generic marketplace or Stellar capability catalog.`,
     description ? `About this product: ${description}` : null,
-    greeting
-      ? `Opening greeting (use ONLY on the very first reply in a new conversation, or when the user says /start). Do not repeat it on later messages. Spirit: "${greeting}"`
-      : null,
-    "Never start a reply with a canned greeting like \"How can I help you?\" unless this is the first message and that phrase is the configured opening greeting.",
+    ...greetingLines,
     "",
-    "Answer using only the product knowledge below. If the answer is not in that knowledge, say you do not know based on the information you have. Do not invent facts, prices, or policies. Keep replies concise and helpful.",
+    "Answer using only the product knowledge below. If the answer is not in that knowledge, say you do not know based on the information you have. Do not invent facts, prices, or policies.",
+    "Do not dump Free/Priced/On-chain capability menus, marketplace listings, or unrelated Stellar operation catalogs unless the product knowledge explicitly contains that and the user asked for it.",
+    "Keep replies concise. Prefer short sentences over bullet catalogs.",
     "",
     "## Product knowledge",
     knowledge || "(No content has been added yet. Say you do not have product information yet.)",

--- a/packages/database/drizzle/0018_pending_action_confirms.sql
+++ b/packages/database/drizzle/0018_pending_action_confirms.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "pending_action_confirms" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"token" text NOT NULL,
+	"product_id" uuid NOT NULL,
+	"action_id" uuid NOT NULL,
+	"channel" text NOT NULL,
+	"external_user_id" text,
+	"params" jsonb,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "pending_action_confirms" ADD CONSTRAINT "pending_action_confirms_product_id_products_id_fk" FOREIGN KEY ("product_id") REFERENCES "public"."products"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "pending_action_confirms" ADD CONSTRAINT "pending_action_confirms_action_id_product_actions_id_fk" FOREIGN KEY ("action_id") REFERENCES "public"."product_actions"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "pending_action_confirms_token_uidx" ON "pending_action_confirms" USING btree ("token");
+--> statement-breakpoint
+CREATE INDEX "pending_action_confirms_product_id_idx" ON "pending_action_confirms" USING btree ("product_id");
+--> statement-breakpoint
+CREATE INDEX "pending_action_confirms_expires_at_idx" ON "pending_action_confirms" USING btree ("expires_at");

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1787479200000,
       "tag": "0017_channel_links",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1787546400000,
+      "tag": "0018_pending_action_confirms",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -10,5 +10,6 @@ export * from "./api-keys";
 export * from "./reviews";
 export * from "./products";
 export * from "./channel-links";
+export * from "./pending-action-confirms";
 export * from "./relations";
 export * from "./chat";

--- a/packages/database/src/schema/pending-action-confirms.ts
+++ b/packages/database/src/schema/pending-action-confirms.ts
@@ -1,0 +1,39 @@
+import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { primaryId, timestamps } from "./_shared";
+import { productActions, products } from "./products";
+
+/**
+ * Short-lived server-side params for Telegram/Discord confirm buttons.
+ * Telegram callback_data is capped at 64 bytes, so full Pay params (Stellar
+ * addresses) cannot fit in the button — only a short token is embedded.
+ */
+export const pendingActionConfirms = pgTable(
+  "pending_action_confirms",
+  {
+    id: primaryId(),
+    /** Short opaque token placed in callback_data / custom_id. */
+    token: text("token").notNull(),
+    productId: uuid("product_id")
+      .notNull()
+      .references(() => products.id, { onDelete: "cascade" }),
+    actionId: uuid("action_id")
+      .notNull()
+      .references(() => productActions.id, { onDelete: "cascade" }),
+    /** "telegram" | "discord" */
+    channel: text("channel").notNull(),
+    /** Telegram from.id / Discord snowflake — confirm must match. */
+    externalUserId: text("external_user_id"),
+    /** Params the model filled (query string, JSON object, or string). */
+    params: jsonb("params").$type<string | Record<string, unknown> | null>(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    ...timestamps,
+  },
+  (t) => [
+    uniqueIndex("pending_action_confirms_token_uidx").on(t.token),
+    index("pending_action_confirms_product_id_idx").on(t.productId),
+    index("pending_action_confirms_expires_at_idx").on(t.expiresAt),
+  ],
+);
+
+export type PendingActionConfirm = typeof pendingActionConfirms.$inferSelect;
+export type NewPendingActionConfirm = typeof pendingActionConfirms.$inferInsert;

--- a/packages/database/src/schema/products.ts
+++ b/packages/database/src/schema/products.ts
@@ -22,11 +22,13 @@ export const productActionKind = pgEnum("product_action_kind", ["capability", "h
 
 /**
  * Config for a product action. Discriminated by `kind` on the row:
- *  - capability → `{ slug }`
+ *  - capability → `{ slug, operation? }` (e.g. slug `stellar` + operation `pay`,
+ *    or combined slug `stellar/pay`)
  *  - http → `{ url, method, paramsSchema? }`
  */
 export type ProductActionConfig =
-  { slug: string } | { url: string; method: string; paramsSchema?: Record<string, unknown> };
+  | { slug: string; operation?: string }
+  | { url: string; method: string; paramsSchema?: Record<string, unknown> };
 
 /**
  * One product tenant: an embeddable agent configured by a product owner.

--- a/packages/database/src/schema/relations.ts
+++ b/packages/database/src/schema/relations.ts
@@ -8,6 +8,7 @@ import { apiKeys } from "./api-keys";
 import { chatThreads, chatMessages } from "./chat";
 import { products, productContent, productActions } from "./products";
 import { channelLinks } from "./channel-links";
+import { pendingActionConfirms } from "./pending-action-confirms";
 
 // Typed relations enable Drizzle's relational query API (db.query.users.findMany
 // with `with: { wallets: true }`, etc.) without hand-written joins.
@@ -61,18 +62,31 @@ export const productsRelations = relations(products, ({ one, many }) => ({
   content: many(productContent),
   actions: many(productActions),
   channelLinks: many(channelLinks),
+  pendingActionConfirms: many(pendingActionConfirms),
 }));
 
 export const productContentRelations = relations(productContent, ({ one }) => ({
   product: one(products, { fields: [productContent.productId], references: [products.id] }),
 }));
 
-export const productActionsRelations = relations(productActions, ({ one }) => ({
+export const productActionsRelations = relations(productActions, ({ one, many }) => ({
   product: one(products, { fields: [productActions.productId], references: [products.id] }),
+  pendingConfirms: many(pendingActionConfirms),
 }));
 
 export const channelLinksRelations = relations(channelLinks, ({ one }) => ({
   user: one(users, { fields: [channelLinks.userId], references: [users.id] }),
   agent: one(agents, { fields: [channelLinks.agentId], references: [agents.id] }),
   product: one(products, { fields: [channelLinks.productId], references: [products.id] }),
+}));
+
+export const pendingActionConfirmsRelations = relations(pendingActionConfirms, ({ one }) => ({
+  product: one(products, {
+    fields: [pendingActionConfirms.productId],
+    references: [products.id],
+  }),
+  action: one(productActions, {
+    fields: [pendingActionConfirms.actionId],
+    references: [productActions.id],
+  }),
 }));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Telegram Pay failed because confirm buttons stuffed full Stellar addresses into Telegram’s **64-byte** `callback_data`. Also fixed product-agent voice (catalog dumps), greeting-every-message on single-turn webhooks, and raw `**markdown**` that Telegram dropped.

## Changes

- **Pending confirms store** (`pending_action_confirms`): save params server-side; button only carries `c:<token>`
- **Capability call**: flat JSON `{ to, amount }` → GET query; support `slug` + optional `operation` (or `stellar/pay`)
- **Product prompt**: speak as the product agent; greet only on `/start` for Telegram
- **Telegram HTML**: convert light markdown → HTML so bold/code render
- Discord confirm buttons use the same pending-token path

## Ops

1. ~~Run migration `0018` on prod~~ (done)
2. **Merge this PR** → Vercel deploys dashboard to mainnet
3. Studio Pay action: slug `stellar/pay` **or** slug `stellar` + operation `pay`
4. Retest: `/connect` → pay → Confirm

## Type of change

- [x] Feature
- [x] Fix

## Checklist

- [x] Format / typecheck fixed for CI
- [x] Helper selfcheck for capability-call / telegram-html / pending-callback

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

