### PR TITLE
Added: Discord DM wallet connect and DM-only paid actions

### DIFF
--- a/apps/dashboard/app/api/connect/discord/complete/route.ts
+++ b/apps/dashboard/app/api/connect/discord/complete/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getCurrentUser } from "../../../../../features/capabilities/current-user";
+import { upsertDiscordChannelLink } from "../../../../../features/products/channel-links";
+import { verifyDiscordConnectToken } from "../../../../../lib/connect-token";
+
+export const runtime = "nodejs";
+
+const bodySchema = z.object({
+  token: z.string().min(1),
+  agentId: z.string().uuid(),
+});
+
+/** Complete Discord wallet connect: bind discord user → signed-in user + Card. */
+export async function POST(request: Request) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const raw = (await request.json().catch(() => null)) as unknown;
+  const parsed = bodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request." }, { status: 400 });
+  }
+
+  let connect;
+  try {
+    connect = await verifyDiscordConnectToken(parsed.data.token);
+  } catch {
+    return NextResponse.json(
+      { error: "This connect link expired. Run /connect in Discord again." },
+      { status: 400 },
+    );
+  }
+
+  const result = await upsertDiscordChannelLink({
+    productId: connect.productId,
+    discordUserId: connect.externalUserId,
+    userId: user.id,
+    agentId: parsed.data.agentId,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    productName: connect.productName,
+    walletAddress: user.walletAddress,
+  });
+}

--- a/apps/dashboard/app/api/widget/[publicKey]/discord/route.ts
+++ b/apps/dashboard/app/api/widget/[publicKey]/discord/route.ts
@@ -7,6 +7,7 @@ import {
   DISCORD_INTERACTION_MESSAGE_COMPONENT,
   DISCORD_INTERACTION_PING,
   getDiscordOptionString,
+  isDiscordDm,
   verifyDiscordRequest,
   type DiscordInteraction,
 } from "../../../../../features/products/discord";
@@ -14,6 +15,7 @@ import {
   handleDiscordActionConfirm,
   handleDiscordAsk,
 } from "../../../../../features/products/discord-chat";
+import { handleDiscordWalletCommand } from "../../../../../features/products/discord-wallet-commands";
 import { createRateLimiter } from "../../../../../features/products/widget-chat";
 
 export const runtime = "nodejs";
