### PR TITLE
Readable Discord/Telegram action results + echo /ask question

### DIFF
--- a/apps/dashboard/features/products/discord-chat.ts
+++ b/apps/dashboard/features/products/discord-chat.ts
@@ -11,6 +11,7 @@ import {
   buildWidgetTools,
   proposeWidgetAction,
 } from "./widget-chat";
+import { formatActionResultForChat, withDiscordAskContext } from "./format-action-result";
 
 const MAX_TOKENS = 700;
 const MAX_TOOL_HOPS = 3;
@@ -147,13 +148,15 @@ export async function handleDiscordActionConfirm(
   });
 
   if (res.ok) {
-    const paid = res.paid ? `\nPaid: ${res.paid} USDC` : "";
-    const proof = res.txHash ? `\nTx: \`${res.txHash}\`` : "";
-    const output = res.body ? `\n\`\`\`\n${res.body.slice(0, 1200)}\n\`\`\`` : "";
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
-      `Action executed successfully!${paid}${proof}${output}`,
+      formatActionResultForChat({
+        ok: true,
+        body: res.body,
+        paid: res.paid,
+        txHash: res.txHash,
+      }),
     );
     return;
   }
@@ -161,7 +164,10 @@ export async function handleDiscordActionConfirm(
   await editDiscordInteractionResponse(
     applicationId,
     interactionToken,
-    `Action failed: ${res.error ?? "Unknown error"}`,
+    formatActionResultForChat({
+      ok: false,
+      error: res.error ?? "Unknown error",
+    }),
   );
 }
 
@@ -178,7 +184,7 @@ export async function handleDiscordAsk(
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
-      "The agent is currently unavailable (missing model key).",
+      withDiscordAskContext(question, "The agent is currently unavailable (missing model key)."),
     );
     return;
   }
@@ -212,7 +218,10 @@ export async function handleDiscordAsk(
         await editDiscordInteractionResponse(
           applicationId,
           interactionToken,
-          "The agent is currently unavailable. Please try again later.",
+          withDiscordAskContext(
+            question,
+            "The agent is currently unavailable. Please try again later.",
+          ),
         );
         return;
       }
@@ -223,7 +232,7 @@ export async function handleDiscordAsk(
         await editDiscordInteractionResponse(
           applicationId,
           interactionToken,
-          "No response received from the agent.",
+          withDiscordAskContext(question, "No response received from the agent."),
         );
         return;
       }
@@ -244,7 +253,10 @@ export async function handleDiscordAsk(
               await editDiscordInteractionResponse(
                 applicationId,
                 interactionToken,
-                `${proposed.reply}\n\n**Paid actions are DM-only.** Message this bot privately → \`/connect\` → then \`/ask\` again in the DM.`,
+                withDiscordAskContext(
+                  question,
+                  `${proposed.reply}\n\n**Paid actions are DM-only.** Message this bot privately → \`/connect\` → then \`/ask\` again in the DM.`,
+                ),
               );
               return;
             }
@@ -253,7 +265,7 @@ export async function handleDiscordAsk(
               await editDiscordInteractionResponse(
                 applicationId,
                 interactionToken,
-                "Could not identify your Discord user.",
+                withDiscordAskContext(question, "Could not identify your Discord user."),
               );
               return;
             }
@@ -263,7 +275,10 @@ export async function handleDiscordAsk(
               await editDiscordInteractionResponse(
                 applicationId,
                 interactionToken,
-                `${proposed.reply}\n\nConnect your wallet first: run \`/connect\` in this DM, open the link, then ask again.`,
+                withDiscordAskContext(
+                  question,
+                  `${proposed.reply}\n\nConnect your wallet first: run \`/connect\` in this DM, open the link, then ask again.`,
+                ),
               );
               return;
             }
@@ -280,7 +295,10 @@ export async function handleDiscordAsk(
           await editDiscordInteractionResponse(
             applicationId,
             interactionToken,
-            `${proposed.reply}\n\nNeed a linked wallet? Run \`/connect\` in this DM first.`,
+            withDiscordAskContext(
+              question,
+              `${proposed.reply}\n\nNeed a linked wallet? Run \`/connect\` in this DM first.`,
+            ),
             runPendingButton(pendingToken),
           );
           return;
@@ -302,7 +320,7 @@ export async function handleDiscordAsk(
       await editDiscordInteractionResponse(
         applicationId,
         interactionToken,
-        text || "I could not find an answer for that.",
+        withDiscordAskContext(question, text || "I could not find an answer for that."),
       );
       return;
     }
@@ -310,13 +328,16 @@ export async function handleDiscordAsk(
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
-      "I couldn't quite complete that request. Could you rephrase?",
+      withDiscordAskContext(
+        question,
+        "I couldn't quite complete that request. Could you rephrase?",
+      ),
     );
   } catch {
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
-      "An error occurred while processing your request.",
+      withDiscordAskContext(question, "An error occurred while processing your request."),
     );
   }
 }

