### PR TITLE
Fixed: Default Balance address to linked Card wallet

### DIFF
--- a/apps/dashboard/features/agents/run-capability.ts
+++ b/apps/dashboard/features/agents/run-capability.ts
@@ -224,7 +224,12 @@ export async function runCapability(input: {
       });
       const body = await direct.text();
       if (!direct.ok) {
-        return { ok: false, status: direct.status, body, error: friendlyError(direct.status) };
+        return {
+          ok: false,
+          status: direct.status,
+          body,
+          error: capabilityErrorMessage(direct.status, body),
+        };
       }
       // Action ops return a `tael_action` intent to SIGN, not data. If we get
       // one, the agent's card signs it and submits it on-chain (with Tael's fee
@@ -330,7 +335,12 @@ export async function runCapability(input: {
     });
     const body = await res.text();
     if (!res.ok) {
-      return { ok: false, status: res.status, body, error: friendlyError(res.status) };
+      return {
+        ok: false,
+        status: res.status,
+        body,
+        error: capabilityErrorMessage(res.status, body),
+      };
     }
     // Call succeeded and the response is in hand. If this agent carries a
     // TrustLine balance and now holds spare cash, opportunistically pay it down
@@ -368,6 +378,20 @@ function friendlyError(status: number): string {
   if (status === 404) return "This capability is no longer available.";
   if (status >= 500) return "The agent couldn't pay, or the upstream API is down. Try again.";
   return `The call failed (${status}).`;
+}
+
+/** Prefer the capability's `{ error }` body when present (e.g. missing address). */
+function capabilityErrorMessage(status: number, body: string): string {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const err = (parsed as Record<string, unknown>).error;
+      if (typeof err === "string" && err.trim()) return err.trim();
+    }
+  } catch {
+    // ignore
+  }
+  return friendlyError(status);
 }
 
 /** The validated Pay intent an action capability returns to be signed. */

--- a/apps/dashboard/features/products/capability-call.ts
+++ b/apps/dashboard/features/products/capability-call.ts
@@ -91,3 +91,78 @@ export function toCapabilityRequest(
 
   return { method: "POST", body: JSON.stringify(params) };
 }
+
+/** Stellar ops that require `address=` (or similar) and can default to the Card. */
+const ADDRESS_OPS = new Set([
+  "balance",
+  "account",
+  "payments",
+  "portfolio",
+  "effects",
+  "offers",
+  "claimable",
+]);
+
+/** True when this capability/operation typically needs a Stellar address. */
+export function operationNeedsAddress(ref: CapabilityRef): boolean {
+  const op = (ref.operation ?? "").split("/")[0]?.toLowerCase() ?? "";
+  if (ADDRESS_OPS.has(op)) return true;
+  // Combined legacy slug already split; also catch bare "balance" slug misuse.
+  return ADDRESS_OPS.has(ref.slug.toLowerCase());
+}
+
+/** Whether a capability request already includes an address-like query param. */
+export function requestHasAddress(call: CapabilityRequest): boolean {
+  if (call.query) {
+    const qs = new URLSearchParams(call.query.replace(/^\?/, ""));
+    for (const key of ["address", "account", "claimant"]) {
+      const v = qs.get(key)?.trim();
+      if (v && v.length > 0) return true;
+    }
+  }
+  if (call.body) {
+    try {
+      const parsed: unknown = JSON.parse(call.body);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const o = parsed as Record<string, unknown>;
+        for (const key of ["address", "account", "claimant"]) {
+          if (typeof o[key] === "string" && o[key].trim()) return true;
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return false;
+}
+
+/**
+ * If the op needs an address and none was provided, default to the linked Card
+ * address (Discord/Telegram "check my balance" UX).
+ */
+export function withDefaultCardAddress(
+  call: CapabilityRequest,
+  ref: CapabilityRef,
+  cardAddress: string,
+): CapabilityRequest {
+  if (!operationNeedsAddress(ref) || requestHasAddress(call) || !cardAddress.trim()) {
+    return call;
+  }
+  // Prefer GET query — balance/account/etc. are GET ops.
+  if (call.method === "POST" && call.body) {
+    try {
+      const parsed: unknown = JSON.parse(call.body);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return {
+          method: "POST",
+          body: JSON.stringify({ ...(parsed as Record<string, unknown>), address: cardAddress }),
+        };
+      }
+    } catch {
+      // fall through to query
+    }
+  }
+  const qs = new URLSearchParams(call.query?.replace(/^\?/, "") ?? "");
+  qs.set("address", cardAddress);
+  return { method: "GET", query: qs.toString() };
+}

--- a/apps/dashboard/features/products/run-product-action.ts
+++ b/apps/dashboard/features/products/run-product-action.ts
@@ -1,10 +1,14 @@
 "use server";
 
-import { and, eq, productActions, products } from "@tael/database";
+import { agents, and, eq, productActions, products, wallets } from "@tael/database";
 import { db } from "../../lib/db";
 import { runCapability, type RunResult } from "../agents/run-capability";
 import { getCurrentUser } from "../capabilities/current-user";
-import { resolveCapabilityRef, toCapabilityRequest } from "./capability-call";
+import {
+  resolveCapabilityRef,
+  toCapabilityRequest,
+  withDefaultCardAddress,
+} from "./capability-call";
 
 const FETCH_TIMEOUT_MS = 15_000;
 
@@ -103,7 +107,20 @@ export async function runProductAction(input: {
     });
     if (!ref.slug) return { ok: false, error: "Action is misconfigured." };
 
-    const call = toCapabilityRequest(input.params);
+    let call = toCapabilityRequest(input.params);
+
+    // Balance/account-style ops need address=… — default to the linked Card when
+    // the model forgot (common on Discord/Telegram: "check my balance").
+    const [wallet] = await db
+      .select({ address: wallets.address })
+      .from(agents)
+      .innerJoin(wallets, eq(agents.walletId, wallets.id))
+      .where(and(eq(agents.id, agentId), eq(agents.ownerId, payerUserId)))
+      .limit(1);
+    if (wallet?.address) {
+      call = withDefaultCardAddress(call, ref, wallet.address);
+    }
+
     const result: RunResult = await runCapability({
       agentId,
       slug: ref.slug,

--- a/apps/dashboard/features/products/widget-chat.ts
+++ b/apps/dashboard/features/products/widget-chat.ts
@@ -64,7 +64,7 @@ export function buildWidgetTools(actions: ProductAction[]): WidgetToolDef[] {
         description:
           action.kind === "http"
             ? "Optional JSON object of parameters to send with the HTTP request."
-            : 'Parameters for the capability. Prefer a JSON object string like {"to":"G…","amount":"0.05"} for Pay, or a query string to=G…&amount=0.05.',
+            : 'Parameters for the capability. Prefer a JSON object string like {"to":"G…","amount":"0.05"} for Pay, or {"address":"G…"} for Balance. If the user says "my balance" and has a linked Card, address can be omitted.',
       },
     };
     return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Discord DM wallet connect works, but **Balance** failed with `The call failed (400)` because `GET /stellar/balance` requires `address=G…` and the model proposed the action with no params.

## Fix

- When running address-based Stellar ops (`balance`, `account`, `payments`, `portfolio`, …) without an address, **default to the linked Card’s Stellar address**
- Surface the capability’s `{ error }` text instead of a bare `(400)` when present

## How to retest

1. Deploy / merge
2. In Discord DM (wallet already linked): `/ask` → check my balance → **Run action**
3. Should return balances for your Card address

## Type of change

- [x] Fix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

