### PR TITLE
Fixed: Discord /ask shows the answer only

### DIFF
--- a/apps/dashboard/features/products/discord-chat.ts
+++ b/apps/dashboard/features/products/discord-chat.ts
@@ -11,7 +11,7 @@ import {
   buildWidgetTools,
   proposeWidgetAction,
 } from "./widget-chat";
-import { formatActionResultForChat, withDiscordAskContext } from "./format-action-result";
+import { formatActionResultForChat } from "./format-action-result";
 
 const MAX_TOKENS = 700;
 const MAX_TOOL_HOPS = 3;
@@ -184,7 +184,7 @@ export async function handleDiscordAsk(
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
-      withDiscordAskContext(question, "The agent is currently unavailable (missing model key)."),
+      "The agent is currently unavailable (missing model key).",
     );
     return;
   }
@@ -218,10 +218,7 @@ export async function handleDiscordAsk(
         await editDiscordInteractionResponse(
           applicationId,
           interactionToken,
-          withDiscordAskContext(
-            question,
-            "The agent is currently unavailable. Please try again later.",
-          ),
+          "The agent is currently unavailable. Please try again later.",
         );
         return;
       }
@@ -232,7 +229,7 @@ export async function handleDiscordAsk(
         await editDiscordInteractionResponse(
           applicationId,
           interactionToken,
-          withDiscordAskContext(question, "No response received from the agent."),
+          "No response received from the agent.",
         );
         return;
       }
@@ -253,10 +250,7 @@ export async function handleDiscordAsk(
               await editDiscordInteractionResponse(
                 applicationId,
                 interactionToken,
-                withDiscordAskContext(
-                  question,
-                  `${proposed.reply}\n\n**Paid actions are DM-only.** Message this bot privately → \`/connect\` → then \`/ask\` again in the DM.`,
-                ),
+                `${proposed.reply}\n\n**Paid actions are DM-only.** Message this bot privately → \`/connect\` → then \`/ask\` again in the DM.`,
               );
               return;
             }
@@ -265,7 +259,7 @@ export async function handleDiscordAsk(
               await editDiscordInteractionResponse(
                 applicationId,
                 interactionToken,
-                withDiscordAskContext(question, "Could not identify your Discord user."),
+                "Could not identify your Discord user.",
               );
               return;
             }
@@ -275,10 +269,7 @@ export async function handleDiscordAsk(
               await editDiscordInteractionResponse(
                 applicationId,
                 interactionToken,
-                withDiscordAskContext(
-                  question,
-                  `${proposed.reply}\n\nConnect your wallet first: run \`/connect\` in this DM, open the link, then ask again.`,
-                ),
+                `${proposed.reply}\n\nConnect your wallet first: run \`/connect\` in this DM, open the link, then ask again.`,
               );
               return;
             }
@@ -295,10 +286,7 @@ export async function handleDiscordAsk(
           await editDiscordInteractionResponse(
             applicationId,
             interactionToken,
-            withDiscordAskContext(
-              question,
-              `${proposed.reply}\n\nNeed a linked wallet? Run \`/connect\` in this DM first.`,
-            ),
+            `${proposed.reply}\n\nNeed a linked wallet? Run \`/connect\` in this DM first.`,
             runPendingButton(pendingToken),
           );
           return;
@@ -320,7 +308,7 @@ export async function handleDiscordAsk(
       await editDiscordInteractionResponse(
         applicationId,
         interactionToken,
-        withDiscordAskContext(question, text || "I could not find an answer for that."),
+        text || "I could not find an answer for that.",
       );
       return;
     }
@@ -328,16 +316,13 @@ export async function handleDiscordAsk(
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
-      withDiscordAskContext(
-        question,
-        "I couldn't quite complete that request. Could you rephrase?",
-      ),
+      "I couldn't quite complete that request. Could you rephrase?",
     );
   } catch {
     await editDiscordInteractionResponse(
       applicationId,
       interactionToken,
-      withDiscordAskContext(question, "An error occurred while processing your request."),
+      "An error occurred while processing your request.",
     );
   }
 }

--- a/apps/dashboard/features/products/format-action-result.ts
+++ b/apps/dashboard/features/products/format-action-result.ts
@@ -148,14 +148,6 @@ export function formatActionResultForChat(input: FormatActionResultInput): strin
   return parts.join("\n").slice(0, 1900);
 }
 
-/** Prefix Discord replies so slash-command questions stay visible in the thread. */
-export function withDiscordAskContext(question: string, body: string): string {
-  const q = question.trim();
-  if (!q) return body;
-  const header = `**You asked:** ${q.length > 280 ? `${q.slice(0, 280)}…` : q}`;
-  return `${header}\n\n${body}`.slice(0, 2000);
-}
-
 /** Convert Discord-ish markdown links/bold to Telegram HTML. */
 export function discordMarkdownToTelegramHtml(text: string): string {
   let s = text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Discord `/ask` was echoing the question as **You asked:** before the reply. That cluttered demo videos and DMs. Replies now show the answer only.

## Type of change

- [x] Fix

## Checklist

- [ ] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` pass locally
- [ ] Added/updated tests for the change
- [ ] Added a changeset (`pnpm changeset`) if a published `@tael/*` package changed
- [ ] Updated docs (`ARCHITECTURE.md` / package `README`) if boundaries or public APIs changed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02b9d8c6-b9e4-41d4-b5cc-35d9306a6cb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02b9d8c6-b9e4-41d4-b5cc-35d9306a6cb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