--- a/apps/dashboard/features/products/format-action-result.ts
+++ b/apps/dashboard/features/products/format-action-result.ts
@@ -1,0 +1,167 @@
+/**
+ * Turn capability / action JSON into short human-readable chat text
+ * (Discord + Telegram). Keeps proof links for on-chain results.
+ */
+
+const NETWORK = process.env.STELLAR_NETWORK === "mainnet" ? "public" : "testnet";
+const STELLAR_EXPERT_TX = `https://stellar.expert/explorer/${NETWORK}/tx/`;
+const STELLAR_EXPERT_ACCOUNT = `https://stellar.expert/explorer/${NETWORK}/account/`;
+
+function shortAddr(address: string): string {
+  const a = address.trim();
+  if (a.length <= 12) return a;
+  return `${a.slice(0, 6)}…${a.slice(-4)}`;
+}
+
+function formatAmount(raw: string): string {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return raw;
+  // Trim trailing zeros but keep some precision for tiny balances.
+  if (Math.abs(n) >= 1) return n.toLocaleString(undefined, { maximumFractionDigits: 7 });
+  return n.toFixed(7).replace(/\.?0+$/, "") || "0";
+}
+
+interface BalanceRow {
+  asset?: string;
+  code?: string;
+  issuer?: string | null;
+  balance?: string;
+}
+
+function formatBalanceBody(body: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const o = parsed as Record<string, unknown>;
+  if (!Array.isArray(o.balances)) return null;
+
+  // Balance endpoint always includes `address`. Other payloads (e.g. claimable)
+  // also have a `balances` array — skip those here.
+  const address = typeof o.address === "string" ? o.address : "";
+  if (!address) return null;
+
+  const lines: string[] = [
+    `**Balances for** \`${shortAddr(address)}\``,
+    `[View account ↗](${STELLAR_EXPERT_ACCOUNT}${address})`,
+  ];
+
+  const rows = o.balances as BalanceRow[];
+  if (rows.length === 0) {
+    lines.push("No assets found on this account.");
+  } else {
+    for (const row of rows) {
+      const asset =
+        (typeof row.asset === "string" && row.asset) ||
+        (typeof row.code === "string" && row.code) ||
+        "Asset";
+      const bal = typeof row.balance === "string" ? formatAmount(row.balance) : "?";
+      if (asset === "XLM" || asset === "native") {
+        lines.push(`• **XLM:** ${bal}`);
+      } else if (typeof row.issuer === "string" && row.issuer) {
+        lines.push(`• **${asset}** (${shortAddr(row.issuer)}): ${bal}`);
+      } else {
+        lines.push(`• **${asset}:** ${bal}`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatPayBody(body: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const o = parsed as Record<string, unknown>;
+  if (o.action !== "pay" && o.tael_action !== "pay") return null;
+
+  const to = typeof o.to === "string" ? o.to : "";
+  const amount = typeof o.amount === "string" ? o.amount : "";
+  const asset = typeof o.asset === "string" ? o.asset : "USDC";
+  const fee = typeof o.fee === "string" ? o.fee : "";
+  const txHash =
+    (typeof o.txHash === "string" && o.txHash) || (typeof o.hash === "string" && o.hash) || "";
+
+  const lines = ["**Payment sent**"];
+  if (amount) lines.push(`• Amount: **${formatAmount(amount)} ${asset}**`);
+  if (fee && Number(fee) > 0) lines.push(`• Fee: **${formatAmount(fee)} ${asset}**`);
+  if (to) lines.push(`• To: \`${shortAddr(to)}\``);
+  if (txHash) lines.push(`• Proof: [View on Stellar Expert ↗](${STELLAR_EXPERT_TX}${txHash})`);
+  return lines.join("\n");
+}
+
+export interface FormatActionResultInput {
+  ok: boolean;
+  body?: string;
+  paid?: string;
+  txHash?: string;
+  error?: string;
+  /** Optional action name for the header. */
+  actionName?: string;
+}
+
+/**
+ * Human-readable action result for chat surfaces.
+ * Uses Discord-friendly markdown (also fine in Telegram HTML if we strip later).
+ */
+export function formatActionResultForChat(input: FormatActionResultInput): string {
+  if (!input.ok) {
+    return `Action failed: ${input.error ?? "Unknown error"}`;
+  }
+
+  const parts: string[] = [];
+  const name = input.actionName?.trim();
+  parts.push(name ? `**${name} — done**` : "**Action executed successfully**");
+
+  if (input.paid != null && Number(input.paid) > 0) {
+    parts.push(`Paid: **${formatAmount(input.paid)} USDC** from your linked Card.`);
+  } else if (input.paid != null) {
+    parts.push("Free lookup — nothing charged.");
+  }
+
+  const body = input.body?.trim() ?? "";
+  if (body) {
+    const balance = formatBalanceBody(body);
+    const pay = formatPayBody(body);
+    if (balance) {
+      parts.push("", balance);
+    } else if (pay) {
+      parts.push("", pay);
+    } else {
+      // Unknown JSON / text — keep a short readable clip, not a huge dump.
+      const clip = body.length > 600 ? `${body.slice(0, 600)}…` : body;
+      parts.push("", clip.startsWith("{") ? `\`\`\`json\n${clip}\n\`\`\`` : clip);
+    }
+  }
+
+  if (input.txHash && !body.includes(input.txHash)) {
+    parts.push("", `Proof: [View on Stellar Expert ↗](${STELLAR_EXPERT_TX}${input.txHash})`);
+  }
+
+  return parts.join("\n").slice(0, 1900);
+}
+
+/** Prefix Discord replies so slash-command questions stay visible in the thread. */
+export function withDiscordAskContext(question: string, body: string): string {
+  const q = question.trim();
+  if (!q) return body;
+  const header = `**You asked:** ${q.length > 280 ? `${q.slice(0, 280)}…` : q}`;
+  return `${header}\n\n${body}`.slice(0, 2000);
+}
+
+/** Convert Discord-ish markdown links/bold to Telegram HTML. */
+export function discordMarkdownToTelegramHtml(text: string): string {
+  let s = text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  s = s.replace(/\*\*([^*]+)\*\*/g, "<b>$1</b>");
+  s = s.replace(/`([^`]+)`/g, "<code>$1</code>");
+  s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, '<a href="$2">$1</a>');
+  s = s.replace(/```(?:json)?\n?([\s\S]*?)```/g, (_m, code: string) => `<pre>${code}</pre>`);
+  return s;
+}

--- a/apps/dashboard/features/products/telegram-action-callback.ts
+++ b/apps/dashboard/features/products/telegram-action-callback.ts
@@ -7,6 +7,7 @@ import {
   editTelegramMessageText,
   type TelegramCallbackQuery,
 } from "./telegram";
+import { discordMarkdownToTelegramHtml, formatActionResultForChat } from "./format-action-result";
 
 /** Reconstructs UUID from 32-hex actionId in legacy callback_data. */
 function parseCallbackActionId(rawHex: string): string {
@@ -92,20 +93,18 @@ export async function handleTelegramActionCallback(input: {
   });
 
   if (res.ok) {
-    const paid = res.paid ? `\nPaid: ${res.paid} USDC` : "";
-    const proof = res.txHash ? `\nTx: <code>${res.txHash}</code>` : "";
-    const safeBody = res.body
-      ? `\n\n<pre>${res.body
-          .slice(0, 1500)
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;")}</pre>`
-      : "";
     await editTelegramMessageText(
       token,
       chatId,
       messageId,
-      `Action executed successfully!${paid}${proof}${safeBody}`,
+      discordMarkdownToTelegramHtml(
+        formatActionResultForChat({
+          ok: true,
+          body: res.body,
+          paid: res.paid,
+          txHash: res.txHash,
+        }),
+      ),
       { parseMode: "HTML" },
     );
   } else {
@@ -113,7 +112,13 @@ export async function handleTelegramActionCallback(input: {
       token,
       chatId,
       messageId,
-      `Action failed: ${res.error ?? "Unknown error"}`,
+      discordMarkdownToTelegramHtml(
+        formatActionResultForChat({
+          ok: false,
+          error: res.error ?? "Unknown error",
+        }),
+      ),
+      { parseMode: "HTML" },
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Discord slash `/ask` only shows “used /ask”, so the user’s question disappears from the thread. Action success replies dumped raw JSON (Balance especially), which is hard to read, and Pay results didn’t surface a clear Stellar settlement proof link.

This PR:

1. **Echoes the question** in Discord replies as `You asked: …` so the intent stays visible in the DM.
2. **Formats Balance / Pay** into short verbal markdown (asset lines, account link, amount/to/fee).
3. **Adds Stellar Expert proof links** for payments (and account view for balances).
4. Applies the same formatter on **Telegram** action confirms (HTML).

## Type of change

- [x] Feature
- [x] Fix
- [ ] Refactor / chore
- [ ] Docs

## Checklist

- [x] `pnpm typecheck` (dashboard) passes
- [ ] Added/updated tests for the change
- [ ] Added a changeset (`pnpm changeset`) if a published `@tael/*` package changed
- [ ] Updated docs (`ARCHITECTURE.md` / package `README`) if boundaries or public APIs changed

## Evidence

Formatter smoke test (sample Balance + Pay payloads):

[formatter_smoke_test.log](https://cursor.com/agents/bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fformatter_smoke_test.log)

After merge/deploy: reconnect Discord in Studio if needed, then `/ask` → confirm Balance should show a readable list + account link instead of raw JSON; Pay should include a Stellar Expert proof link.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bebea02d-dd8c-449d-bb5d-33a955cfb5e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