@@ -33,6 +35,11 @@ export async function POST(request: Request, context: { params: Promise<{ public
   const publicKey = decodeURIComponent(rawKey ?? "").trim();
   if (!publicKey) return new Response("Missing public key.", { status: 400 });
 
+  // Read body first so signature verify can start ASAP after product lookup.
+  const signature = request.headers.get("x-signature-ed25519");
+  const timestamp = request.headers.get("x-signature-timestamp");
+  const rawBody = await request.text();
+
   const product = await getProductByPublicKey(publicKey);
   if (!product) return new Response("Agent not found.", { status: 404 });
 
@@ -49,10 +56,6 @@ export async function POST(request: Request, context: { params: Promise<{ public
     });
   }
 
-  const signature = request.headers.get("x-signature-ed25519");
-  const timestamp = request.headers.get("x-signature-timestamp");
-  const rawBody = await request.text();
-
   if (
     !signature ||
     !timestamp ||
@@ -68,6 +71,7 @@ export async function POST(request: Request, context: { params: Promise<{ public
     return new Response("Invalid payload.", { status: 400 });
   }
 
+  // Discord requires PONG within ~3s when saving the Interactions URL.
   if (interaction.type === DISCORD_INTERACTION_PING) {
     return jsonResponse({ type: DISCORD_CALLBACK_PONG });
   }
@@ -79,6 +83,12 @@ export async function POST(request: Request, context: { params: Promise<{ public
     });
   }
 
+  const isDm = isDiscordDm(interaction);
+  const discordUserId = interaction.member?.user?.id ?? interaction.user?.id ?? null;
+  const dashboardBase = (
+    process.env.NEXT_PUBLIC_DASHBOARD_URL ?? new URL(request.url).origin
+  ).replace(/\/$/, "");
+
   if (interaction.type === DISCORD_INTERACTION_MESSAGE_COMPONENT) {
     const customId = interaction.data?.custom_id ?? "";
     if (!customId.startsWith("c:")) {
@@ -89,7 +99,6 @@ export async function POST(request: Request, context: { params: Promise<{ public
     }
 
     const pendingToken = customId.slice(2).trim();
-    const discordUserId = interaction.member?.user?.id ?? interaction.user?.id ?? null;
 
     after(() =>
       handleDiscordActionConfirm(
@@ -99,13 +108,31 @@ export async function POST(request: Request, context: { params: Promise<{ public
         interaction.token,
         pendingToken,
         discordUserId,
+        isDm,
       ),
     );
     return jsonResponse({ type: DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE });
   }
 
   if (interaction.type === DISCORD_INTERACTION_APPLICATION_COMMAND) {
-    if (interaction.data?.name !== "ask") {
+    const commandName = interaction.data?.name ?? "";
+
+    if (commandName === "connect" || commandName === "wallet" || commandName === "disconnect") {
+      after(() =>
+        handleDiscordWalletCommand({
+          applicationId,
+          interactionToken: interaction.token,
+          command: commandName,
+          discordUserId,
+          product,
+          dashboardBase,
+          isDm,
+        }),
+      );
+      return jsonResponse({ type: DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE });
+    }
+
+    if (commandName !== "ask") {
       return jsonResponse({
         type: 4,
         data: { content: "Unknown command.", flags: 64 },
@@ -120,7 +147,7 @@ export async function POST(request: Request, context: { params: Promise<{ public
       });
     }
 
-    const userId = interaction.member?.user?.id ?? interaction.user?.id ?? "anon";
+    const userId = discordUserId ?? "anon";
     if (!allowRequest(`${publicKey}:${userId}`)) {
       return jsonResponse({
         type: 4,
@@ -128,7 +155,9 @@ export async function POST(request: Request, context: { params: Promise<{ public
       });
     }
 
-    after(() => handleDiscordAsk(product, applicationId, interaction.token, question, userId));
+    after(() =>
+      handleDiscordAsk(product, applicationId, interaction.token, question, discordUserId, isDm),
+    );
     return jsonResponse({ type: DISCORD_CALLBACK_DEFERRED_CHANNEL_MESSAGE });
   }
 

--- a/apps/dashboard/app/connect/discord/page.tsx
+++ b/apps/dashboard/app/connect/discord/page.tsx
@@ -1,0 +1,55 @@
+import { DiscordConnectClient } from "../../../features/connect/discord-connect-client";
+import { listCardsForPicker } from "../../../features/agents/queries";
+import { getCurrentUser } from "../../../features/capabilities/current-user";
+import { verifyDiscordConnectToken } from "../../../lib/connect-token";
+
+export const dynamic = "force-dynamic";
+
+export default async function DiscordConnectPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ t?: string }>;
+}) {
+  const { t: token } = await searchParams;
+  if (!token?.trim()) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-md items-center px-4 py-10">
+        <p className="text-sm text-muted-foreground">
+          Missing connect token. Run <span className="font-mono">/connect</span> in a DM with the
+          Discord bot and open the new link.
+        </p>
+      </main>
+    );
+  }
+
+  let connect;
+  try {
+    connect = await verifyDiscordConnectToken(token.trim());
+  } catch {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-md items-center px-4 py-10">
+        <p className="text-sm text-muted-foreground">
+          This connect link expired or is invalid. Run <span className="font-mono">/connect</span>{" "}
+          in Discord again.
+        </p>
+      </main>
+    );
+  }
+
+  const user = await getCurrentUser();
+  const cards = user ? await listCardsForPicker() : [];
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md items-center px-4 py-10">
+      <div className="w-full">
+        <DiscordConnectClient
+          token={token.trim()}
+          productName={connect.productName || "this product"}
+          signedIn={Boolean(user)}
+          walletAddress={user?.walletAddress ?? null}
+          cards={cards}
+        />
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/features/connect/channel-connect-client.tsx
+++ b/apps/dashboard/features/connect/channel-connect-client.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@tael/ui";
+import { ConnectWalletButton } from "../../features/auth/connect-wallet-button";
+import { createAgent } from "../../features/agents/actions";
+import type { CardPickerOption } from "../../features/agents/queries";
+
+interface ChannelConnectClientProps {
+  channel: "telegram" | "discord";
+  token: string;
+  productName: string;
+  signedIn: boolean;
+  walletAddress: string | null;
+  cards: CardPickerOption[];
+}
+
+const CHANNEL_LABEL: Record<"telegram" | "discord", string> = {
+  telegram: "Telegram",
+  discord: "Discord",
+};
+
+/** Shared Freighter + Card link UI for Telegram/Discord product bots. */
+export function ChannelConnectClient({
+  channel,
+  token,
+  productName,
+  signedIn,
+  walletAddress,
+  cards: initialCards,
+}: ChannelConnectClientProps) {
+  const label = CHANNEL_LABEL[channel];
+  const [cards, setCards] = useState(initialCards);
+  const [agentId, setAgentId] = useState(initialCards[0]?.id ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const redirectTo = `/connect/${channel}?t=${encodeURIComponent(token)}`;
+
+  function handleCreateCard() {
+    setError(null);
+    startTransition(async () => {
+      const res = await createAgent({
+        name: `${label} Card`,
+        maxPerCall: "5",
+        dailyLimit: "50",
+      });
+      if (!res.ok || !res.id) {
+        setError(res.error ?? "Could not create a Card.");
+        return;
+      }
+      const next = [...cards, { id: res.id, name: `${label} Card`, policy: null }];
+      setCards(next);
+      setAgentId(res.id);
+    });
+  }
+
+  function handleComplete() {
+    setError(null);
+    if (!agentId) {
+      setError("Create or select a Card first.");
+      return;
+    }
+    startTransition(async () => {
+      const res = await fetch(`/api/connect/${channel}/complete`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token, agentId }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string; ok?: boolean };
+      if (!res.ok || !data.ok) {
+        setError(data.error ?? "Could not link wallet.");
+        return;
+      }
+      setDone(true);
+    });
+  }
+
+  if (done) {
+    return (
+      <div className="space-y-3 rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-5">
+        <h1 className="text-lg font-semibold">Wallet connected</h1>
+        <p className="text-sm text-muted-foreground">
+          Your Stellar wallet is linked to{" "}
+          <span className="font-medium text-foreground">{productName}</span> on {label}. Go back to
+          the bot DM and run an action — your Card will pay.
+        </p>
+        {walletAddress ? (
+          <p className="font-mono text-xs text-muted-foreground">{walletAddress}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (!signedIn) {
+    return (
+      <div className="space-y-4 rounded-xl border p-5">
+        <div>
+          <h1 className="text-lg font-semibold">Connect wallet for {productName}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Sign in with Freighter so this {label} bot can run paid actions using your Card. Prefer
+            DMs for payments — not public channels.
+          </p>
+        </div>
+        <ConnectWalletButton redirectTo={redirectTo} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-xl border p-5">
+      <div>
+        <h1 className="text-lg font-semibold">Link Card for {productName}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Signed in as <span className="font-mono text-xs">{walletAddress}</span>. Pick the Card
+          that will pay for actions in {label} DMs.
+        </p>
+      </div>
+
+      {cards.length > 0 ? (
+        <label className="block space-y-1.5">
+          <span className="text-sm font-medium">Card</span>
+          <select
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            value={agentId}
+            onChange={(e) => setAgentId(e.target.value)}
+          >
+            {cards.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          You do not have a Card yet. Create one to pay for {label} actions.
+        </p>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        {cards.length === 0 ? (
+          <Button type="button" size="sm" onClick={handleCreateCard} disabled={pending}>
+            {pending ? "Creating…" : "Create Card"}
+          </Button>
+        ) : (
+          <Button type="button" size="sm" onClick={handleComplete} disabled={pending || !agentId}>
+            {pending ? "Linking…" : `Link to ${label}`}
+          </Button>
+        )}
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/apps/dashboard/features/connect/discord-connect-client.tsx
+++ b/apps/dashboard/features/connect/discord-connect-client.tsx
@@ -3,13 +3,13 @@
 import { ChannelConnectClient } from "./channel-connect-client";
 import type { CardPickerOption } from "../agents/queries";
 
-/** Telegram-specific wrapper around the shared channel connect UI. */
-export function TelegramConnectClient(props: {
+/** Discord-specific wrapper around the shared channel connect UI. */
+export function DiscordConnectClient(props: {
   token: string;
   productName: string;
   signedIn: boolean;
   walletAddress: string | null;
   cards: CardPickerOption[];
 }) {
-  return <ChannelConnectClient channel="telegram" {...props} />;
+  return <ChannelConnectClient channel="discord" {...props} />;
 }

--- a/apps/dashboard/features/products/actions.ts
+++ b/apps/dashboard/features/products/actions.ts
@@ -202,7 +202,7 @@ export async function connectDiscordBot(
   const applicationId = parsedClientId.data;
   const cmdResult = await registerDiscordAskCommand(cleanToken, applicationId);
   if (!cmdResult.ok) {
-    return { ok: false, error: cmdResult.error ?? "Could not register /ask command." };
+    return { ok: false, error: cmdResult.error ?? "Could not register Discord commands." };
   }
 
   const interactionsUrl = `${baseUrl.replace(/\/$/, "")}/api/widget/${encodeURIComponent(product.publicKey)}/discord`;

--- a/apps/dashboard/features/products/channel-links.ts
+++ b/apps/dashboard/features/products/channel-links.ts
@@ -8,10 +8,10 @@ export interface ResolvedChannelLink {
   agentId: string;
 }
 
-/** Look up a Telegram user's linked Card for a product bot. */
-export async function getTelegramChannelLink(
+async function getChannelLink(
+  channel: "telegram" | "discord",
   productId: string,
-  telegramUserId: string,
+  externalUserId: string,
 ): Promise<ResolvedChannelLink | null> {
   const [row] = await db
     .select({
@@ -21,9 +21,9 @@ export async function getTelegramChannelLink(
     .from(channelLinks)
     .where(
       and(
-        eq(channelLinks.channel, "telegram"),
+        eq(channelLinks.channel, channel),
         eq(channelLinks.productId, productId),
-        eq(channelLinks.externalUserId, telegramUserId),
+        eq(channelLinks.externalUserId, externalUserId),
       ),
     )
     .limit(1);
@@ -32,10 +32,10 @@ export async function getTelegramChannelLink(
   return { userId: row.userId, agentId: row.agentId };
 }
 
-/** Upsert Telegram → user + Card link for a product. Verifies Card ownership. */
-export async function upsertTelegramChannelLink(input: {
+async function upsertChannelLink(input: {
+  channel: "telegram" | "discord";
   productId: string;
-  telegramUserId: string;
+  externalUserId: string;
   userId: string;
   agentId: string;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
@@ -47,7 +47,7 @@ export async function upsertTelegramChannelLink(input: {
 
   if (!card) return { ok: false, error: "That Card does not belong to you." };
 
-  const existing = await getTelegramChannelLink(input.productId, input.telegramUserId);
+  const existing = await getChannelLink(input.channel, input.productId, input.externalUserId);
   if (existing) {
     await db
       .update(channelLinks)
@@ -58,16 +58,16 @@ export async function upsertTelegramChannelLink(input: {
       })
       .where(
         and(
-          eq(channelLinks.channel, "telegram"),
+          eq(channelLinks.channel, input.channel),
           eq(channelLinks.productId, input.productId),
-          eq(channelLinks.externalUserId, input.telegramUserId),
+          eq(channelLinks.externalUserId, input.externalUserId),
         ),
       );
   } else {
     await db.insert(channelLinks).values({
-      channel: "telegram",
+      channel: input.channel,
       productId: input.productId,
-      externalUserId: input.telegramUserId,
+      externalUserId: input.externalUserId,
       userId: input.userId,
       agentId: input.agentId,
     });
@@ -76,18 +76,82 @@ export async function upsertTelegramChannelLink(input: {
   return { ok: true };
 }
 
-/** Remove a Telegram link for this product. */
-export async function deleteTelegramChannelLink(
+async function deleteChannelLink(
+  channel: "telegram" | "discord",
   productId: string,
-  telegramUserId: string,
+  externalUserId: string,
 ): Promise<void> {
   await db
     .delete(channelLinks)
     .where(
       and(
-        eq(channelLinks.channel, "telegram"),
+        eq(channelLinks.channel, channel),
         eq(channelLinks.productId, productId),
-        eq(channelLinks.externalUserId, telegramUserId),
+        eq(channelLinks.externalUserId, externalUserId),
       ),
     );
+}
+
+/** Look up a Telegram user's linked Card for a product bot. */
+export async function getTelegramChannelLink(
+  productId: string,
+  telegramUserId: string,
+): Promise<ResolvedChannelLink | null> {
+  return getChannelLink("telegram", productId, telegramUserId);
+}
+
+/** Upsert Telegram → user + Card link for a product. Verifies Card ownership. */
+export async function upsertTelegramChannelLink(input: {
+  productId: string;
+  telegramUserId: string;
+  userId: string;
+  agentId: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  return upsertChannelLink({
+    channel: "telegram",
+    productId: input.productId,
+    externalUserId: input.telegramUserId,
+    userId: input.userId,
+    agentId: input.agentId,
+  });
+}
+
+/** Remove a Telegram link for this product. */
+export async function deleteTelegramChannelLink(
+  productId: string,
+  telegramUserId: string,
+): Promise<void> {
+  return deleteChannelLink("telegram", productId, telegramUserId);
+}
+
+/** Look up a Discord user's linked Card for a product bot. */
+export async function getDiscordChannelLink(
+  productId: string,
+  discordUserId: string,
+): Promise<ResolvedChannelLink | null> {
+  return getChannelLink("discord", productId, discordUserId);
+}
+
+/** Upsert Discord → user + Card link for a product. Verifies Card ownership. */
+export async function upsertDiscordChannelLink(input: {
+  productId: string;
+  discordUserId: string;
+  userId: string;
+  agentId: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  return upsertChannelLink({
+    channel: "discord",
+    productId: input.productId,
+    externalUserId: input.discordUserId,
+    userId: input.userId,
+    agentId: input.agentId,
+  });
+}
+
+/** Remove a Discord link for this product. */
+export async function deleteDiscordChannelLink(
+  productId: string,
+  discordUserId: string,
+): Promise<void> {
+  return deleteChannelLink("discord", productId, discordUserId);
 }

--- a/apps/dashboard/features/products/discord-chat.ts
+++ b/apps/dashboard/features/products/discord-chat.ts
@@ -3,6 +3,7 @@ import { createLlmChatCompletion, getLlmConfig } from "../../lib/llm";
 import { getProductActionsForChat, getProductContentForChat } from "./queries";
 import { editDiscordInteractionResponse } from "./discord";
 import { createPendingActionConfirm, consumePendingActionConfirm } from "./pending-action-confirms";
+import { getDiscordChannelLink } from "./channel-links";
 import { getEnabledActionForPublicKey, runProductAction } from "./run-product-action";
 import {
   actionIdFromToolName,
@@ -83,8 +84,18 @@ export async function handleDiscordActionConfirm(
   applicationId: string,
   interactionToken: string,
   pendingToken: string,
-  discordUserId?: string | null,
+  discordUserId: string | null | undefined,
+  isDm: boolean,
 ): Promise<void> {
+  if (!isDm) {
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      "Paid actions only run in DMs. Message this bot privately, `/connect`, then try again.",
+    );
+    return;
+  }
+
   const pending = await consumePendingActionConfirm({
     token: pendingToken,
     channel: "discord",
@@ -94,7 +105,7 @@ export async function handleDiscordActionConfirm(
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
-      "This confirmation expired. Ask again to get a new button.",
+      "This confirmation expired. Ask again in a DM to get a new button.",
     );
     return;
   }
@@ -109,17 +120,40 @@ export async function handleDiscordActionConfirm(
     return;
   }
 
-  const res = await runProductAction({
-    actionId: check.actionId,
-    params: pending.params,
-  });
-
-  if (res.ok) {
-    const output = res.body ? `\n\`\`\`\n${res.body.slice(0, 1500)}\n\`\`\`` : "";
+  if (!discordUserId) {
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
-      `Action executed successfully.${output}`,
+      "Could not identify your Discord user.",
+    );
+    return;
+  }
+
+  const link = await getDiscordChannelLink(productId, discordUserId);
+  if (!link) {
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      "Connect your wallet first. In this DM run `/connect`, open the link, then try again.",
+    );
+    return;
+  }
+
+  const res = await runProductAction({
+    actionId: check.actionId,
+    params: pending.params,
+    payerUserId: link.userId,
+    agentId: link.agentId,
+  });
+
+  if (res.ok) {
+    const paid = res.paid ? `\nPaid: ${res.paid} USDC` : "";
+    const proof = res.txHash ? `\nTx: \`${res.txHash}\`` : "";
+    const output = res.body ? `\n\`\`\`\n${res.body.slice(0, 1200)}\n\`\`\`` : "";
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      `Action executed successfully!${paid}${proof}${output}`,
     );
     return;
   }
@@ -136,7 +170,8 @@ export async function handleDiscordAsk(
   applicationId: string,
   interactionToken: string,
   question: string,
-  discordUserId?: string | null,
+  discordUserId: string | null | undefined,
+  isDm: boolean,
 ): Promise<void> {
   const llm = getLlmConfig();
   if (!llm) {
@@ -153,7 +188,6 @@ export async function handleDiscordAsk(
     getProductActionsForChat(product.id),
   ]);
 
-  // Each /ask is single-turn — never open with a canned greeting.
   const system = buildWidgetSystemPrompt(product, content, actions, {
     allowGreeting: false,
   });
@@ -203,6 +237,38 @@ export async function handleDiscordAsk(
 
           const args = safeParseArgs(call.function.arguments);
           const proposed = proposeWidgetAction(action, args);
+
+          // Paid capability actions: DMs only + linked wallet.
+          if (action.kind === "capability") {
+            if (!isDm) {
+              await editDiscordInteractionResponse(
+                applicationId,
+                interactionToken,
+                `${proposed.reply}\n\n**Paid actions are DM-only.** Message this bot privately → \`/connect\` → then \`/ask\` again in the DM.`,
+              );
+              return;
+            }
+
+            if (!discordUserId) {
+              await editDiscordInteractionResponse(
+                applicationId,
+                interactionToken,
+                "Could not identify your Discord user.",
+              );
+              return;
+            }
+
+            const link = await getDiscordChannelLink(product.id, discordUserId);
+            if (!link) {
+              await editDiscordInteractionResponse(
+                applicationId,
+                interactionToken,
+                `${proposed.reply}\n\nConnect your wallet first: run \`/connect\` in this DM, open the link, then ask again.`,
+              );
+              return;
+            }
+          }
+
           const pendingToken = await createPendingActionConfirm({
             productId: product.id,
             actionId: action.id,
@@ -214,7 +280,7 @@ export async function handleDiscordAsk(
           await editDiscordInteractionResponse(
             applicationId,
             interactionToken,
-            proposed.reply,
+            `${proposed.reply}\n\nNeed a linked wallet? Run \`/connect\` in this DM first.`,
             runPendingButton(pendingToken),
           );
           return;

--- a/apps/dashboard/features/products/discord-connect-panel.tsx
+++ b/apps/dashboard/features/products/discord-connect-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Check, Copy, ExternalLink, MessageCircle, Unplug } from "lucide-react";
 import { Button, Input } from "@tael/ui";
@@ -12,7 +12,7 @@ interface DiscordConnectPanelProps {
   product: Product;
   baseUrl: string;
   pending: boolean;
-  startTransition: ReturnType<typeof useTransition>[1];
+  startTransition: (action: () => void | Promise<void>) => void;
 }
 
 export function DiscordConnectPanel({

--- a/apps/dashboard/features/products/discord-connect-panel.tsx
+++ b/apps/dashboard/features/products/discord-connect-panel.tsx
@@ -6,6 +6,7 @@ import { Check, Copy, ExternalLink, MessageCircle, Unplug } from "lucide-react";
 import { Button, Input } from "@tael/ui";
 import type { Product } from "@tael/database";
 import { connectDiscordBot, disconnectDiscordBot } from "./actions";
+import { buildDiscordUserInstallUrl } from "./discord";
 
 interface DiscordConnectPanelProps {
   product: Product;
@@ -68,7 +69,7 @@ export function DiscordConnectPanel({
       );
       if (res.ok) {
         setDiscordSuccess(
-          `Connected as ${res.botUsername ?? "bot"}. Paste the Interactions URL in Discord.`,
+          `Connected as ${res.botUsername ?? "bot"}. Paste Interactions URL, then use DMs for /connect + paid actions.`,
         );
         setDiscordInviteUrl(res.inviteUrl ?? null);
         setDiscordToken("");
@@ -102,9 +103,10 @@ export function DiscordConnectPanel({
       <div>
         <h2 className="text-base font-semibold">Discord Bot Integration</h2>
         <p className="text-sm text-muted-foreground">
-          Connect your Discord application so anyone in the server can run{" "}
-          <span className="font-mono text-xs">/ask</span> and get answers from this product agent.
-          Action confirmations show as buttons, same as Telegram.
+          Connect your Discord application so people can{" "}
+          <span className="font-mono text-xs">/ask</span> in servers or DMs. Wallet connect and paid
+          actions are <span className="font-medium text-foreground">DM-only</span> for safety —
+          Hermies-style private chat, not public channel spends.
         </p>
       </div>
 
@@ -165,6 +167,29 @@ export function DiscordConnectPanel({
               >
                 Open invite link <ExternalLink className="h-3.5 w-3.5" />
               </a>
+            </div>
+          ) : null}
+
+          {discordClientId ? (
+            <div className="space-y-2 rounded-lg border bg-background/60 p-3">
+              <p className="text-xs font-medium">3. Add App for personal DMs (Hermies-style)</p>
+              <p className="text-xs text-muted-foreground">
+                Users can install the app to their account and message the bot in DMs without a
+                shared server. Also enable User Install in Discord → Installation if available.
+              </p>
+              <a
+                href={buildDiscordUserInstallUrl(discordClientId)}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm text-foreground underline-offset-4 hover:underline"
+              >
+                Open user-install link <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+              <p className="text-xs text-muted-foreground">
+                After reconnecting, commands include <span className="font-mono">/connect</span>,{" "}
+                <span className="font-mono">/wallet</span>,{" "}
+                <span className="font-mono">/disconnect</span>. Run them in a DM.
+              </p>
             </div>
           ) : null}
         </div>

--- a/apps/dashboard/features/products/discord-connect-panel.tsx
+++ b/apps/dashboard/features/products/discord-connect-panel.tsx
@@ -6,7 +6,7 @@ import { Check, Copy, ExternalLink, MessageCircle, Unplug } from "lucide-react";
 import { Button, Input } from "@tael/ui";
 import type { Product } from "@tael/database";
 import { connectDiscordBot, disconnectDiscordBot } from "./actions";
-import { buildDiscordUserInstallUrl } from "./discord";
+import { buildDiscordUserInstallUrl } from "./discord-urls";
 
 interface DiscordConnectPanelProps {
   product: Product;

--- a/apps/dashboard/features/products/discord-urls.ts
+++ b/apps/dashboard/features/products/discord-urls.ts
@@ -1,0 +1,21 @@
+/** Client-safe Discord OAuth / invite URL helpers (no Node crypto). */
+
+/** Build the OAuth invite URL for a product bot (guild install). */
+export function buildDiscordInviteUrl(clientId: string): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    scope: "bot applications.commands",
+    permissions: "2147485696", // Send Messages + Use Application Commands
+  });
+  return `https://discord.com/oauth2/authorize?${params.toString()}`;
+}
+
+/** Build a user-install (Add App) URL for Hermies-style DMs. */
+export function buildDiscordUserInstallUrl(clientId: string): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    integration_type: "1",
+    scope: "applications.commands",
+  });
+  return `https://discord.com/oauth2/authorize?${params.toString()}`;
+}

--- a/apps/dashboard/features/products/discord-wallet-commands.ts
+++ b/apps/dashboard/features/products/discord-wallet-commands.ts
@@ -1,0 +1,83 @@
+import type { Product } from "@tael/database";
+import { deleteDiscordChannelLink, getDiscordChannelLink } from "./channel-links";
+import { createDiscordConnectToken } from "../../lib/connect-token";
+import { editDiscordInteractionResponse } from "./discord";
+
+/** Handle /connect /wallet /disconnect after Discord deferred ACK. */
+export async function handleDiscordWalletCommand(input: {
+  applicationId: string;
+  interactionToken: string;
+  command: string;
+  discordUserId: string | null;
+  product: Product;
+  dashboardBase: string;
+  isDm: boolean;
+}): Promise<boolean> {
+  const { applicationId, interactionToken, command, discordUserId, product, dashboardBase, isDm } =
+    input;
+
+  if (command !== "connect" && command !== "wallet" && command !== "disconnect") {
+    return false;
+  }
+
+  if (!discordUserId) {
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      "Could not identify your Discord user.",
+    );
+    return true;
+  }
+
+  if (command === "connect") {
+    if (!isDm) {
+      await editDiscordInteractionResponse(
+        applicationId,
+        interactionToken,
+        `For security, connect your wallet in a **DM** with this bot (not a server channel).\n\n1. Open my profile → Message\n2. Run \`/connect\` there\n3. Open the link, Freighter sign-in, link a Card`,
+      );
+      return true;
+    }
+
+    const connectToken = await createDiscordConnectToken({
+      externalUserId: discordUserId,
+      productId: product.id,
+      productPublicKey: product.publicKey,
+      productName: product.name,
+    });
+    const url = `${dashboardBase}/connect/discord?t=${encodeURIComponent(connectToken)}`;
+    await editDiscordInteractionResponse(
+      applicationId,
+      interactionToken,
+      `Connect your Stellar wallet for **${product.name}** (expires in 15 min).\n\n1. Open: ${url}\n2. Sign in with Freighter\n3. Link a Card\n4. Come back here and run paid actions in this DM`,
+    );
+    return true;
+  }
+
+  if (command === "wallet") {
+    const link = await getDiscordChannelLink(product.id, discordUserId);
+    if (!link) {
+      await editDiscordInteractionResponse(
+        applicationId,
+        interactionToken,
+        "No wallet linked yet. Open a DM with this bot and run `/connect`.",
+      );
+    } else {
+      await editDiscordInteractionResponse(
+        applicationId,
+        interactionToken,
+        "Wallet linked. Paid actions in DMs will use your linked Card. Run `/disconnect` to unlink.",
+      );
+    }
+    return true;
+  }
+
+  // disconnect
+  await deleteDiscordChannelLink(product.id, discordUserId);
+  await editDiscordInteractionResponse(
+    applicationId,
+    interactionToken,
+    "Wallet unlinked from this bot.",
+  );
+  return true;
+}

--- a/apps/dashboard/features/products/discord.ts
+++ b/apps/dashboard/features/products/discord.ts
@@ -104,21 +104,22 @@ export async function getDiscordBotInfo(
   }
 }
 
-/** Register the product /ask slash command on this application. */
+/** Register product slash commands (ask + wallet) with DM support. */
 export async function registerDiscordAskCommand(
   token: string,
   applicationId: string,
 ): Promise<{ ok: boolean; error?: string }> {
   try {
-    const res = await fetch(`${DISCORD_API_BASE}/applications/${applicationId}/commands`, {
-      method: "POST",
-      headers: {
-        authorization: `Bot ${token}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
+    // Bulk overwrite keeps guild + DM commands in sync.
+    // contexts: 0=Guild, 1=Bot DM, 2=Private channel
+    // integration_types: 0=Guild install, 1=User install
+    const commands = [
+      {
         name: "ask",
-        description: "Ask this product agent a question",
+        description: "Ask this product agent a question (use DMs for paid actions)",
+        dm_permission: true,
+        integration_types: [0, 1],
+        contexts: [0, 1, 2],
         options: [
           {
             name: "question",
@@ -127,12 +128,42 @@ export async function registerDiscordAskCommand(
             required: true,
           },
         ],
-      }),
-      signal: AbortSignal.timeout(10_000),
+      },
+      {
+        name: "connect",
+        description: "Link your Stellar wallet + Card for paid actions (DM recommended)",
+        dm_permission: true,
+        integration_types: [0, 1],
+        contexts: [0, 1, 2],
+      },
+      {
+        name: "wallet",
+        description: "Check whether your wallet is linked to this bot",
+        dm_permission: true,
+        integration_types: [0, 1],
+        contexts: [0, 1, 2],
+      },
+      {
+        name: "disconnect",
+        description: "Unlink your wallet from this bot",
+        dm_permission: true,
+        integration_types: [0, 1],
+        contexts: [0, 1, 2],
+      },
+    ];
+
+    const res = await fetch(`${DISCORD_API_BASE}/applications/${applicationId}/commands`, {
+      method: "PUT",
+      headers: {
+        authorization: `Bot ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(commands),
+      signal: AbortSignal.timeout(15_000),
     });
     const data = (await res.json().catch(() => null)) as { message?: string; code?: number } | null;
     if (!res.ok) {
-      return { ok: false, error: data?.message ?? "Failed to register /ask command." };
+      return { ok: false, error: data?.message ?? "Failed to register Discord commands." };
     }
     return { ok: true };
   } catch {
@@ -140,29 +171,36 @@ export async function registerDiscordAskCommand(
   }
 }
 
-/** Best-effort cleanup of the /ask command on disconnect. */
+/** Best-effort cleanup of product commands on disconnect. */
 export async function deleteDiscordAskCommand(token: string, applicationId: string): Promise<void> {
   try {
-    const listRes = await fetch(`${DISCORD_API_BASE}/applications/${applicationId}/commands`, {
-      method: "GET",
+    await fetch(`${DISCORD_API_BASE}/applications/${applicationId}/commands`, {
+      method: "PUT",
       headers: {
         authorization: `Bot ${token}`,
         "content-type": "application/json",
       },
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!listRes.ok) return;
-    const commands = (await listRes.json().catch(() => [])) as { id: string; name: string }[];
-    const ask = commands.find((c) => c.name === "ask");
-    if (!ask) return;
-    await fetch(`${DISCORD_API_BASE}/applications/${applicationId}/commands/${ask.id}`, {
-      method: "DELETE",
-      headers: { authorization: `Bot ${token}` },
+      body: JSON.stringify([]),
       signal: AbortSignal.timeout(10_000),
     });
   } catch {
     // best-effort
   }
+}
+
+/** True when the interaction is a bot DM (not a server channel). */
+export function isDiscordDm(interaction: DiscordInteraction): boolean {
+  return !interaction.guild_id;
+}
+
+/** Build a user-install (Add App) URL for Hermies-style DMs. */
+export function buildDiscordUserInstallUrl(clientId: string): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    integration_type: "1",
+    scope: "applications.commands",
+  });
+  return `https://discord.com/oauth2/authorize?${params.toString()}`;
 }
 
 /** Follow up on a deferred interaction with the final reply. */

--- a/apps/dashboard/features/products/discord.ts
+++ b/apps/dashboard/features/products/discord.ts
@@ -193,16 +193,6 @@ export function isDiscordDm(interaction: DiscordInteraction): boolean {
   return !interaction.guild_id;
 }
 
-/** Build a user-install (Add App) URL for Hermies-style DMs. */
-export function buildDiscordUserInstallUrl(clientId: string): string {
-  const params = new URLSearchParams({
-    client_id: clientId,
-    integration_type: "1",
-    scope: "applications.commands",
-  });
-  return `https://discord.com/oauth2/authorize?${params.toString()}`;
-}
-
 /** Follow up on a deferred interaction with the final reply. */
 export async function editDiscordInteractionResponse(
   applicationId: string,
@@ -233,15 +223,7 @@ export async function editDiscordInteractionResponse(
   }
 }
 
-/** Build the OAuth invite URL for a product bot. */
-export function buildDiscordInviteUrl(clientId: string): string {
-  const params = new URLSearchParams({
-    client_id: clientId,
-    scope: "bot applications.commands",
-    permissions: "2147485696", // Send Messages + Use Application Commands
-  });
-  return `https://discord.com/oauth2/authorize?${params.toString()}`;
-}
+export { buildDiscordInviteUrl, buildDiscordUserInstallUrl } from "./discord-urls";
 
 /** Extract a slash-command string option by name. */
 export function getDiscordOptionString(

--- a/apps/dashboard/features/products/run-product-action.ts
+++ b/apps/dashboard/features/products/run-product-action.ts
@@ -78,7 +78,7 @@ export async function runProductAction(input: {
 
   if (row.kind === "capability") {
     let payerUserId: string;
-    let agentId = input.agentId;
+    const agentId = input.agentId;
 
     if (input.payerUserId) {
       payerUserId = input.payerUserId;

--- a/apps/dashboard/lib/connect-token.ts
+++ b/apps/dashboard/lib/connect-token.ts
@@ -1,15 +1,18 @@
 import {
   createTelegramConnectToken as mintTelegramConnectToken,
   verifyTelegramConnectToken as checkTelegramConnectToken,
+  createDiscordConnectToken as mintDiscordConnectToken,
+  verifyDiscordConnectToken as checkDiscordConnectToken,
+  type ChannelConnectPayload,
   type TelegramConnectPayload,
 } from "@tael/auth";
 import { AUTH_SECRET } from "./config";
 
-export type { TelegramConnectPayload };
+export type { ChannelConnectPayload, TelegramConnectPayload };
 
 /** Mint a short-lived token for the Telegram → web wallet connect flow. */
 export async function createTelegramConnectToken(
-  payload: Omit<TelegramConnectPayload, "channel">,
+  payload: Omit<ChannelConnectPayload, "channel">,
 ): Promise<string> {
   return mintTelegramConnectToken(payload, AUTH_SECRET);
 }
@@ -17,4 +20,18 @@ export async function createTelegramConnectToken(
 /** Verify a Telegram connect token. Throws on invalid/expired. */
 export async function verifyTelegramConnectToken(token: string): Promise<TelegramConnectPayload> {
   return checkTelegramConnectToken(token, AUTH_SECRET);
+}
+
+/** Mint a short-lived token for the Discord → web wallet connect flow. */
+export async function createDiscordConnectToken(
+  payload: Omit<ChannelConnectPayload, "channel">,
+): Promise<string> {
+  return mintDiscordConnectToken(payload, AUTH_SECRET);
+}
+
+/** Verify a Discord connect token. Throws on invalid/expired. */
+export async function verifyDiscordConnectToken(
+  token: string,
+): Promise<ChannelConnectPayload & { channel: "discord" }> {
+  return checkDiscordConnectToken(token, AUTH_SECRET);
 }

--- a/packages/auth/src/connect-token.ts
+++ b/packages/auth/src/connect-token.ts
@@ -3,21 +3,26 @@ import { secretKey } from "./secret";
 
 const CONNECT_TTL = "15m";
 
-export interface TelegramConnectPayload {
-  channel: "telegram";
+export type ConnectChannel = "telegram" | "discord";
+
+export interface ChannelConnectPayload {
+  channel: ConnectChannel;
   externalUserId: string;
   productId: string;
   productPublicKey: string;
   productName: string;
 }
 
-/** Mint a short-lived token for Telegram → web wallet connect. */
-export async function createTelegramConnectToken(
-  payload: Omit<TelegramConnectPayload, "channel">,
+/** @deprecated Prefer ChannelConnectPayload */
+export type TelegramConnectPayload = ChannelConnectPayload & { channel: "telegram" };
+
+async function createChannelConnectToken(
+  channel: ConnectChannel,
+  payload: Omit<ChannelConnectPayload, "channel">,
   secret: string,
 ): Promise<string> {
   return new SignJWT({
-    channel: "telegram",
+    channel,
     externalUserId: payload.externalUserId,
     productId: payload.productId,
     productPublicKey: payload.productPublicKey,
@@ -29,13 +34,13 @@ export async function createTelegramConnectToken(
     .sign(secretKey(secret));
 }
 
-/** Verify a Telegram connect token. Throws on invalid/expired. */
-export async function verifyTelegramConnectToken(
+async function verifyChannelConnectToken(
+  channel: ConnectChannel,
   token: string,
   secret: string,
-): Promise<TelegramConnectPayload> {
+): Promise<ChannelConnectPayload> {
   const { payload } = await jwtVerify(token, secretKey(secret));
-  if (payload.channel !== "telegram") throw new Error("Invalid connect token channel.");
+  if (payload.channel !== channel) throw new Error("Invalid connect token channel.");
   const externalUserId = typeof payload.externalUserId === "string" ? payload.externalUserId : "";
   const productId = typeof payload.productId === "string" ? payload.productId : "";
   const productPublicKey =
@@ -45,10 +50,44 @@ export async function verifyTelegramConnectToken(
     throw new Error("Invalid connect token payload.");
   }
   return {
-    channel: "telegram",
+    channel,
     externalUserId,
     productId,
     productPublicKey,
     productName,
   };
+}
+
+/** Mint a short-lived token for Telegram → web wallet connect. */
+export async function createTelegramConnectToken(
+  payload: Omit<ChannelConnectPayload, "channel">,
+  secret: string,
+): Promise<string> {
+  return createChannelConnectToken("telegram", payload, secret);
+}
+
+/** Verify a Telegram connect token. Throws on invalid/expired. */
+export async function verifyTelegramConnectToken(
+  token: string,
+  secret: string,
+): Promise<TelegramConnectPayload> {
+  return verifyChannelConnectToken("telegram", token, secret) as Promise<TelegramConnectPayload>;
+}
+
+/** Mint a short-lived token for Discord → web wallet connect. */
+export async function createDiscordConnectToken(
+  payload: Omit<ChannelConnectPayload, "channel">,
+  secret: string,
+): Promise<string> {
+  return createChannelConnectToken("discord", payload, secret);
+}
+
+/** Verify a Discord connect token. Throws on invalid/expired. */
+export async function verifyDiscordConnectToken(
+  token: string,
+  secret: string,
+): Promise<ChannelConnectPayload & { channel: "discord" }> {
+  return verifyChannelConnectToken("discord", token, secret) as Promise<
+    ChannelConnectPayload & { channel: "discord" }
+  >;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Discord product bots should feel like Hermies: personal DMs for wallet + money, not public channel spends.

Also checked **PR #185**: no review findings. The `prefer-const` lint fix from that branch never landed on `main` (merged before that commit) — included here.

## Changes

- Discord `/connect`, `/wallet`, `/disconnect` (DM-first; connect blocked in guild channels)
- Freighter connect page `/connect/discord` + complete API (mirrors Telegram)
- `channel_links` for Discord → linked Card pays on confirm
- **Paid actions are DM-only** — server `/ask` can answer; Pay prompts redirect to DM + `/connect`
- Slash commands registered with `dm_permission` + user-install contexts
- Deploy panel: user-install link + DM guidance

## How to test after merge

1. Studio → Deploy → Discord → **Disconnect** then **Connect** again (re-registers commands)
2. Paste Interactions Endpoint URL → Save in Discord portal
3. Open bot profile → Message (DM)
4. `/connect` → Freighter → link Card → `/wallet`
5. `/ask question: pay 0.05 USDC to G…` → Confirm in DM
6. In a server channel, `/ask` for Pay should tell you to use DMs

## Type of change

- [x] Feature
- [x] Fix (prefer-const missed from #185)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

